### PR TITLE
fix: Display 2 decimal of CO2 percent

### DIFF
--- a/src/components/Analysis/AnalysisListItem.jsx
+++ b/src/components/Analysis/AnalysisListItem.jsx
@@ -17,7 +17,7 @@ import {
   pickPurposeIcon,
   purposeToColor
 } from 'src/components/helpers'
-import { formatCO2 } from 'src/lib/trips'
+import { computeFormatedPercentage, formatCO2 } from 'src/lib/trips'
 
 const styles = {
   co2: { fontWeight: 700 }
@@ -48,7 +48,7 @@ const AnalysisListItem = ({ sortedTimeserie, totalCO2, type }) => {
   const travelCount = sortedTimeserieValue.timeseries.length
   const CO2 = sortedTimeserieValue.totalCO2
 
-  const CO2percent = `${Math.round((CO2 * 100) / totalCO2)}%`
+  const CO2percent = computeFormatedPercentage(CO2, totalCO2)
   const isDisabled = travelCount === 0 && CO2 === 0
 
   const handleClick = () => {

--- a/src/lib/trips.js
+++ b/src/lib/trips.js
@@ -9,6 +9,21 @@ import { UNKNOWN_MODE } from 'src/constants/const'
 import { computeCaloriesTrip, computeCO2Trip } from 'src/lib/metrics'
 import { modes } from 'src/components/helpers'
 
+/**
+ * Compute the percentage and returns it as a formatted string
+ * @param {number} value
+ * @param {number} total
+ * @returns {string}
+ */
+export const computeFormatedPercentage = (value, total) => {
+  if (total === 0) return '0%'
+
+  const [int, dec] = ((value * 100) / total).toFixed(2).split('.')
+  if (dec === '00') return `${int}%`
+
+  return `${int}.${dec}%`
+}
+
 export const getPurpose = trip => {
   return get(trip, 'properties.manual_purpose')
 }

--- a/src/lib/trips.spec.js
+++ b/src/lib/trips.spec.js
@@ -15,7 +15,8 @@ import {
   getSectionsFormatedFromTrip,
   getModesSortedByDistance,
   computeAndFormatCO2Trip,
-  getFeatureMode
+  getFeatureMode,
+  computeFormatedPercentage
 } from 'src/lib/trips'
 
 const mockedFeatures = () => [
@@ -166,4 +167,21 @@ describe('getFeatureMode', () => {
 
     expect(result).toBe('UNKNOWN')
   })
+})
+
+describe('computeFormatedPercentage', () => {
+  it.each`
+    value | total  | result
+    ${50} | ${100} | ${'50%'}
+    ${50} | ${90}  | ${'55.56%'}
+    ${50} | ${80}  | ${'62.50%'}
+    ${50} | ${0}   | ${'0%'}
+    ${0}  | ${0}   | ${'0%'}
+    ${0}  | ${100} | ${'0%'}
+  `(
+    `should return $result with ($value, $total) params`,
+    ({ value, total, result }) => {
+      expect(computeFormatedPercentage(value, total)).toBe(result)
+    }
+  )
 })


### PR DESCRIPTION
Display of 2 decimal of the CO2 **percentage** for more accuracy
(Except if the decimal part is "00")

Before:
![image01](https://user-images.githubusercontent.com/14182143/156416517-adcd67c8-79da-46cd-9360-15926e141eb8.png)

After:
![Capture d’écran 2022-03-02 à 18 24 43](https://user-images.githubusercontent.com/14182143/156416556-3c57b1c8-8ab7-46e7-82d2-bee06479186a.png)


