### PR TITLE
chore: Deploy and publish through travis on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,14 @@ jobs:
         - provider: script
           repo: cozy/coachco2
           skip-cleanup: true
-          # publish stable or beta versions using Github Releases (git tag)
-          script: DEPLOY_BRANCH=build && yarn cozyPublish
+          # deploy the build on a build branch and publish to the Cozy registry
+          script: DEPLOY_BRANCH=build && yarn deploy && yarn cozyPublish
+          on:
+            branch: master
+        - provider: script
+          repo: cozy/coachco2
+          skip-cleanup: true
+          # deploy the build on a build branch and publish stable or beta versions using Github Releases (git tag)
+          script: DEPLOY_BRANCH=build && yarn deploy && yarn cozyPublish
           on:
             tags: true


### PR DESCRIPTION
Travis now deploy & publish when merged on master or after a tag 