### PR TITLE
Feat/2109

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cozy-client": "^27.14.4",
     "cozy-intent": "^1.9.1",
     "cozy-scripts": "5.13.0",
-    "cozy-ui": "^60.10.0",
+    "cozy-ui": "^62.1.0",
     "date-fns": "^1.30.1",
     "humanize-duration": "3.27.1",
     "leaflet": "^1.7.1",

--- a/src/components/Avatar.jsx
+++ b/src/components/Avatar.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import UiAvatar from 'cozy-ui/transpiled/react/Avatar'
 
@@ -12,10 +12,10 @@ const makeStyle = ({ faded, color }) => {
     : { backgroundColor: color }
 }
 
-const Avatar = ({ icon, color, faded }) => {
-  const style = useMemo(() => makeStyle({ faded, color }), [color, faded])
+const Avatar = ({ icon, color, faded, ghost }) => {
+  const style = makeStyle({ faded, color })
 
-  return <UiAvatar style={style} icon={icon} size={32} />
+  return <UiAvatar style={style} icon={icon} size={32} ghost={ghost} />
 }
 
-export default React.memo(Avatar)
+export default Avatar

--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useCallback, useState } from 'react'
 import PropTypes from 'prop-types'
 import { useHistory } from 'react-router-dom'
+import get from 'lodash/get'
 
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
@@ -19,20 +20,44 @@ import {
   getFormattedDuration,
   getModes,
   formatTripDistance,
-  getStartDate,
-  getMainMode
+  getStartDate
 } from 'src/lib/trips'
 import { computeCO2Trip } from 'src/lib/metrics'
-import { pickModeIcon, modeToColor } from 'src/components/helpers'
+import {
+  pickPurposeIcon,
+  purposeToColor,
+  pickModeIcon
+} from 'src/components/helpers'
 import TripDialogDesktop from 'src/components/Trip/TripDialogDesktop'
 
 const styles = {
   co2: { fontWeight: 700 }
 }
 
