### PR TITLE
fix: Space between trips icons

### DIFF
--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -31,25 +31,19 @@ import {
 import TripDialogDesktop from 'src/components/Trip/TripDialogDesktop'
 
 const styles = {
-  co2: { fontWeight: 700 }
+  co2: { fontWeight: 700 },
+  tripIcon: {
+    marginRight: '4px'
+  }
 }
-
-const getIconStyle = (idx, icons) => ({
-  margin: idx !== 0 && idx < icons.length - 1 ? '0 4px' : '0'
-})
 
 const TripItemSecondary = ({ tripModeIcons, duration, distance }) => {
   return (
     <>
       {tripModeIcons.map((tripModeIcon, idx) => (
-        <Icon
-          key={idx}
-          icon={tripModeIcon}
-          size={10}
-          style={getIconStyle(idx, tripModeIcons)}
-        />
+        <Icon key={idx} icon={tripModeIcon} size={10} style={styles.tripIcon} />
       ))}
-      {` · ${duration} · ${distance}`}
+      {`· ${duration} · ${distance}`}
     </>
   )
 }


### PR DESCRIPTION
In the case of 4 or more trips, the space between the icons was not good anymore

Before:
![Capture d’écran 2022-02-17 à 11 09 56](https://user-images.githubusercontent.com/14182143/154454456-bdd96155-913f-450d-989a-4b3bddd2c7cd.png)

After:
![Capture d’écran 2022-02-17 à 11 10 16](https://user-images.githubusercontent.com/14182143/154454509-e48c582a-ca45-40e4-8819-73c93c32a653.png)

