### PR TITLE
feat: Implement WebviewIntentProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
   "dependencies": {
     "@material-ui/core": "4",
     "cozy-client": "^27.14.4",
+    "cozy-device-helper": "^1.17.0",
+    "cozy-intent": "^1.8.0",
     "cozy-scripts": "5.13.0",
     "cozy-ui": "^60.10.0",
     "date-fns": "^1.30.1",

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -14,6 +14,7 @@ import { CozyProvider } from 'cozy-client'
 import { I18n } from 'cozy-ui/transpiled/react/I18n'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import { WebviewIntentProvider } from 'cozy-intent'
 
 import setupApp from 'src/targets/browser/setupApp'
 import { register as registerServiceWorker } from 'src/targets/browser/serviceWorkerRegistration'
@@ -34,19 +35,21 @@ const generateClassName = createGenerateClassName({
 const init = function() {
   const { root, client, lang, polyglot } = setupApp()
   render(
-    <StylesProvider generateClassName={generateClassName}>
-      <CozyProvider client={client}>
-        <AccountProvider>
-          <I18n lang={lang} polyglot={polyglot}>
-            <MuiCozyTheme>
-              <BreakpointsProvider>
-                <App />
-              </BreakpointsProvider>
-            </MuiCozyTheme>
-          </I18n>
-        </AccountProvider>
-      </CozyProvider>
-    </StylesProvider>,
+    <WebviewIntentProvider>
+      <StylesProvider generateClassName={generateClassName}>
+        <CozyProvider client={client}>
+          <AccountProvider>
+            <I18n lang={lang} polyglot={polyglot}>
+              <MuiCozyTheme>
+                <BreakpointsProvider>
+                  <App />
+                </BreakpointsProvider>
+              </MuiCozyTheme>
+            </I18n>
+          </AccountProvider>
+        </CozyProvider>
+      </StylesProvider>
+    </WebviewIntentProvider>,
     root
   )
 }

--- a/test/AppLike.jsx
+++ b/test/AppLike.jsx
@@ -4,17 +4,20 @@ import { HashRouter } from 'react-router-dom'
 import { CozyProvider, createMockClient } from 'cozy-client'
 import I18n from 'cozy-ui/transpiled/react/I18n'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import { WebviewIntentProvider } from 'cozy-intent'
 
 import enLocale from '../src/locales/en.json'
 
 const AppLike = ({ children, client }) => (
-  <CozyProvider client={client || createMockClient({})}>
-    <I18n dictRequire={() => enLocale} lang="en">
-      <BreakpointsProvider>
-        <HashRouter>{children}</HashRouter>
-      </BreakpointsProvider>
-    </I18n>
-  </CozyProvider>
+  <WebviewIntentProvider>
+    <CozyProvider client={client || createMockClient({})}>
+      <I18n dictRequire={() => enLocale} lang="en">
+        <BreakpointsProvider>
+          <HashRouter>{children}</HashRouter>
+        </BreakpointsProvider>
+      </I18n>
+    </CozyProvider>
+  </WebviewIntentProvider>
 )
 
 export default AppLike

--- a/yarn.lock
+++ b/yarn.lock
@@ -3906,6 +3906,13 @@ cozy-device-helper@^1.12.0, cozy-device-helper@^1.7.3:
   dependencies:
     lodash "^4.17.19"
 
+cozy-device-helper@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.17.0.tgz#fbce9737ea83c67969b2b173163b37299a36283c"
+  integrity sha512-G61i75dPe/JwLUxN0foWG34lnm+0iybMu05AjoXv/UU2fRsTPfNnsHH4ZRi5JS6OPK4ccuj+ffRmabdywo23TA==
+  dependencies:
+    lodash "^4.17.19"
+
 cozy-doctypes@1.39.0:
   version "1.39.0"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.39.0.tgz#edbd8b7575d858ce5305c0e7c6d14cf6c44b6d83"
@@ -3922,6 +3929,13 @@ cozy-flags@2.7.1:
   integrity sha512-TtVhuyMSRADRr4q5LSaRjq6u03S5m1zkZRc8n3q8bfad86FizqGC02m3e/Zh4kWTwnsO0pVW+mzeVSsBqDVT/g==
   dependencies:
     microee "^0.0.6"
+
+cozy-intent@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-1.8.0.tgz#dce5fe4dfc547be9a809000f23c9a7070eaf05c8"
+  integrity sha512-c5KsEFV21I/CAooyNKBuwt18FWdfPOtnxK/rDQVZm8JhTj2EZ9dxVNSZR5dsKohBN+czA9Rwl0icmvsvFiNT+A==
+  dependencies:
+    post-me "0.4.5"
 
 cozy-interapp@0.4.9:
   version "0.4.9"
@@ -8688,17 +8702,6 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
-  version "1.0.6"
-  uid "494c40416ecde95732c864f9b921e7e545075aa5"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
-  dependencies:
-    "@juggle/resize-observer" "^3.1.3"
-    jest-environment-jsdom-sixteen "^1.0.3"
-    react-spring "9.0.0-rc.3"
-    react-use-gesture "^7.0.8"
-    react-use-measure "^2.0.0"
-
 "mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"
   resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
@@ -9652,6 +9655,11 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+post-me@0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/post-me/-/post-me-0.4.5.tgz#6171b721c7b86230c51cfbe48ddea047ef8831ce"
+  integrity sha512-XgPdktF/2M5jglgVDULr9NUb/QNv3bY3g6RG22iTb5MIMtB07/5FJB5fbVmu5Eaopowc6uZx7K3e7x1shPwnXw==
 
 postcss-assets-webpack-plugin@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
In order to make all **Cozy Apps** compatible with **Amirale**, we have to wrap them in the `cozy-intent` provider.

To do so, we have to:
- Add `cozy-intent`
- Upgrade `cozy-device-helper` to the latest version (necessary for `cozy-intent` as its peer dependency)
- Wrap the application at the highest possible level with the `<WebviewIntentProvider />`