+const getIconStyle = (idx, icons) => ({
+  margin: idx !== 0 && idx < icons.length - 1 ? '0 4px' : '0'
+})
+
+const TripItemSecondary = ({ tripModeIcons, duration, distance }) => {
+  return (
+    <>
+      {tripModeIcons.map((tripModeIcon, idx) => (
+        <Icon
+          key={idx}
+          icon={tripModeIcon}
+          size={10}
+          style={getIconStyle(idx, tripModeIcons)}
+        />
+      ))}
+      {` · ${duration} · ${distance}`}
+    </>
+  )
+}
+
 export const TripItem = ({ geojson, trip, withDateHeader }) => {
-  const { f, t } = useI18n()
+  const { f } = useI18n()
   const history = useHistory()
+  const purpose = get(trip, 'properties.manual_purpose')
   const { isMobile } = useBreakpoints()
   const [showTripDialog, setShowTripDialog] = useState(false)
 
@@ -41,17 +66,17 @@ export const TripItem = ({ geojson, trip, withDateHeader }) => {
   const modes = useMemo(() => getModes(trip), [trip])
   const distance = useMemo(() => formatTripDistance(trip), [trip])
   const day = useMemo(() => f(getStartDate(trip), 'dddd DD MMMM'), [f, trip])
-  const mainMode = useMemo(() => getMainMode(trip), [trip])
+  const AvatarIcon = useMemo(() => pickPurposeIcon(purpose), [purpose])
+  const AvatarColor = useMemo(() => purposeToColor(purpose), [purpose])
 
   const CO2 = useMemo(() => {
     const CO2Trip = computeCO2Trip(trip)
     return Math.round(CO2Trip * 100) / 100
   }, [trip])
 
-  const tripDetails = useMemo(() => {
-    const tModes = modes.map(m => t(`trips.modes.${m}`)).join(', ')
-    return `${duration} · ${distance} · ${tModes} `
-  }, [duration, modes, t, distance])
+  const tripModeIcons = useMemo(() => modes.map(mode => pickModeIcon(mode)), [
+    modes
+  ])
 
   const handleClick = useCallback(() => {
     if (isMobile) {
@@ -65,13 +90,26 @@ export const TripItem = ({ geojson, trip, withDateHeader }) => {
       {withDateHeader && <ListSubheader>{day}</ListSubheader>}
       <ListItem className="u-pl-1-s u-pl-2" button onClick={handleClick}>
         <ListItemIcon>
-          <Avatar icon={pickModeIcon(mainMode)} color={modeToColor(mainMode)} />
+          <Avatar
+            icon={AvatarIcon}
+            ghost={purpose === undefined}
+            color={AvatarColor}
+          />
         </ListItemIcon>
-        <ListItemText primary={endPlace} secondary={tripDetails} />
+        <ListItemText
+          primary={endPlace}
+          secondary={
+            <TripItemSecondary
+              tripModeIcons={tripModeIcons}
+              duration={duration}
+              distance={distance}
+            />
+          }
+        />
         <Typography className="u-mh-half" style={styles.co2} variant="body2">
           {CO2}&nbsp;kg
         </Typography>
-        <Icon icon={RightIcon} className="u-coolGrey" />
+        <Icon icon={RightIcon} color={'var(--secondaryTextColor)'} />
       </ListItem>
       <Divider />
       {showTripDialog && (
@@ -90,4 +128,4 @@ TripItem.propTypes = {
   withDateHeader: PropTypes.bool.isRequired
 }
 
-export default React.memo(TripItem)
+export default TripItem

--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -18,7 +18,7 @@ import Avatar from 'src/components/Avatar'
 import {
   getEndPlaceDisplayName,
   getFormattedDuration,
-  getModes,
+  getModesSortedByDistance,
   formatTripDistance,
   getStartDate
 } from 'src/lib/trips'
@@ -63,7 +63,7 @@ export const TripItem = ({ geojson, trip, withDateHeader }) => {
 
   const endPlace = useMemo(() => getEndPlaceDisplayName(trip), [trip])
   const duration = useMemo(() => getFormattedDuration(trip), [trip])
-  const modes = useMemo(() => getModes(trip), [trip])
+  const modes = useMemo(() => getModesSortedByDistance(trip), [trip])
   const distance = useMemo(() => formatTripDistance(trip), [trip])
   const day = useMemo(() => f(getStartDate(trip), 'dddd DD MMMM'), [f, trip])
   const AvatarIcon = useMemo(() => pickPurposeIcon(purpose), [purpose])

--- a/src/lib/trips.js
+++ b/src/lib/trips.js
@@ -91,16 +91,25 @@ const getFeatureMode = feature => {
   return manualMode || sensedMode
 }
 
-export const getModes = trip => {
+const getFeatureModes = feature => {
+  return feature.features.map(feature => getFeatureMode(feature))
+}
+
+const getDistance = x => {
+  return get(x, 'features[0].properties.distance')
+}
+
+const tripsSortedByDistance = (a, b) => {
+  return getDistance(a) > getDistance(b) ? -1 : 1
+}
+
+export const getModesSortedByDistance = trip => {
   return uniq(
     flatten(
-      trip.features.map(feature => {
-        if (feature.features) {
-          return feature.features.map(feature => getFeatureMode(feature))
-        } else {
-          return getFeatureMode(feature)
-        }
-      })
+      trip.features
+        .filter(feature => feature.type === 'FeatureCollection')
+        .sort(tripsSortedByDistance)
+        .map(getFeatureModes)
     ).filter(Boolean)
   )
 }

--- a/src/lib/trips.spec.js
+++ b/src/lib/trips.spec.js
@@ -3,7 +3,10 @@ import {
   makeWalkingTrip,
   makeCarTrip,
   mockTimeserie,
-  mockSerie
+  mockSerie,
+  mockFeature,
+  mockFeatureCollection,
+  modeProps
 } from 'test/mockTrip'
 
 import {
@@ -11,14 +14,41 @@ import {
   formatCO2,
   getSectionsFormatedInfo,
   transformTimeserieToTrip,
-  transformTimeseriesToTrips
-} from './trips'
+  transformTimeseriesToTrips,
+  getModes
+} from 'src/lib/trips'
 
 const timeseries = [
   mockTimeserie('timeserieId01', [mockSerie()]),
   mockTimeserie('timeserieId02', [mockSerie()]),
   mockTimeserie('timeserieId03', [mockSerie()])
 ]
+
+describe('getModes', () => {
+  const mockedFeatures = [
+    mockFeature('featureId01'),
+    mockFeature('featureId02'),
+    mockFeature('featureId03'),
+    mockFeature('featureId04'),
+    mockFeatureCollection('featureCollectionId01', [
+      mockFeature('featureId05', modeProps.bicycle)
+    ]),
+    mockFeatureCollection('featureCollectionId02', [
+      mockFeature('featureId06', modeProps.walking)
+    ]),
+    mockFeatureCollection('featureCollectionId03', [
+      mockFeature('featureId07', modeProps.car)
+    ])
+  ]
+  const mockedSerie = mockSerie('serieId01', mockedFeatures)
+
+  it('should return modes sorted by distance', () => {
+    const result = getModes(mockedSerie)
+
+    expect(result).toHaveLength(3)
+    expect(result).toStrictEqual(['CAR', 'BICYCLING', 'WALKING'])
+  })
+})
 
 describe('formatCalories', () => {
   it('should return formated value', () => {

--- a/src/lib/trips.spec.js
+++ b/src/lib/trips.spec.js
@@ -15,7 +15,7 @@ import {
   getSectionsFormatedInfo,
   transformTimeserieToTrip,
   transformTimeseriesToTrips,
-  getModes
+  getModesSortedByDistance
 } from 'src/lib/trips'
 
 const timeseries = [
@@ -24,7 +24,7 @@ const timeseries = [
   mockTimeserie('timeserieId03', [mockSerie()])
 ]
 
-describe('getModes', () => {
+describe('getModesSortedByDistance', () => {
   const mockedFeatures = [
     mockFeature('featureId01'),
     mockFeature('featureId02'),
@@ -42,8 +42,8 @@ describe('getModes', () => {
   ]
   const mockedSerie = mockSerie('serieId01', mockedFeatures)
 
-  it('should return modes sorted by distance', () => {
-    const result = getModes(mockedSerie)
+  it('should return feature collection modes sorted by distance', () => {
+    const result = getModesSortedByDistance(mockedSerie)
 
     expect(result).toHaveLength(3)
     expect(result).toStrictEqual(['CAR', 'BICYCLING', 'WALKING'])

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -8,8 +8,8 @@ export const buildGeoJSONQueryByAccountId = accountId => ({
     .where({
       'cozyMetadata.sourceAccount': accountId
     })
-    .sortBy([{ 'cozyMetadata.sourceAccount': 'desc' }, { startDate: 'desc' }])
     .indexFields(['cozyMetadata.sourceAccount', 'startDate'])
+    .sortBy([{ 'cozyMetadata.sourceAccount': 'desc' }, { startDate: 'desc' }])
     .limitBy(50),
   options: {
     as: `${DOCTYPE_GEOJSON}/sourceAccount/${accountId}`,

--- a/test/mockTrip.js
+++ b/test/mockTrip.js
@@ -1,19 +1,53 @@
+import cloneDeep from 'lodash/cloneDeep'
+
 import { DOCTYPE_GEOJSON } from 'src/constants/const'
 
 export const tripTemplate = {
+  type: 'FeatureCollection',
   features: [
     {
+      type: 'FeatureCollection',
       features: []
     }
   ]
+}
+
+export const modeProps = {
+  bicycle: {
+    mode: 'BICYCLING',
+    distance: 2456,
+    duration: 600,
+    startDate: '2021-01-01T08:00:00',
+    endDate: '2021-01-01T08:10:00'
+  },
+  walking: {
+    mode: 'WALKING',
+    distance: 563,
+    duration: 540,
+    startDate: '2021-01-01T08:11:00',
+    endDate: '2021-01-01T08:20:00'
+  },
+  car: {
+    mode: 'CAR',
+    distance: 14789,
+    duration: 1800,
+    startDate: '2021-01-01T08:30:00',
+    endDate: '2021-01-01T09:00:00'
+  },
+  plane: {
+    mode: 'AIR_OR_HSR',
+    distance: 504789,
+    duration: 1800,
+    startDate: '2021-01-01T08:30:00',
+    endDate: '2021-01-01T09:00:00'
+  }
 }
 
 export const createTripFromTemplate = (
   tripTemplate,
   { mode, distance, startDate, endDate, duration, speeds }
 ) => {
-  const trip = { ...tripTemplate }
-  const tripSpeeds = speeds || [1]
+  const trip = cloneDeep(tripTemplate)
   trip.features[0].features[0] = {
     properties: {
       sensed_mode: `PredictedModeTypes.${mode}`,
@@ -21,45 +55,46 @@ export const createTripFromTemplate = (
       start_fmt_time: startDate,
       end_fmt_time: endDate,
       duration,
-      speeds: tripSpeeds
+      speeds: speeds || [1]
     }
   }
   return trip
 }
 
 export const makeBicycleTrip = () =>
-  createTripFromTemplate(tripTemplate, {
-    mode: 'BICYCLING',
-    distance: 2456,
-    duration: 600,
-    startDate: '2021-01-01T08:00:00',
-    endDate: '2021-01-01T08:10:00'
-  })
+  createTripFromTemplate(tripTemplate, modeProps.bicycle)
+export const makeBicycleFeature = id => mockFeature(id, modeProps.bicycle)
 
 export const makeWalkingTrip = () =>
-  createTripFromTemplate(tripTemplate, {
-    mode: 'WALKING',
-    distance: 563,
-    duration: 540,
-    startDate: '2021-01-01T08:11:00',
-    endDate: '2021-01-01T08:20:00'
-  })
+  createTripFromTemplate(tripTemplate, modeProps.walking)
+export const makeWalkingFeature = id => mockFeature(id, modeProps.walking)
 
 export const makeCarTrip = () =>
-  createTripFromTemplate(tripTemplate, {
-    mode: 'CAR',
-    distance: 14789,
-    duration: 1800,
-    startDate: '2021-01-01T08:30:00',
-    endDate: '2021-01-01T09:00:00'
-  })
+  createTripFromTemplate(tripTemplate, modeProps.car)
+export const makeCarFeature = id => mockFeature(id, modeProps.car)
 
-export const mockFeature = id => ({
-  id,
-  type: 'Feature',
-  geometry: {},
-  properties: {}
-})
+export const makePlaneTrip = () => {
+  return createTripFromTemplate(tripTemplate, modeProps.plane)
+}
+export const makePlaneFeature = id => mockFeature(id, modeProps.plane)
+
+export const mockFeature = (id, props) => {
+  return {
+    id,
+    type: 'Feature',
+    geometry: {},
+    properties: props
+      ? {
+          sensed_mode: props.mode ? `PredictedModeTypes.${props.mode}` : '',
+          distance: props.distance || '',
+          start_fmt_time: props.startDate || '',
+          end_fmt_time: props.endDate || '',
+          duration: props.duration || '',
+          speeds: props.speeds || [1]
+        }
+      : {}
+  }
+}
 
 export const mockFeatureCollection = (id, features) => ({
   id,
@@ -68,27 +103,29 @@ export const mockFeatureCollection = (id, features) => ({
   features
 })
 
-export const mockSerie = (id = 'serieId01') => ({
+export const mockSerie = (id = 'serieId01', features) => ({
   id,
   type: 'FeatureCollection',
   properties: {
     start_place: { $oid: 'sectionId01' },
     end_place: { $oid: 'sectionId02' }
   },
-  features: [
+  features: features || [
     mockFeature('sectionId01'),
     mockFeature('sectionId02'),
     mockFeatureCollection('sectionId03', [mockFeature('featureId01')])
   ]
 })
 
-export const mockTimeserie = (id = 'timeserieId01', series) => ({
-  _id: id,
-  id,
-  _type: DOCTYPE_GEOJSON,
-  cozyMetadata: {},
-  startDate: '',
-  endDate: '',
-  source: '',
-  series
-})
+export const mockTimeserie = (id = 'timeserieId01', series) => {
+  return {
+    _id: id,
+    id,
+    _type: DOCTYPE_GEOJSON,
+    cozyMetadata: {},
+    startDate: '',
+    endDate: '',
+    source: '',
+    series
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4008,10 +4008,10 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@^60.10.0:
-  version "60.10.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-60.10.0.tgz#d600d2469c8ee15ebac5e60af48cb311f103662b"
-  integrity sha512-BBaTpMhfXk0bsLcKjPbwCEBLXsG7jMEfA0QDJIyWMFYhjIiDlaw2sBDL/EVNu89SpWYC77pK1ho8qMc1L+nUsg==
+cozy-ui@^62.1.0:
+  version "62.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-62.1.0.tgz#f966a9739cb48da3e4ead85b7daf2605cc3c4e65"
+  integrity sha512-QyWPIrXm0PIk3VN3tJ4g/N8Ev9+OjDuEZE+egx7Ns3Ra4swX9Uf7UVMCNEcRu8Fe3mmqq+Obh4pAaBmd6hCigQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
Aujourd'hui l'icône de la Modalité du trajet est affiché alors que la cible est la Raison du trajet.
Nous avions fait cela car la raison est non renseignée par défaut.

De plus, les couleurs misent en oeuvre ne correspondant pas à ce que l'on retrouve ensuite lors de la qualification des déplacements.