### PR TITLE
feat: Add trip carbon computation 

### DIFF
--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -5,11 +5,11 @@ import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
 import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
-import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction'
 import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Icon from 'cozy-ui/transpiled/react/Icon'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import MainModeIcon from 'src/components/MainModeIcon'
 import GeoCard from 'src/components/GeoCard'
@@ -18,7 +18,8 @@ import {
   getFormattedDuration,
   getModes,
   formatDistance,
-  getStartDate
+  getStartDate,
+  computeCO2Trip
 } from './trips'
 
 export const TripItem = ({ trip, withDateHeader }) => {
@@ -30,6 +31,11 @@ export const TripItem = ({ trip, withDateHeader }) => {
   const modes = useMemo(() => getModes(trip), [trip])
   const distance = useMemo(() => formatDistance(trip), [trip])
   const day = useMemo(() => f(getStartDate(trip), 'dddd DD MMMM'), [f, trip])
+
+  const CO2 = useMemo(() => {
+    const CO2Trip = computeCO2Trip(trip)
+    return Math.round(CO2Trip * 100) / 100
+  }, [trip])
 
   const tripDetails = useMemo(() => {
     const tModes = modes.map(m => t(`trips.modes.${m}`)).join(', ')
@@ -54,9 +60,8 @@ export const TripItem = ({ trip, withDateHeader }) => {
           <MainModeIcon trip={trip} />
         </ListItemIcon>
         <ListItemText primary={endPlace} secondary={tripDetails} />
-        <ListItemSecondaryAction>
-          <Icon icon={RightIcon} color="var(--secondaryTextColor)" />
-        </ListItemSecondaryAction>
+        <Typography variant="h6">{CO2} kg</Typography>
+        <Icon icon={RightIcon} color="var(--secondaryTextColor)" />
       </ListItem>
       <Divider variant="inset" />
     </>

--- a/src/components/trips.js
+++ b/src/components/trips.js
@@ -5,7 +5,23 @@ import flatten from 'lodash/flatten'
 import uniq from 'lodash/uniq'
 import distanceInWords from 'date-fns/distance_in_words'
 
-import { UNKNOWN_MODE } from 'src/constants/const'
+import {
+  AIR_MODE,
+  BUS_MODE,
+  CAR_MODE,
+  SUBWAY_MODE,
+  TRAIN_MODE,
+  UNKNOWN_MODE,
+  PLANE_CO2_KG_PER_KM_SHORT,
+  PLANE_CO2_KG_PER_KM_MEDIUM,
+  PLANE_CO2_KG_PER_KM_LONG,
+  SHORT_PLANE_TRIP_MAX_DISTANCE,
+  MEDIUM_PLANE_TRIP_MAX_DISTANCE,
+  CAR_AVERAGE_CO2_KG_PER_KM,
+  BUS_MEDIUM_AGGLOMERATION_CO2_KG_PER_KM,
+  TRAIN_HIGHLINE_CO2_KG_PER_KM,
+  SUBWAY_TRAM_TROLLEYBUS_MEDIUM_AGGLOMERATION_CO2_KG_PER_KM
+} from 'src/constants/const'
 
 export const collectFeaturesByOid = geojson => {
   const res = {}
@@ -121,4 +137,54 @@ export const getSectionsInfo = trip => {
 
 export const getStartDate = trip => {
   return new Date(trip.properties.start_fmt_time)
+}
+
+/**
+ * Compute the total CO2 consumed by the trip.
+ * For each section, compute the related consumed CO2 based on the mode and distance.
+ * See the src/constants/const.js file for more insights about the CO2 values
+ *
+ * @param {object} trip - The GeoJSON trip
+ * @returns {number} The consumed CO2, in kg
+ */
+export const computeCO2Trip = trip => {
+  const sections = getSectionsInfo(trip)
+  let totalCO2 = 0
+  for (const section of sections) {
+    const distance = section.distance / 1000 // convert in km
+    switch (section.mode) {
+      case AIR_MODE:
+        if (distance <= SHORT_PLANE_TRIP_MAX_DISTANCE) {
+          totalCO2 += distance * PLANE_CO2_KG_PER_KM_SHORT
+          break
+        } else if (distance <= MEDIUM_PLANE_TRIP_MAX_DISTANCE) {
+          totalCO2 += distance * PLANE_CO2_KG_PER_KM_MEDIUM
+        } else {
+          totalCO2 += distance * PLANE_CO2_KG_PER_KM_LONG
+        }
+        break
+      case CAR_MODE:
+        // TODO: should depends on the energy type + number of passengers
+        totalCO2 += distance * CAR_AVERAGE_CO2_KG_PER_KM
+        break
+      case BUS_MODE:
+        // TODO: should depends on the area
+        totalCO2 += distance * BUS_MEDIUM_AGGLOMERATION_CO2_KG_PER_KM
+        break
+      case SUBWAY_MODE:
+        // TODO: should depends on the area
+        totalCO2 +=
+          distance * SUBWAY_TRAM_TROLLEYBUS_MEDIUM_AGGLOMERATION_CO2_KG_PER_KM
+        break
+      case TRAIN_MODE:
+        // TODO: should depends on train type
+        totalCO2 += distance * TRAIN_HIGHLINE_CO2_KG_PER_KM
+        break
+      case UNKNOWN_MODE:
+        break
+      default:
+        break
+    }
+  }
+  return totalCO2
 }

--- a/src/components/trips.spec.js
+++ b/src/components/trips.spec.js
@@ -1,0 +1,126 @@
+import { computeCO2Trip } from './trips'
+import {
+  CAR_AVERAGE_CO2_KG_PER_KM,
+  BUS_MEDIUM_AGGLOMERATION_CO2_KG_PER_KM,
+  SUBWAY_TRAM_TROLLEYBUS_MEDIUM_AGGLOMERATION_CO2_KG_PER_KM,
+  TRAIN_HIGHLINE_CO2_KG_PER_KM,
+  PLANE_CO2_KG_PER_KM_SHORT,
+  PLANE_CO2_KG_PER_KM_MEDIUM,
+  PLANE_CO2_KG_PER_KM_LONG
+} from 'src/constants/const'
+
+const createTripFromTemplate = (
+  tripTemplate,
+  { mode, distance, startDate, endDate }
+) => {
+  const trip = { ...tripTemplate }
+  trip.features[0].features[0] = {
+    properties: {
+      sensed_mode: `PredictedModeTypes.${mode}`,
+      distance,
+      start_fmt_time: startDate,
+      end_fmt_time: endDate
+    }
+  }
+  return trip
+}
+
+describe('trips', () => {
+  const tripTemplate = {
+    features: [
+      {
+        features: []
+      }
+    ]
+  }
+  it('should correctly compute the bicycling CO2', () => {
+    const trip = createTripFromTemplate(tripTemplate, {
+      mode: 'BICYCLING',
+      distance: 2456,
+      startDate: '2021-01-01T08:00:00',
+      endDate: '2021-01-01T08:10:00'
+    })
+    const CO2 = computeCO2Trip(trip)
+    expect(CO2).toEqual(0)
+  })
+  it('should correctly compute the walking CO2', () => {
+    const trip = createTripFromTemplate(tripTemplate, {
+      mode: 'WALKING',
+      distance: 563,
+      startDate: '2021-01-01T08:11:00',
+      endDate: '2021-01-01T08:20:00'
+    })
+    const CO2 = computeCO2Trip(trip)
+    expect(CO2).toEqual(0)
+  })
+  it('should correctly compute the car CO2', () => {
+    const trip = createTripFromTemplate(tripTemplate, {
+      mode: 'CAR',
+      distance: 14789,
+      startDate: '2021-01-01T08:30:00',
+      endDate: '2021-01-01T09:00:00'
+    })
+    const CO2 = computeCO2Trip(trip)
+    expect(CO2).toEqual((14789 / 1000) * CAR_AVERAGE_CO2_KG_PER_KM)
+  })
+  it('should correctly compute the bus CO2', () => {
+    const trip = createTripFromTemplate(tripTemplate, {
+      mode: 'BUS',
+      distance: 5645,
+      startDate: '2021-01-01T09:00:00',
+      endDate: '2021-01-01T10:00:00'
+    })
+    const CO2 = computeCO2Trip(trip)
+    expect(CO2).toEqual((5645 / 1000) * BUS_MEDIUM_AGGLOMERATION_CO2_KG_PER_KM)
+  })
+  it('should correctly compute the subway CO2', () => {
+    const trip = createTripFromTemplate(tripTemplate, {
+      mode: 'SUBWAY',
+      distance: 2145,
+      startDate: '2021-01-01T10:00:00',
+      endDate: '2021-01-01T10:30:00'
+    })
+    const CO2 = computeCO2Trip(trip)
+    expect(CO2).toEqual(
+      (2145 / 1000) * SUBWAY_TRAM_TROLLEYBUS_MEDIUM_AGGLOMERATION_CO2_KG_PER_KM
+    )
+  })
+  it('should correctly compute the train CO2', () => {
+    const trip = createTripFromTemplate(tripTemplate, {
+      mode: 'TRAIN',
+      distance: 76654,
+      startDate: '2021-01-01T11:00:00',
+      endDate: '2021-01-01T12:00:00'
+    })
+    const CO2 = computeCO2Trip(trip)
+    expect(CO2).toEqual((76654 / 1000) * TRAIN_HIGHLINE_CO2_KG_PER_KM)
+  })
+  it('should correctly compute the plane CO2', () => {
+    const shortTrip = createTripFromTemplate(tripTemplate, {
+      mode: 'AIR_OR_HSR',
+      distance: 800000,
+      startDate: '2021-01-01T13:00:00',
+      endDate: '2021-01-01T14:00:00'
+    })
+    const shortCO2 = computeCO2Trip(shortTrip)
+    expect(shortCO2).toEqual((800000 / 1000) * PLANE_CO2_KG_PER_KM_SHORT)
+
+    const mediumTrip = createTripFromTemplate(tripTemplate, {
+      mode: 'AIR_OR_HSR',
+      distance: 2000000,
+      startDate: '2021-01-01T15:00:00',
+      endDate: '2021-01-01T17:00:00'
+    })
+    const mediumCO2 = computeCO2Trip(mediumTrip)
+    expect(mediumCO2).toEqual((2000000 / 1000) * PLANE_CO2_KG_PER_KM_MEDIUM)
+
+    const longTrip = createTripFromTemplate(tripTemplate, {
+      mode: 'AIR_OR_HSR',
+      distance: 5000000,
+      startDate: '2021-01-01T18:00:00',
+      endDate: '2021-01-01T23:00:00'
+    })
+    const longCO2 = computeCO2Trip(longTrip)
+    expect(longCO2).toEqual((5000000 / 1000) * PLANE_CO2_KG_PER_KM_LONG)
+  })
+})

--- a/src/constants/const.js
+++ b/src/constants/const.js
@@ -9,3 +9,81 @@ export const TRAIN_MODE = 'TRAIN'
 export const WALKING_MODE = 'WALKING'
 export const UNKNOWN_MODE = 'UNKNOWN'
 export const BUS_MODE = 'BUS'
+
+/**
+ * Transporation CO2 constants, given in Kg per Km.
+ * All values come from ADEME: https://www.bilans-ges.ademe.fr/
+ * Be careful: most of those values are only relevant in France and are always an approximation.
+ * It is most of the time an average value, as many factors can impact the carbon emission.
+ * Note the values do not include vehicle construction nor infrastructure impact.
+ */
+
+/**
+ * Plane CO2 values.
+ * Includes contrail cirrus clouds impact: https://www.nature.com/articles/s41467-018-04068-0
+ */
+// https://www.bilans-ges.ademe.fr/en/basecarbone/donnees-consulter/liste-element/categorie/547/siGras/1
+export const PLANE_CO2_KG_PER_KM_SHORT = 0.258
+export const PLANE_CO2_KG_PER_KM_MEDIUM = 0.187
+export const PLANE_CO2_KG_PER_KM_LONG = 0.152
+
+export const SHORT_PLANE_TRIP_MAX_DISTANCE = 1000
+export const MEDIUM_PLANE_TRIP_MAX_DISTANCE = 3500
+
+/**
+ * Train CO2 values.
+ * For other countries, see: https://www.bilans-ges.ademe.fr/en/basecarbone/donnees-consulter/liste-element/categorie/185
+ */
+
+// https://www.bilans-ges.ademe.fr/en/basecarbone/donnees-consulter/liste-element/categorie/180
+export const TRAIN_TGV_CO2_KG_PER_KM = 0.00173
+// https://www.bilans-ges.ademe.fr/en/basecarbone/donnees-consulter/liste-element/categorie/180
+export const TRAIN_HIGHLINE_CO2_KG_PER_KM = 0.00529
+// https://www.bilans-ges.ademe.fr/en/basecarbone/donnees-consulter/liste-element/categorie/179
+export const TER_TRAIN_CO2_KG_PER_KM = 0.0248
+
+/**
+ * Subway, tram and trolley bus CO2 values.
+ */
+
+// https://www.bilans-ges.ademe.fr/en/basecarbone/donnees-consulter/liste-element/categorie/182
+export const SUBWAY_ILE_DE_FRANCE_CO2_KG_PER_KM = 0.0025
+export const TRAM_ILE_DE_FRANCE_CO2_KG_PER_KM = 0.0022
+export const SUBURBAN_TRANSILIEN_ILE_DE_FRANCE_CO2_KG_PER_KM = 0.0041
+// https://www.bilans-ges.ademe.fr/en/basecarbone/donnees-consulter/liste-element/categorie/183
+export const SUBWAY_TRAM_TROLLEYBUS_MEDIUM_AGGLOMERATION_CO2_KG_PER_KM = 0.00472
+export const SUBWAY_TRAM_TROLLEYBUS_LARGE_AGGLOMERATION_CO2_KG_PER_KM = 0.00298
+
+/**
+ * Bus CO2 values.
+ * The values consider a filling rate of 10 people
+ */
+
+// This groups different combustion types.
+// https://www.bilans-ges.ademe.fr/en/basecarbone/donnees-consulter/liste-element/categorie/530
+export const BUS_SMALL_AGGLOMERATION_CO2_KG_PER_KM = 0.146
+export const BUS_MEDIUM_AGGLOMERATION_CO2_KG_PER_KM = 0.137
+export const BUS_LARGE_AGGLOMERATION_CO2_KG_PER_KM = 0.129
+// https://www.bilans-ges.ademe.fr/en/basecarbone/donnees-consulter/liste-element/categorie/531
+export const BUS_ELECTRIC_CO2_KG_PER_KM = 0.0217
+
+/**
+ * Moto and scooter CO2 values.
+ * We rely on average usage values, at it can differ between urban or rural usage.
+ */
+// https://www.bilans-ges.ademe.fr/en/basecarbone/donnees-consulter/liste-element/categorie/164
+export const MOTO_INF_250_CO2_KG_PER_KM = 0.0604
+export const MOTO_SUP_250_CO2_KG_PER_KM = 0.165
+export const MOTO_ELECTRIC_INF_250_CO2_KG_PER_KM = 0.0249
+
+/**
+ * Car CO2 values.
+ * Note the values should be divided by the number of passengers to have
+ * the CO2 per person.
+ */
+
+// https://www.bilans-ges.ademe.fr/en/basecarbone/donnees-consulter/liste-element/categorie/151
+export const CAR_AVERAGE_CO2_KG_PER_KM = 0.192
+// https://www.bilans-ges.ademe.fr/en/basecarbone/donnees-consulter/liste-element/categorie/493
+// Note the manufacture is not included to remain consistent with other values
+export const CAR_ELECTRIC_CO2_KG_PER_KM = 0.0198


### PR DESCRIPTION
For each trip, compute the CO2 total, based on the distance and
transport mode.
We rely on constants values for each mode, all taken from the ADEME
database: https://www.bilans-ges.ademe.fr/

Note that most of those values are approximations, as many factors can
imapct the CO2 production (vehicle type and age, conductor usage, number
of passengers, etc).