### PR TITLE
feat: Add BottomSheet hack to prevent pull-down-to-refresh

### DIFF
--- a/src/components/BottomSheet/BottomSheet.jsx
+++ b/src/components/BottomSheet/BottomSheet.jsx
@@ -58,6 +58,15 @@ const BottomSheet = ({ toolbarNode, header, content, settings }) => {
     settings
   ])
 
+  // hack to prevent pull-down-to-refresh behavior when dragging down the bottom sheet.
+  // Needed for iOS Safari
+  useEffect(() => {
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = 'auto'
+    }
+  }, [])
+
   useEffect(() => {
     const maxHeight = toolbarNode
       ? window.innerHeight - toolbarNode.offsetHeight


### PR DESCRIPTION
Dragging down the bottomSheet on Safari triggered the pull-down-to-refresh behavior