### PR TITLE
Add date filter for analysis pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Home : replace the icon of a trip by the purpose's one, and displays all used modes
 * Analysis: new analysis pages allowing to visualize the most CO2 consuming trips by mode and purpose
 * Analysis: new pages in the analysis tab allowing to visualize the trips filtered by mode or purpose by clicking on them
+* Date selector for analysis pages
 
 ## 🐛 Bug Fixes
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   testURL: 'http://localhost/',
   moduleFileExtensions: ['js', 'jsx', 'json', 'styl'],
   setupFiles: ['<rootDir>/test/jestLib/setup.js'],
+  setupFilesAfterEnv: ['<rootDir>/test/jestLib/setupAfterEnv.js'],
   moduleDirectories: ['src', 'node_modules'],
   moduleNameMapper: {
     '\\.(png|gif|jpe?g|svg)$': '<rootDir>/test/__mocks__/fileMock.js',

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "homepage": "https://github.com/cozy/coachco2#README",
   "devDependencies": {
     "@material-ui/lab": "^4.0.0-alpha.60",
+    "@testing-library/jest-dom": "5.16.2",
     "@testing-library/react": "11.2.7",
     "babel-preset-cozy-app": "1.11.0",
     "bundlemon": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@material-ui/lab": "^4.0.0-alpha.60",
     "@testing-library/jest-dom": "5.16.2",
     "@testing-library/react": "11.2.7",
+    "@testing-library/react-hooks": "^7.0.2",
     "babel-preset-cozy-app": "1.11.0",
     "bundlemon": "1.3.0",
     "cozy-ach": "^1.39.0",

--- a/src/components/Analysis/Modes/ModesList.jsx
+++ b/src/components/Analysis/Modes/ModesList.jsx
@@ -3,14 +3,14 @@ import React from 'react'
 import { isQueryLoading, useQuery } from 'cozy-client'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
-import { buildGeoJSONQueryNoLimitByDate } from 'src/queries/queries'
+import { buildGeoJSONQueryByDateNoLimit } from 'src/queries/queries'
 import { useSelectDatesContext } from 'src/components/Providers/SelectDatesProvider'
 import LoadedModesList from 'src/components/Analysis/Modes/LoadedModesList'
 
 const ModesList = () => {
   const { selectedDate } = useSelectDatesContext()
 
-  const geoJsonQuery = buildGeoJSONQueryNoLimitByDate(selectedDate)
+  const geoJsonQuery = buildGeoJSONQueryByDateNoLimit(selectedDate)
   const { data: timeseries, ...queryResult } = useQuery(
     geoJsonQuery.definition,
     geoJsonQuery.options

--- a/src/components/Analysis/Modes/ModesList.jsx
+++ b/src/components/Analysis/Modes/ModesList.jsx
@@ -3,11 +3,14 @@ import React from 'react'
 import { isQueryLoading, useQuery } from 'cozy-client'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
-import { buildGeoJSONQueryNoLimit } from 'src/queries/queries'
+import { buildGeoJSONQueryNoLimitByDate } from 'src/queries/queries'
+import { useSelectDatesContext } from 'src/components/Providers/SelectDatesProvider'
 import LoadedModesList from 'src/components/Analysis/Modes/LoadedModesList'
 
 const ModesList = () => {
-  const geoJsonQuery = buildGeoJSONQueryNoLimit()
+  const { selectedDate } = useSelectDatesContext()
+
+  const geoJsonQuery = buildGeoJSONQueryNoLimitByDate(selectedDate)
   const { data: timeseries, ...queryResult } = useQuery(
     geoJsonQuery.definition,
     geoJsonQuery.options

--- a/src/components/Analysis/Purposes/PurposesList.jsx
+++ b/src/components/Analysis/Purposes/PurposesList.jsx
@@ -3,11 +3,14 @@ import React from 'react'
 import { isQueryLoading, useQuery } from 'cozy-client'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
-import { buildGeoJSONQueryNoLimit } from 'src/queries/queries'
+import { buildGeoJSONQueryNoLimitByDate } from 'src/queries/queries'
+import { useSelectDatesContext } from 'src/components/Providers/SelectDatesProvider'
 import LoadedPurposesList from 'src/components/Analysis/Purposes/LoadedPurposesList'
 
 const PurposesList = () => {
-  const geoJsonQuery = buildGeoJSONQueryNoLimit()
+  const { selectedDate } = useSelectDatesContext()
+
+  const geoJsonQuery = buildGeoJSONQueryNoLimitByDate(selectedDate)
   const { data: timeseries, ...queryResult } = useQuery(
     geoJsonQuery.definition,
     geoJsonQuery.options

--- a/src/components/Analysis/Purposes/PurposesList.jsx
+++ b/src/components/Analysis/Purposes/PurposesList.jsx
@@ -3,14 +3,14 @@ import React from 'react'
 import { isQueryLoading, useQuery } from 'cozy-client'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
-import { buildGeoJSONQueryNoLimitByDate } from 'src/queries/queries'
+import { buildGeoJSONQueryByDateNoLimit } from 'src/queries/queries'
 import { useSelectDatesContext } from 'src/components/Providers/SelectDatesProvider'
 import LoadedPurposesList from 'src/components/Analysis/Purposes/LoadedPurposesList'
 
 const PurposesList = () => {
   const { selectedDate } = useSelectDatesContext()
 
-  const geoJsonQuery = buildGeoJSONQueryNoLimitByDate(selectedDate)
+  const geoJsonQuery = buildGeoJSONQueryByDateNoLimit(selectedDate)
   const { data: timeseries, ...queryResult } = useQuery(
     geoJsonQuery.definition,
     geoJsonQuery.options

--- a/src/components/Analysis/Purposes/PurposesList.spec.js
+++ b/src/components/Analysis/Purposes/PurposesList.spec.js
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react'
 import PurposesList from './PurposesList'
 import { isQueryLoading, useQuery } from 'cozy-client'
 
-import { buildGeoJSONQueryNoLimitByDate } from 'src/queries/queries'
+import { buildGeoJSONQueryByDateNoLimit } from 'src/queries/queries'
 
 jest.mock('cozy-client', () => ({
   isQueryLoading: jest.fn(),
@@ -25,7 +25,7 @@ jest.mock('src/components/Providers/SelectDatesProvider', () => ({
 
 describe('PurposesList', () => {
   beforeEach(() => {
-    buildGeoJSONQueryNoLimitByDate.mockReturnValue({
+    buildGeoJSONQueryByDateNoLimit.mockReturnValue({
       definition: 'definition',
       options: 'options'
     })
@@ -35,7 +35,7 @@ describe('PurposesList', () => {
     })
   })
 
-  it('should call useQuery with correct definition from buildGeoJSONQueryNoLimitByDate', () => {
+  it('should call useQuery with correct definition from buildGeoJSONQueryByDateNoLimit', () => {
     render(<PurposesList />)
 
     expect(useQuery).toHaveBeenCalledWith('definition', 'options')

--- a/src/components/Analysis/Purposes/PurposesList.spec.js
+++ b/src/components/Analysis/Purposes/PurposesList.spec.js
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react'
 import PurposesList from './PurposesList'
 import { isQueryLoading, useQuery } from 'cozy-client'
 
-import { buildGeoJSONQueryNoLimit } from 'src/queries/queries'
+import { buildGeoJSONQueryNoLimitByDate } from 'src/queries/queries'
 
 jest.mock('cozy-client', () => ({
   isQueryLoading: jest.fn(),
@@ -19,10 +19,13 @@ jest.mock(
     <div data-testid="LoadedPurposesList" data-timeseries={timeseries} />
   )
 )
+jest.mock('src/components/Providers/SelectDatesProvider', () => ({
+  useSelectDatesContext: jest.fn(() => ({ selectedDate: '' }))
+}))
 
 describe('PurposesList', () => {
   beforeEach(() => {
-    buildGeoJSONQueryNoLimit.mockReturnValue({
+    buildGeoJSONQueryNoLimitByDate.mockReturnValue({
       definition: 'definition',
       options: 'options'
     })
@@ -32,7 +35,7 @@ describe('PurposesList', () => {
     })
   })
 
-  it('should call useQuery with correct definition from buildGeoJSONQueryNoLimit', () => {
+  it('should call useQuery with correct definition from buildGeoJSONQueryNoLimitByDate', () => {
     render(<PurposesList />)
 
     expect(useQuery).toHaveBeenCalledWith('definition', 'options')

--- a/src/components/Providers/SelectDatesProvider.jsx
+++ b/src/components/Providers/SelectDatesProvider.jsx
@@ -1,0 +1,24 @@
+import React, { createContext, useState, useContext, useMemo } from 'react'
+
+export const SelectDatesContext = createContext()
+export const useSelectDatesContext = () => useContext(SelectDatesContext)
+
+export const SelectDatesProvider = ({ children }) => {
+  const [selectedDate, setSelectedDate] = useState(null)
+
+  const value = useMemo(
+    () => ({
+      selectedDate,
+      setSelectedDate
+    }),
+    [selectedDate]
+  )
+
+  return (
+    <SelectDatesContext.Provider value={value}>
+      {children}
+    </SelectDatesContext.Provider>
+  )
+}
+
+export default SelectDatesProvider

--- a/src/components/SelectDates.jsx
+++ b/src/components/SelectDates.jsx
@@ -1,0 +1,45 @@
+import React, { useCallback, useEffect } from 'react'
+
+import { useSelectDatesContext } from 'src/components/Providers/SelectDatesProvider'
+import SelectDatesWithLoader from 'src/components/SelectDates/SelectDatesWithLoader'
+import { makeLatestDate } from 'src/components/SelectDates/helpers'
+import useAllTimeseriesByAccount from 'src/hooks/useAllTimeseriesByAccount'
+
+const computeOptions = (isLoading, timeseries) => {
+  if (isLoading) return null
+  return timeseries.map(timeserie => new Date(timeserie.startDate))
+}
+
+const SelectDates = () => {
+  const { selectedDate, setSelectedDate } = useSelectDatesContext()
+  const { timeseries, isLoading } = useAllTimeseriesByAccount()
+
+  const options = useCallback(computeOptions(isLoading, timeseries), [
+    isLoading,
+    timeseries
+  ])
+
+  useEffect(() => {
+    if (options && selectedDate === null) {
+      setSelectedDate(makeLatestDate(options))
+    }
+  }, [options, selectedDate, setSelectedDate])
+
+  useEffect(() => {
+    return () => {
+      setSelectedDate(null)
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <SelectDatesWithLoader
+      className="u-mt-1-s u-ml-0-s u-flex-justify-center-s u-flex u-ml-2"
+      isLoading={isLoading || selectedDate === null}
+      options={options}
+      selectedDate={selectedDate}
+      setSelectedDate={setSelectedDate}
+    />
+  )
+}
+
+export default SelectDates

--- a/src/components/SelectDates/DropdownButton.jsx
+++ b/src/components/SelectDates/DropdownButton.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import cx from 'classnames'
+import Button from '@material-ui/core/Button'
+import { makeStyles } from '@material-ui/core/styles'
+
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import BottomIcon from 'cozy-ui/transpiled/react/Icons/Bottom'
+
+const useStyles = makeStyles(() => ({
+  button: {
+    padding: '0 1rem',
+    justifyContent: ({ spaceBetween }) =>
+      spaceBetween ? 'space-between' : 'left'
+  },
+  typography: {
+    textTransform: 'capitalize'
+  }
+}))
+
+const DropdownButton = ({ children, className, spaceBetween, ...props }) => {
+  const classes = useStyles({ spaceBetween })
+
+  return (
+    <Button
+      className={cx(classes.button, className)}
+      endIcon={<Icon icon={BottomIcon} size={10} />}
+      {...props}
+    >
+      <Typography className={classes.typography} variant="body1">
+        {children}
+      </Typography>
+    </Button>
+  )
+}
+
+export default DropdownButton

--- a/src/components/SelectDates/DropdownMenuButton.jsx
+++ b/src/components/SelectDates/DropdownMenuButton.jsx
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { makeStyles } from '@material-ui/core/styles'
+import Menu from '@material-ui/core/Menu'
+import MenuItem from '@material-ui/core/MenuItem'
+
+import DropdownButton from 'src/components/SelectDates/DropdownButton'
+
+const useStyles = makeStyles(() => ({
+  paper: {
+    textTransform: 'capitalize',
+    width: ({ anchorEl }) =>
+      anchorEl ? window.getComputedStyle(anchorEl).width : undefined,
+    marginTop: 2
+  }
+}))
+
+const DropdownMenuButton = ({
+  className,
+  type,
+  options,
+  selectedIndex,
+  disabledIndexes,
+  onclick,
+  ...props
+}) => {
+  const [anchorEl, setAnchorEl] = useState(null)
+  const [activeIndex, setActiveIndex] = useState(selectedIndex || 0)
+  const { paper } = useStyles({ anchorEl })
+
+  const handleClick = event => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleMenuItemClick = index => () => {
+    setAnchorEl(null)
+    setActiveIndex(index)
+    onclick && onclick(type, options[index])
+  }
+
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  useEffect(() => {
+    if (selectedIndex !== undefined) {
+      setActiveIndex(selectedIndex)
+    }
+  }, [selectedIndex])
+
+  return (
+    <>
+      <DropdownButton
+        data-testid="dropdown-button"
+        className={className}
+        onClick={handleClick}
+        {...props}
+      >
+        {options[activeIndex]}
+      </DropdownButton>
+      <Menu
+        data-testid="dropdown-menu"
+        classes={{ paper }}
+        anchorEl={anchorEl}
+        getContentAnchorEl={null}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center'
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center'
+        }}
+        elevation={2}
+      >
+        {options.map((option, index) => (
+          <MenuItem
+            data-testid={`dropdown-menuItem-${index}`}
+            key={index}
+            onClick={handleMenuItemClick(index)}
+            selected={index === activeIndex}
+            disabled={disabledIndexes && disabledIndexes.includes(index)}
+          >
+            {option}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  )
+}
+
+DropdownMenuButton.proptypes = {
+  className: PropTypes.string,
+  type: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  options: PropTypes.array.isRequired,
+  selectedIndex: PropTypes.number,
+  disabledIndexes: PropTypes.array,
+  onclick: PropTypes.func
+}
+
+export default DropdownMenuButton

--- a/src/components/SelectDates/DropdownMenuButton.spec.js
+++ b/src/components/SelectDates/DropdownMenuButton.spec.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+
+import DropdownMenuButton from './DropdownMenuButton'
+
+const setup = ({ type, selectedIndex, disabledIndexes, click } = {}) => {
+  return render(
+    <DropdownMenuButton
+      type={type}
+      options={['value1', 'value2']}
+      selectedIndex={selectedIndex}
+      disabledIndexes={disabledIndexes}
+      onclick={click}
+    />
+  )
+}
+
+describe('DropdownMenuButton', () => {
+  it('should trigger onclick fn from prop when clicking an option', () => {
+    const click = jest.fn()
+    const { getByTestId } = setup({ type: 'year', click })
+
+    fireEvent.click(getByTestId('dropdown-menuItem-0'))
+    expect(click).toHaveBeenCalledWith('year', 'value1')
+
+    jest.clearAllMocks()
+
+    fireEvent.click(getByTestId('dropdown-menuItem-1'))
+    expect(click).toHaveBeenCalledWith('year', 'value2')
+  })
+
+  it('should show options value as menu option', () => {
+    const { getByTestId } = setup()
+
+    expect(getByTestId('dropdown-menuItem-0').textContent).toBe('value1')
+    expect(getByTestId('dropdown-menuItem-1').textContent).toBe('value2')
+  })
+
+  it('should show first option value as default dropdown button value', () => {
+    const { getByTestId } = setup()
+
+    expect(getByTestId('dropdown-button').textContent).toBe('value1')
+  })
+
+  it('should disable the correct menu option', () => {
+    const { getByTestId } = setup({ disabledIndexes: [1] })
+
+    expect(getByTestId('dropdown-menuItem-0')).toHaveAttribute(
+      'aria-disabled',
+      'false'
+    )
+    expect(getByTestId('dropdown-menuItem-1')).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    )
+  })
+
+  it('should set the correct menu option selected', () => {
+    const { getByTestId } = setup()
+
+    expect(getByTestId('dropdown-menuItem-0')).toHaveClass('Mui-selected')
+    expect(getByTestId('dropdown-menuItem-1')).not.toHaveClass('Mui-selected')
+
+    fireEvent.click(getByTestId('dropdown-menuItem-1'))
+
+    expect(getByTestId('dropdown-menuItem-0')).not.toHaveClass('Mui-selected')
+    expect(getByTestId('dropdown-menuItem-1')).toHaveClass('Mui-selected')
+  })
+})

--- a/src/components/SelectDates/EmptySelectDates.jsx
+++ b/src/components/SelectDates/EmptySelectDates.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import cx from 'classnames'
+import { makeStyles } from '@material-ui/core/styles'
+
+import Box from 'cozy-ui/transpiled/react/Box'
+import Paper from 'cozy-ui/transpiled/react/Paper'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
+import LeftIcon from 'cozy-ui/transpiled/react/Icons/Left'
+
+const useStyles = makeStyles(theme => ({
+  paper: {
+    display: 'inline-flex',
+    width: 264,
+    borderRadius: 1000
+  },
+  iconButton: {
+    color: theme.palette.text.icon,
+    boxShadow: theme.shadows[2]
+  }
+}))
+
+const EmptySelectDates = ({ className }) => {
+  const classes = useStyles()
+
+  return (
+    <Box display="flex" className={className}>
+      <Paper className={classes.paper} elevation={2} />
+      <Box className="u-ml-half" display="inline-flex">
+        <IconButton className={classes.iconButton} disabled={true}>
+          <Icon icon={LeftIcon} />
+        </IconButton>
+        <IconButton
+          className={cx(classes.iconButton, 'u-ml-half')}
+          disabled={true}
+        >
+          <Icon icon={RightIcon} />
+        </IconButton>
+      </Box>
+    </Box>
+  )
+}
+
+export default EmptySelectDates

--- a/src/components/SelectDates/SelectDates.jsx
+++ b/src/components/SelectDates/SelectDates.jsx
@@ -1,0 +1,140 @@
+import React, { useCallback } from 'react'
+import PropTypes from 'prop-types'
+import cx from 'classnames'
+import { makeStyles } from '@material-ui/core/styles'
+
+import Box from 'cozy-ui/transpiled/react/Box'
+import Paper from 'cozy-ui/transpiled/react/Paper'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
+import LeftIcon from 'cozy-ui/transpiled/react/Icons/Left'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import {
+  computeMonths,
+  computeYears,
+  makeNewDate,
+  isDisableNextPreviousButton
+} from 'src/components/SelectDates/helpers'
+import DropdownMenuButton from 'src/components/SelectDates/DropdownMenuButton'
+
+const useStyles = makeStyles(theme => ({
+  paper: {
+    display: 'inline-flex',
+    width: 264,
+    borderRadius: 1000
+  },
+  leftDropdownButton: {
+    borderTopLeftRadius: 1000,
+    borderBottomLeftRadius: 1000
+  },
+  rightDropdownButton: {
+    borderTopRightRadius: 1000,
+    borderBottomRightRadius: 1000,
+    paddingRight: '1.2rem'
+  },
+  divider: {
+    margin: '0.6rem 0'
+  },
+  iconButton: {
+    color: theme.palette.text.icon,
+    boxShadow: theme.shadows[2]
+  }
+}))
+
+const SelectDates = ({ className, options, selectedDate, setSelectedDate }) => {
+  const classes = useStyles()
+  const { lang } = useI18n()
+
+  const { months, monthSelectedIndex, disabledMonthsIndexes } = useCallback(
+    computeMonths({
+      dates: options,
+      selectedDate,
+      lang
+    }),
+    [options, selectedDate, lang]
+  )
+
+  const { years, yearSelectedIndex, disabledYearsIndexes } = useCallback(
+    computeYears(options, selectedDate),
+    [options, selectedDate]
+  )
+
+  const handleDropdownClick = (type, value) => {
+    const newDate = makeNewDate({
+      oldDate: selectedDate,
+      lang,
+      value,
+      type,
+      dates: options
+    })
+
+    setSelectedDate(newDate)
+  }
+
+  const handleIconButtonClick = n => () => {
+    setSelectedDate(date => {
+      return new Date(date.setMonth(date.getMonth() + n))
+    })
+  }
+
+  const isDisabledIconButton = type =>
+    isDisableNextPreviousButton({ type, selectedDate, options })
+
+  return (
+    <Box display="flex" className={className}>
+      <Paper className={classes.paper} elevation={2}>
+        <DropdownMenuButton
+          data-testid="dropdown-button-year"
+          type="year"
+          className={classes.leftDropdownButton}
+          options={years}
+          onclick={handleDropdownClick}
+          selectedIndex={yearSelectedIndex}
+          disabledIndexes={disabledYearsIndexes}
+        />
+        <Divider className={classes.divider} orientation="vertical" flexItem />
+        <DropdownMenuButton
+          data-testid="dropdown-button-month"
+          type="month"
+          className={classes.rightDropdownButton}
+          fullWidth
+          spaceBetween
+          options={months}
+          onclick={handleDropdownClick}
+          selectedIndex={monthSelectedIndex}
+          disabledIndexes={disabledMonthsIndexes}
+        />
+      </Paper>
+      <Box className="u-ml-half" display="inline-flex">
+        <IconButton
+          data-testid="previous-button"
+          className={classes.iconButton}
+          onClick={handleIconButtonClick(-1)}
+          disabled={isDisabledIconButton('previous')}
+        >
+          <Icon icon={LeftIcon} />
+        </IconButton>
+        <IconButton
+          data-testid="next-button"
+          className={cx(classes.iconButton, 'u-ml-half')}
+          onClick={handleIconButtonClick(+1)}
+          disabled={isDisabledIconButton('next')}
+        >
+          <Icon icon={RightIcon} />
+        </IconButton>
+      </Box>
+    </Box>
+  )
+}
+
+SelectDates.proptypes = {
+  className: PropTypes.string,
+  options: PropTypes.array.isRequired,
+  selectedDate: PropTypes.number.isRequired,
+  setSelectedDate: PropTypes.func.isRequired
+}
+
+export default SelectDates

--- a/src/components/SelectDates/SelectDates.spec.js
+++ b/src/components/SelectDates/SelectDates.spec.js
@@ -1,0 +1,88 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+
+import AppLike from 'test/AppLike'
+
+import SelectDates from './SelectDates'
+
+const dates = [new Date('2022-01'), new Date('2021-12'), new Date('2021-11')]
+const defaultDate = dates[1]
+
+const setup = ({
+  options = dates,
+  selectedDate = defaultDate,
+  setSelectedDate = jest.fn(x => x)
+} = {}) => {
+  return {
+    comp: render(
+      <AppLike>
+        <SelectDates
+          options={options}
+          selectedDate={selectedDate}
+          setSelectedDate={setSelectedDate}
+        />
+      </AppLike>
+    ),
+    setSelectedDate
+  }
+}
+
+describe('SelectDates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should disabled next button if latest date is selected', async () => {
+    const { comp } = setup({ selectedDate: dates[0] })
+    const { getByTestId } = comp
+
+    expect(getByTestId('next-button')).toHaveAttribute('disabled')
+  })
+
+  it('should disabled previous button if earliest date is selected', async () => {
+    const { comp } = setup({ selectedDate: dates[2] })
+    const { getByTestId } = comp
+
+    expect(getByTestId('previous-button')).toHaveAttribute('disabled')
+  })
+
+  it('should set the new date correctly when clicking previous month button', async () => {
+    const setSelectedDate = jest.fn(x => {
+      const createdNewDate = x(new Date(defaultDate))
+      const expectedNewDate = dates[2]
+
+      if (createdNewDate.getTime() !== expectedNewDate.getTime()) {
+        throw new Error("setSelectedDate function doesn't work properly")
+      }
+    })
+
+    const { comp, setSelectedDate: mockSetSelectedDate } = setup({
+      setSelectedDate
+    })
+
+    const { getByTestId } = comp
+
+    fireEvent.click(getByTestId('previous-button'))
+    expect(mockSetSelectedDate).toHaveBeenCalled()
+  })
+
+  it('should set the new date correctly when clicking next month button', async () => {
+    const setSelectedDate = jest.fn(x => {
+      const createdNewDate = x(new Date(defaultDate))
+      const expectedNewDate = dates[0]
+
+      if (createdNewDate.getTime() !== expectedNewDate.getTime()) {
+        throw new Error("setSelectedDate function doesn't work properly")
+      }
+    })
+
+    const { comp, setSelectedDate: mockSetSelectedDate } = setup({
+      setSelectedDate
+    })
+
+    const { getByTestId } = comp
+
+    fireEvent.click(getByTestId('next-button'))
+    expect(mockSetSelectedDate).toHaveBeenCalled()
+  })
+})

--- a/src/components/SelectDates/SelectDatesWithLoader.jsx
+++ b/src/components/SelectDates/SelectDatesWithLoader.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import EmptySelectDates from 'src/components/SelectDates/EmptySelectDates'
+import SelectDates from 'src/components/SelectDates/SelectDates'
+
+const SelectDatesWithLoader = ({
+  className,
+  options,
+  isLoading,
+  selectedDate,
+  setSelectedDate
+}) => {
+  if (isLoading) {
+    return <EmptySelectDates className={className} />
+  }
+
+  return (
+    <SelectDates
+      className={className}
+      options={options}
+      selectedDate={selectedDate}
+      setSelectedDate={setSelectedDate}
+    />
+  )
+}
+
+export default SelectDatesWithLoader

--- a/src/components/SelectDates/__snapshots__/helpers.spec.js.snap
+++ b/src/components/SelectDates/__snapshots__/helpers.spec.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`makeAllMonthsName should return all the months of the year according to the language 1`] = `
+Array [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+]
+`;

--- a/src/components/SelectDates/helpers.js
+++ b/src/components/SelectDates/helpers.js
@@ -1,0 +1,279 @@
+import memoize from 'lodash/memoize'
+
+/**
+ * Returns an array of the names of all the months of the year
+ * @param {string} lang - The language to be used (fr, en, etc.)
+ * @returns {array}
+ */
+export const makeAllMonthsName = lang => {
+  const MONTHS_BY_YEAR = 12
+
+  return Array(MONTHS_BY_YEAR)
+    .fill()
+    .map((_, index) => {
+      return new Intl.DateTimeFormat(`${lang}-${lang.toUpperCase()}`, {
+        month: 'long'
+      }).format(new Date(0, index))
+    })
+}
+
+/**
+ * Returns the earliest date
+ * @param {array} dates
+ * @returns {date}
+ */
+export const makeEarliestDate = dates => new Date(Math.min.apply(null, dates))
+
+/**
+ * Returns the latest date
+ * @param {array} dates
+ * @returns {date}
+ */
+export const makeLatestDate = dates => new Date(Math.max.apply(null, dates))
+
+/**
+ * Creates a sorted year interval between the earliest and latest date. The first year is the latest one.
+ * @param {array} dates
+ * @returns {array}
+ */
+export const makeYearsBetweenEarliestAndLatest = dates => {
+  const latestYear = makeLatestDate(dates).getFullYear()
+  const earliestYear = makeEarliestDate(dates).getFullYear()
+  let previousYear = Number(earliestYear)
+
+  return Array(latestYear - earliestYear + 1)
+    .fill()
+    .map(() => previousYear++)
+    .sort()
+    .reverse()
+}
+
+/**
+ * Returns the unique years of a date list
+ * @param {array} dates
+ * @returns {array}
+ */
+export const makeYearsFromDates = dates => [
+  ...new Set(dates.map(date => date.getFullYear()))
+]
+
+/**
+ * Returns the months of the dates according to the `year` param
+ * @param {object} params
+ * @param {array} params.dates - List of dates
+ * @param {number} params.year - The reference year
+ * @param {array} params.allMonthsName - The names of all the year's months
+ * @returns {array}
+ */
+export const makeMonthsFromYear = ({ dates, year, allMonthsName }) => [
+  ...new Set(
+    dates
+      .map(date =>
+        date.getFullYear() === year ? allMonthsName[date.getMonth()] : null
+      )
+      .filter(el => el !== null)
+  )
+]
+
+/**
+ * Returns the indexes whose values in the first array are not in the second
+ * @param {array} arr1
+ * @param {array} arr2
+ * @returns {array}
+ */
+export const makeIndexesOfUnmatchingValues = (arr1, arr2) => {
+  return arr1
+    .map((val, index) => (!arr2.includes(val) ? index : null))
+    .filter(el => el !== null)
+}
+
+/**
+ * Returns the years between the earliest and latest date, the index of the year according to the `selectedDate` param, and the indexes of the disabled years
+ * @param {array} dates - List of dates
+ * @param {date} selectedDate - The specific date
+ * @returns {object} { years, yearSelectedIndex, disabledYearsIndexes }
+ */
+export const computeYears = (dates, selectedDate) => {
+  const yearsBetweenEarliestAndLatest = makeYearsBetweenEarliestAndLatest(dates)
+  const yearsOfDates = makeYearsFromDates(dates)
+
+  const selectedIndex = yearsBetweenEarliestAndLatest.indexOf(
+    selectedDate.getFullYear()
+  )
+
+  const disabledYearsIndexes = makeIndexesOfUnmatchingValues(
+    yearsBetweenEarliestAndLatest,
+    yearsOfDates
+  )
+
+  return {
+    years: yearsBetweenEarliestAndLatest,
+    yearSelectedIndex: selectedIndex,
+    disabledYearsIndexes
+  }
+}
+
+/**
+ * Return the name of the months according to the direction and the quantity
+ * @param {object} params
+ * @param {number} params.monthCount - The number of months desired
+ * @param {array} params.allMonthsName - The names of all the year's months
+ * @param {boolean} params.endToStart - Start with the beginning or the end of the year
+ * @returns {array}
+ */
+export const makeMonthsNameByCount = ({
+  monthCount,
+  allMonthsName,
+  endToStart
+}) => {
+  return allMonthsName.slice(
+    endToStart ? allMonthsName.length - monthCount : 0,
+    endToStart ? allMonthsName.length : monthCount
+  )
+}
+
+/**
+ * Returns the names of the year's months, the index of the selected date's month, and the month indexes of the month not present in the `dates` param according to the year of the selected date
+ * @param {object} params
+ * @param {array} params.dates - List of dates
+ * @param {date} params.selectedDate - The specific date
+ * @param {string} params.lang - The language to be used
+ * @returns {object} { months, monthSelectedIndex, disabledMonthsIndexes }
+ */
+export const computeMonths = memoize(({ dates, selectedDate, lang }) => {
+  const allMonthsName = makeAllMonthsName(lang)
+  const earliestDate = makeEarliestDate(dates)
+  const latestDate = makeLatestDate(dates)
+  const selectedYear = selectedDate.getFullYear()
+
+  const isSelectedYearSameAsLatestYear =
+    selectedYear === latestDate.getFullYear()
+  const isSelectedYearSameAsEarliestYear =
+    selectedYear === earliestDate.getFullYear()
+
+  // create dropdownMonths
+  let monthCount = 12
+
+  if (isSelectedYearSameAsLatestYear) {
+    monthCount = latestDate.getMonth() + 1
+  } else if (isSelectedYearSameAsEarliestYear) {
+    monthCount = 12 - earliestDate.getMonth()
+  }
+
+  const dropdownMonths = makeMonthsNameByCount({
+    monthCount,
+    allMonthsName,
+    endToStart: isSelectedYearSameAsEarliestYear
+  })
+
+  // create selectedIndex
+  let selectedIndex = dropdownMonths.indexOf(
+    allMonthsName[selectedDate.getMonth()]
+  )
+
+  if (selectedIndex === -1) {
+    let dateToPick
+    if (isSelectedYearSameAsLatestYear) {
+      dateToPick = latestDate
+    } else if (isSelectedYearSameAsEarliestYear) {
+      dateToPick = earliestDate
+    }
+    selectedIndex = dropdownMonths.indexOf(allMonthsName[dateToPick.getMonth()])
+  }
+
+  // create disabledMonthsIndexes
+  const monthsFromYear = makeMonthsFromYear({
+    dates,
+    year: selectedYear,
+    allMonthsName
+  })
+
+  const disabledMonthsIndexes = makeIndexesOfUnmatchingValues(
+    dropdownMonths,
+    monthsFromYear
+  )
+
+  return {
+    months: dropdownMonths,
+    monthSelectedIndex: selectedIndex,
+    disabledMonthsIndexes
+  }
+})
+
+/**
+ * Return a new date according to the rule:
+ * If we change the year and the new date is more recent than the most recent date, we take the closest date. Same thing in the past.
+ * If we change the month, we just get the new date with the new month.
+ * @param {object} params
+ * @param {array} params.oldDate - The previous date
+ * @param {date} params.lang - The month name language
+ * @param {string} params.value - Could be a year or month name
+ * @param {string} params.type - `year`or `month`
+ * @param {string} params.dates - List of dates
+ * @returns {date}
+ */
+export const makeNewDate = memoize(({ oldDate, lang, value, type, dates }) => {
+  const allMonthsName = makeAllMonthsName(lang)
+
+  if (type === 'year') {
+    const dateWithNewYear = new Date(new Date(oldDate).setFullYear(value))
+
+    const { months, monthSelectedIndex } = computeMonths({
+      dates,
+      selectedDate: dateWithNewYear,
+      lang
+    })
+    const monthValue = allMonthsName.indexOf(months[monthSelectedIndex])
+
+    return new Date(new Date(dateWithNewYear).setMonth(monthValue))
+  }
+
+  if (type === 'month') {
+    const monthValue = allMonthsName.indexOf(value)
+
+    return new Date(new Date(oldDate).setMonth(monthValue))
+  }
+
+  return oldDate
+})
+
+/**
+ * Whether the button is disabled or not
+ * @param {object} params
+ * @param {string} params.type - `previous` or `next`
+ * @param {date} params.selectedDate - The specific date
+ * @param {array} params.options - List of dates
+ * @returns {boolean}
+ */
+export const isDisableNextPreviousButton = ({
+  type,
+  selectedDate,
+  options
+}) => {
+  const selectedYearAndMonth = new Date(
+    selectedDate.getFullYear(),
+    selectedDate.getMonth()
+  )
+
+  if (type === 'previous') {
+    const earliestDate = makeEarliestDate(options)
+    const earliestYearAndMonth = new Date(
+      earliestDate.getFullYear(),
+      earliestDate.getMonth()
+    )
+
+    return earliestYearAndMonth.getTime() === selectedYearAndMonth.getTime()
+  }
+
+  if (type === 'next') {
+    const latestDate = makeLatestDate(options)
+    const latestYearAndMonth = new Date(
+      latestDate.getFullYear(),
+      latestDate.getMonth()
+    )
+
+    return latestYearAndMonth.getTime() === selectedYearAndMonth.getTime()
+  }
+
+  return false
+}

--- a/src/components/SelectDates/helpers.spec.js
+++ b/src/components/SelectDates/helpers.spec.js
@@ -1,0 +1,316 @@
+import {
+  makeAllMonthsName,
+  makeEarliestDate,
+  makeLatestDate,
+  makeYearsBetweenEarliestAndLatest,
+  makeYearsFromDates,
+  makeMonthsFromYear,
+  makeIndexesOfUnmatchingValues,
+  computeYears,
+  makeMonthsNameByCount,
+  computeMonths,
+  makeNewDate,
+  isDisableNextPreviousButton
+} from './helpers'
+
+describe('makeAllMonthsName', () => {
+  it('should return all the months of the year according to the language', () => {
+    expect(makeAllMonthsName('fr')).toStrictEqual([
+      'janvier',
+      'février',
+      'mars',
+      'avril',
+      'mai',
+      'juin',
+      'juillet',
+      'août',
+      'septembre',
+      'octobre',
+      'novembre',
+      'décembre'
+    ])
+
+    expect(makeAllMonthsName('en')).toMatchSnapshot()
+  })
+})
+
+describe('makeEarliestDate', () => {
+  it('should return the earliest date', () => {
+    const dates = [new Date('2022'), new Date('2020')]
+
+    expect(makeEarliestDate(dates)).toEqual(dates[1])
+  })
+})
+
+describe('makeLatestDate', () => {
+  it('should return the latest date', () => {
+    const dates = [new Date('2022'), new Date('2020')]
+
+    expect(makeLatestDate(dates)).toEqual(dates[0])
+  })
+})
+
+describe('makeYearsBetweenEarliestAndLatest', () => {
+  it('should return the years in the interval, the latest one first', () => {
+    const dates = [new Date('2018'), new Date('2022'), new Date('2020')]
+
+    expect(makeYearsBetweenEarliestAndLatest(dates)).toEqual([
+      2022,
+      2021,
+      2020,
+      2019,
+      2018
+    ])
+  })
+})
+
+describe('makeYearsFromDates', () => {
+  it('should return the unique years of a date list', () => {
+    const dates = [
+      new Date('2018'),
+      new Date('2020'),
+      new Date('2018'),
+      new Date('2019')
+    ]
+
+    expect(makeYearsFromDates(dates)).toEqual([2018, 2020, 2019])
+  })
+})
+
+describe('makeMonthsFromYear', () => {
+  it('should return the months of the dates according to the `year` param', () => {
+    const dates = [
+      new Date('2022'),
+      new Date('2020-01'),
+      new Date('2020-03'),
+      new Date('2018')
+    ]
+    const year = 2020
+    const allMonthsName = makeAllMonthsName('fr')
+
+    const result = makeMonthsFromYear({ dates, year, allMonthsName })
+
+    expect(result).toStrictEqual(['janvier', 'mars'])
+  })
+})
+
+describe('makeIndexesOfUnmatchingValues', () => {
+  it('should return the indexes whose values in the first array are not in the second', () => {
+    const arr1 = ['a', 'b', 'c', 'd']
+    const arr2 = ['c', 'd', 'e', 'f']
+
+    expect(makeIndexesOfUnmatchingValues(arr1, arr2)).toStrictEqual([0, 1])
+  })
+})
+
+describe('computeYears', () => {
+  it('should return the correct values', () => {
+    const dates = [
+      new Date('2022'),
+      new Date('2020-01'),
+      new Date('2020-03'),
+      new Date('2018')
+    ]
+    const selectedDate = new Date('2020-01')
+
+    expect(computeYears(dates, selectedDate)).toStrictEqual({
+      years: [2022, 2021, 2020, 2019, 2018],
+      yearSelectedIndex: 2, // the index in `years` for the  year of selectedDate aka 2020
+      disabledYearsIndexes: [1, 3] // no 2021 and 2019 in dates
+    })
+  })
+})
+
+describe('makeMonthsNameByCount', () => {
+  it('should return the first 3 months of the year', () => {
+    const result = makeMonthsNameByCount({
+      monthCount: 3,
+      allMonthsName: makeAllMonthsName('fr'),
+      endToStart: false
+    })
+
+    expect(result).toStrictEqual(['janvier', 'février', 'mars'])
+  })
+
+  it('should return the last 3 months of the year', () => {
+    const result = makeMonthsNameByCount({
+      monthCount: 3,
+      allMonthsName: makeAllMonthsName('fr'),
+      endToStart: true
+    })
+
+    expect(result).toStrictEqual(['octobre', 'novembre', 'décembre'])
+  })
+})
+
+describe('computeMonths', () => {
+  // note: the index for march is 2. Date.getMonth() return 0 for January.
+  const setup = () => ({
+    dates: [
+      new Date('2022'),
+      new Date('2020-01'), // January 2020, index 0
+      new Date('2020-03'), // March 2020, index 2
+      new Date('2020-05'), // May 2020, index 4
+      new Date('2018')
+    ],
+    selectedDate: new Date('2020-03'), // March 2020, index 2
+    lang: 'fr'
+  })
+
+  it('should return an object with a correct structure', () => {
+    const result = computeMonths({ ...setup() })
+
+    expect(result).toEqual({
+      months: makeAllMonthsName('fr'),
+      monthSelectedIndex: expect.any(Number),
+      disabledMonthsIndexes: expect.any(Array)
+    })
+  })
+
+  it('should return the correct index for the selected date', () => {
+    const result = computeMonths({ ...setup() })
+
+    expect(result).toMatchObject({
+      monthSelectedIndex: 2
+    })
+  })
+
+  it('should not return 0, 2 and 4 month indexes in disabledMonthsIndexes', () => {
+    const result = computeMonths({ ...setup() })
+
+    expect(result).toMatchObject({
+      disabledMonthsIndexes: [1, 3, 5, 6, 7, 8, 9, 10, 11]
+    })
+  })
+})
+
+describe('makeNewDate', () => {
+  const setup = ({ value, type } = {}) => ({
+    oldDate: new Date('2020-06-01'),
+    lang: 'fr',
+    value,
+    type,
+    dates: [
+      new Date('2022-01-01'),
+      new Date('2022-02-01'),
+      new Date('2021-03-01'),
+      new Date('2021-04-01'),
+      new Date('2021-05-01'),
+      new Date('2020-06-01'),
+      new Date('2020-07-01'),
+      new Date('2020-08-01'),
+      new Date('2019-11-01')
+    ]
+  })
+
+  describe('when changing years', () => {
+    const type = 'year'
+
+    it('should return a date', () => {
+      const result = makeNewDate({ ...setup({ type, value: 2020 }) })
+
+      expect(result instanceof Date).toBe(true)
+    })
+
+    it('should return the same date for the same year', () => {
+      const result = makeNewDate({ ...setup({ type, value: 2020 }) })
+
+      expect(result.getFullYear()).toBe(2020)
+      expect(result.getMonth()).toBe(5) // 5 is June
+    })
+
+    it('should return the same month of the old date even if there is no date for selected month/year', () => {
+      const result = makeNewDate({ ...setup({ type, value: 2021 }) })
+
+      expect(result.getFullYear()).toBe(2021)
+      expect(result.getMonth()).toBe(5)
+    })
+
+    it('should return the earliest date if the selected month is earlier', () => {
+      const result = makeNewDate({ ...setup({ type, value: 2019 }) })
+
+      expect(result.getFullYear()).toBe(2019)
+      expect(result.getMonth()).toBe(10)
+    })
+
+    it('should return the latest date if the selected month is latest', () => {
+      const result = makeNewDate({ ...setup({ type, value: 2022 }) })
+
+      expect(result.getFullYear()).toBe(2022)
+      expect(result.getMonth()).toBe(1)
+    })
+  })
+
+  describe('when changing month', () => {
+    const type = 'month'
+
+    it('should return a date', () => {
+      const result = makeNewDate({ ...setup({ type, value: 2020 }) })
+
+      expect(result instanceof Date).toBe(true)
+    })
+
+    it('should return the correct month', () => {
+      const result = makeNewDate({ ...setup({ type, value: 'juillet' }) })
+
+      expect(result.getFullYear()).toBe(2020)
+      expect(result.getMonth()).toBe(6)
+    })
+  })
+})
+
+describe('isDisableNextPreviousButton', () => {
+  const dates = [new Date('2022-01'), new Date('2022-02'), new Date('2022-03')]
+
+  it('should return true for the `next` type only for the latest date', () => {
+    const result = isDisableNextPreviousButton({
+      type: 'next',
+      selectedDate: new Date('2022-03'),
+      options: dates
+    })
+
+    expect(result).toBe(true)
+
+    expect(
+      isDisableNextPreviousButton({
+        type: 'next',
+        selectedDate: new Date('2022-02'),
+        options: dates
+      })
+    ).toBe(false)
+
+    expect(
+      isDisableNextPreviousButton({
+        type: 'next',
+        selectedDate: new Date('2022-01'),
+        options: dates
+      })
+    ).toBe(false)
+  })
+
+  it('should return true for the `preivous` type only for the earliest date ', () => {
+    const result = isDisableNextPreviousButton({
+      type: 'previous',
+      selectedDate: new Date('2022-03'),
+      options: dates
+    })
+
+    expect(result).toBe(false)
+
+    expect(
+      isDisableNextPreviousButton({
+        type: 'previous',
+        selectedDate: new Date('2022-02'),
+        options: dates
+      })
+    ).toBe(false)
+
+    expect(
+      isDisableNextPreviousButton({
+        type: 'previous',
+        selectedDate: new Date('2022-01'),
+        options: dates
+      })
+    ).toBe(true)
+  })
+})

--- a/src/components/SelectDatesWrapper.jsx
+++ b/src/components/SelectDatesWrapper.jsx
@@ -10,7 +10,7 @@ const computeOptions = (isLoading, timeseries) => {
   return timeseries.map(timeserie => new Date(timeserie.startDate))
 }
 
-const SelectDates = () => {
+const SelectDatesWrapper = () => {
   const { selectedDate, setSelectedDate } = useSelectDatesContext()
   const { timeseries, isLoading } = useAllTimeseriesByAccount()
 
@@ -42,4 +42,4 @@ const SelectDates = () => {
   )
 }
 
-export default SelectDates
+export default SelectDatesWrapper

--- a/src/components/Views/ModeAnalysis.jsx
+++ b/src/components/Views/ModeAnalysis.jsx
@@ -8,7 +8,7 @@ import SelectDatesProvider from 'src/components/Providers/SelectDatesProvider'
 import Titlebar from 'src/components/Titlebar'
 import ModesList from 'src/components/Analysis/Modes/ModesList'
 import TabsNav from 'src/components/Analysis/TabsNav'
-import SelectDates from 'src/components/SelectDates'
+import SelectDatesWrapper from 'src/components/SelectDatesWrapper'
 
 const ModeAnalysis = () => {
   const { t } = useI18n()
@@ -24,7 +24,7 @@ const ModeAnalysis = () => {
     <SelectDatesProvider>
       <Titlebar label={modeTitle} onBack={onBack} />
       {isMobile && <TabsNav />}
-      <SelectDates />
+      <SelectDatesWrapper />
       <ModesList />
     </SelectDatesProvider>
   )

--- a/src/components/Views/ModeAnalysis.jsx
+++ b/src/components/Views/ModeAnalysis.jsx
@@ -4,9 +4,11 @@ import { useParams, useHistory } from 'react-router-dom'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
+import SelectDatesProvider from 'src/components/Providers/SelectDatesProvider'
 import Titlebar from 'src/components/Titlebar'
 import ModesList from 'src/components/Analysis/Modes/ModesList'
 import TabsNav from 'src/components/Analysis/TabsNav'
+import SelectDates from 'src/components/SelectDates'
 
 const ModeAnalysis = () => {
   const { t } = useI18n()
@@ -19,11 +21,12 @@ const ModeAnalysis = () => {
   const onBack = mode ? history.goBack : undefined
 
   return (
-    <>
+    <SelectDatesProvider>
       <Titlebar label={modeTitle} onBack={onBack} />
       {isMobile && <TabsNav />}
+      <SelectDates />
       <ModesList />
-    </>
+    </SelectDatesProvider>
   )
 }
 

--- a/src/components/Views/ModeAnalysis.spec.js
+++ b/src/components/Views/ModeAnalysis.spec.js
@@ -22,17 +22,22 @@ jest.mock('src/components/Analysis/Modes/ModesList', () => () => (
 jest.mock('src/components/Analysis/TabsNav', () => () => (
   <div data-testid="TabsNav" />
 ))
+jest.mock('src/components/SelectDates', () => () => (
+  <div data-testid="SelectDates" />
+))
 
 describe('ModeAnalysis', () => {
   it('should not display TabsNav on Desktop view', () => {
     useBreakpoints.mockReturnValue({ isMobile: false })
     const { queryByTestId } = render(<ModeAnalysis />)
+
     expect(queryByTestId('TabsNav')).not.toBeTruthy()
   })
 
   it('should display TabsNav on Mobile view', () => {
     useBreakpoints.mockReturnValue({ isMobile: true })
     const { queryByTestId } = render(<ModeAnalysis />)
+
     expect(queryByTestId('TabsNav')).toBeTruthy()
   })
 })

--- a/src/components/Views/ModeAnalysis.spec.js
+++ b/src/components/Views/ModeAnalysis.spec.js
@@ -22,7 +22,7 @@ jest.mock('src/components/Analysis/Modes/ModesList', () => () => (
 jest.mock('src/components/Analysis/TabsNav', () => () => (
   <div data-testid="TabsNav" />
 ))
-jest.mock('src/components/SelectDates', () => () => (
+jest.mock('src/components/SelectDatesWrapper', () => () => (
   <div data-testid="SelectDates" />
 ))
 

--- a/src/components/Views/PurposeAnalysis.jsx
+++ b/src/components/Views/PurposeAnalysis.jsx
@@ -6,7 +6,9 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import Titlebar from 'src/components/Titlebar'
 import TabsNav from 'src/components/Analysis/TabsNav'
+import SelectDatesProvider from 'src/components/Providers/SelectDatesProvider'
 import PurposesList from 'src/components/Analysis/Purposes/PurposesList'
+import SelectDates from 'src/components/SelectDates'
 
 const PurposeAnalysis = () => {
   const { t } = useI18n()
@@ -19,11 +21,12 @@ const PurposeAnalysis = () => {
   const onBack = purpose ? history.goBack : undefined
 
   return (
-    <>
+    <SelectDatesProvider>
       <Titlebar label={purposeTitle} onBack={onBack} />
       {isMobile && <TabsNav />}
+      <SelectDates />
       <PurposesList />
-    </>
+    </SelectDatesProvider>
   )
 }
 

--- a/src/components/Views/PurposeAnalysis.jsx
+++ b/src/components/Views/PurposeAnalysis.jsx
@@ -8,7 +8,7 @@ import Titlebar from 'src/components/Titlebar'
 import TabsNav from 'src/components/Analysis/TabsNav'
 import SelectDatesProvider from 'src/components/Providers/SelectDatesProvider'
 import PurposesList from 'src/components/Analysis/Purposes/PurposesList'
-import SelectDates from 'src/components/SelectDates'
+import SelectDatesWrapper from 'src/components/SelectDatesWrapper'
 
 const PurposeAnalysis = () => {
   const { t } = useI18n()
@@ -24,7 +24,7 @@ const PurposeAnalysis = () => {
     <SelectDatesProvider>
       <Titlebar label={purposeTitle} onBack={onBack} />
       {isMobile && <TabsNav />}
-      <SelectDates />
+      <SelectDatesWrapper />
       <PurposesList />
     </SelectDatesProvider>
   )

--- a/src/components/Views/PurposeAnalysis.spec.js
+++ b/src/components/Views/PurposeAnalysis.spec.js
@@ -22,17 +22,22 @@ jest.mock('src/components/Analysis/Purposes/PurposesList', () => () => (
 jest.mock('src/components/Analysis/TabsNav', () => () => (
   <div data-testid="TabsNav" />
 ))
+jest.mock('src/components/SelectDates', () => () => (
+  <div data-testid="SelectDates" />
+))
 
 describe('PurposeAnalysis', () => {
   it('should not display TabsNav on Desktop view', () => {
     useBreakpoints.mockReturnValue({ isMobile: false })
     const { queryByTestId } = render(<PurposeAnalysis />)
+
     expect(queryByTestId('TabsNav')).not.toBeTruthy()
   })
 
   it('should display TabsNav on Mobile view', () => {
     useBreakpoints.mockReturnValue({ isMobile: true })
     const { queryByTestId } = render(<PurposeAnalysis />)
+
     expect(queryByTestId('TabsNav')).toBeTruthy()
   })
 })

--- a/src/components/Views/PurposeAnalysis.spec.js
+++ b/src/components/Views/PurposeAnalysis.spec.js
@@ -22,7 +22,7 @@ jest.mock('src/components/Analysis/Purposes/PurposesList', () => () => (
 jest.mock('src/components/Analysis/TabsNav', () => () => (
   <div data-testid="TabsNav" />
 ))
-jest.mock('src/components/SelectDates', () => () => (
+jest.mock('src/components/SelectDatesWrapper', () => () => (
   <div data-testid="SelectDates" />
 ))
 

--- a/src/hooks/useAllTimeseriesByAccount.js
+++ b/src/hooks/useAllTimeseriesByAccount.js
@@ -1,0 +1,39 @@
+import { useContext } from 'react'
+
+import { isQueryLoading, useQuery } from 'cozy-client'
+
+import { AccountContext } from 'src/components/AccountProvider'
+import {
+  buildGeoJSONQueryByAccountIdNoLimit,
+  buildAccountQuery
+} from 'src/queries/queries'
+
+const useAllTimeseriesByAccount = () => {
+  const { selectedAccount } = useContext(AccountContext)
+
+  const accountQuery = buildAccountQuery()
+  const { data: accounts, ...accountQueryRes } = useQuery(
+    accountQuery.definition,
+    accountQuery.options
+  )
+
+  const isAccountLoading = isQueryLoading(accountQueryRes)
+
+  const account = isAccountLoading ? null : selectedAccount || accounts[0]
+
+  const geoJsonQuery = buildGeoJSONQueryByAccountIdNoLimit(account?._id)
+  const { data: timeseries, ...timeseriesQueryResult } = useQuery(
+    geoJsonQuery.definition,
+    {
+      ...geoJsonQuery.options,
+      enabled: !isAccountLoading
+    }
+  )
+
+  const isAllQueriesLoading =
+    isAccountLoading || isQueryLoading(timeseriesQueryResult)
+
+  return { timeseries, isLoading: isAllQueriesLoading }
+}
+
+export default useAllTimeseriesByAccount

--- a/src/hooks/useAllTimeseriesByAccount.spec.js
+++ b/src/hooks/useAllTimeseriesByAccount.spec.js
@@ -1,0 +1,83 @@
+import React from 'react'
+import { renderHook } from '@testing-library/react-hooks'
+
+import { useQuery } from 'cozy-client'
+
+import AppLike from 'test/AppLike'
+import useAllTimeseriesByAccount from './useAllTimeseriesByAccount'
+
+jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
+
+const setup = () => {
+  const wrapper = ({ children }) => <AppLike>{children}</AppLike>
+
+  return renderHook(() => useAllTimeseriesByAccount(), {
+    wrapper
+  })
+}
+
+describe('useAllTimeseriesByAccount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return isLoading true if none of the queries are loaded', async () => {
+    useQuery
+      .mockReturnValueOnce({ data: null, fetchStatus: 'loading' })
+      .mockReturnValue({ data: null, fetchStatus: 'loading' })
+
+    const {
+      result: {
+        current: { timeseries, isLoading }
+      }
+    } = setup()
+
+    expect(isLoading).toBe(true)
+    expect(timeseries).toBe(null)
+  })
+
+  it('should return isLoading true if only the first query is loaded', async () => {
+    useQuery
+      .mockReturnValueOnce({ data: ['accountData'], fetchStatus: 'loaded' })
+      .mockReturnValue({ data: null, fetchStatus: 'loading' })
+
+    const {
+      result: {
+        current: { timeseries, isLoading }
+      }
+    } = setup()
+
+    expect(isLoading).toBe(true)
+    expect(timeseries).toBe(null)
+  })
+
+  it('should return isLoading true if only the second query is loaded', async () => {
+    useQuery
+      .mockReturnValueOnce({ data: null, fetchStatus: 'loading' })
+      .mockReturnValue({ data: ['timeseriesData'], fetchStatus: 'loaded' })
+
+    const {
+      result: {
+        current: { timeseries, isLoading }
+      }
+    } = setup()
+
+    expect(isLoading).toBe(true)
+    expect(timeseries).toStrictEqual(['timeseriesData'])
+  })
+
+  it('should return isLoading false if both queries are loaded, and the correct timeseries', async () => {
+    useQuery
+      .mockReturnValueOnce({ data: ['accountData'], fetchStatus: 'loaded' })
+      .mockReturnValue({ data: ['timeseriesData'], fetchStatus: 'loaded' })
+
+    const {
+      result: {
+        current: { timeseries, isLoading }
+      }
+    } = setup()
+
+    expect(isLoading).toBe(false)
+    expect(timeseries).toStrictEqual(['timeseriesData'])
+  })
+})

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -66,7 +66,7 @@ export const buildGeoJSONQueryNoLimit = () => ({
   }
 })
 
-export const buildGeoJSONQueryNoLimitByDate = date => {
+export const buildGeoJSONQueryByDateNoLimit = date => {
   const startMonth = startOfMonth(date)
   const endMonth = endOfMonth(date)
   const isDateNull = date === null

--- a/test/AppLike.jsx
+++ b/test/AppLike.jsx
@@ -4,20 +4,20 @@ import { HashRouter } from 'react-router-dom'
 import { CozyProvider, createMockClient } from 'cozy-client'
 import I18n from 'cozy-ui/transpiled/react/I18n'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
-import { WebviewIntentProvider } from 'cozy-intent'
+import AccountProvider from 'src/components/AccountProvider'
 
 import enLocale from '../src/locales/en.json'
 
 const AppLike = ({ children, client }) => (
-  <WebviewIntentProvider>
-    <CozyProvider client={client || createMockClient({})}>
-      <I18n dictRequire={() => enLocale} lang="en">
-        <BreakpointsProvider>
+  <CozyProvider client={client || createMockClient({})}>
+    <I18n dictRequire={() => enLocale} lang="en">
+      <BreakpointsProvider>
+        <AccountProvider>
           <HashRouter>{children}</HashRouter>
-        </BreakpointsProvider>
-      </I18n>
-    </CozyProvider>
-  </WebviewIntentProvider>
+        </AccountProvider>
+      </BreakpointsProvider>
+    </I18n>
+  </CozyProvider>
 )
 
 export default AppLike

--- a/test/jestLib/setup.js
+++ b/test/jestLib/setup.js
@@ -9,5 +9,6 @@ global.requestAnimationFrame = cb => {
 /* Fix error: "Material-UI: The color provided to augmentColor(color) is invalid.
 The color object needs to have a `main` property or a `500` property."*/
 jest.mock('cozy-ui/transpiled/react/utils/color', () => ({
-  getCssVariableValue: () => '#fff'
+  getCssVariableValue: () => '#fff',
+  getInvertedCssVariableValue: () => '#fff'
 }))

--- a/test/jestLib/setupAfterEnv.js
+++ b/test/jestLib/setupAfterEnv.js
@@ -1,0 +1,1 @@
+require('@testing-library/jest-dom')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1706,6 +1706,17 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"
+  integrity sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@11.2.7":
   version "11.2.7"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
@@ -1868,6 +1879,13 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
   integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.13"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.13.tgz#a3323b974ee4280070982b3112351bb1952a7809"
+  integrity sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-redux@^7.1.20":
   version "7.1.22"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.22.tgz#0eab76a37ef477cc4b53665aeaf29cb60631b72a"
@@ -1877,6 +1895,13 @@
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
+
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-transition-group@^4.2.0":
   version "4.4.4"
@@ -1889,6 +1914,15 @@
   version "17.0.38"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
   integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.39"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
+  integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -10143,6 +10177,13 @@ react-dom@16.14.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-event-listener@^0.6.0:
   version "0.6.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1691,6 +1691,21 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
+"@testing-library/jest-dom@5.16.2":
+  version "5.16.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz#f329b36b44aa6149cd6ced9adf567f8b6aa1c959"
+  integrity sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^5.0.0"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    dom-accessibility-api "^0.5.6"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
 "@testing-library/react@11.2.7":
   version "11.2.7"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
@@ -1792,6 +1807,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@*":
+  version "27.4.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.1.tgz#185cbe2926eaaf9662d340cc02e548ce9e11ab6d"
+  integrity sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==
+  dependencies:
+    jest-matcher-utils "^27.0.0"
+    pretty-format "^27.0.0"
+
 "@types/jest@^26.0.20":
   version "26.0.24"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
@@ -1885,6 +1908,13 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.14.3"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz#ee6c7ffe9f8595882ee7bda8af33ae7b8789ef17"
+  integrity sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -2222,6 +2252,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 ansi-wrap@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
@@ -2272,6 +2307,11 @@ aria-query@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -4214,6 +4254,11 @@ css-what@^5.1.0:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
   integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
 css@^2.0.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
@@ -4223,6 +4268,15 @@ css@^2.0.0:
     source-map "^0.6.1"
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -4487,6 +4541,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff-sequences@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
+  integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -6519,6 +6578,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 infer-owner@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
@@ -7145,6 +7209,16 @@ jest-diff@^26.0.0, jest-diff@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-diff@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
+  integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
+
 jest-docblock@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
@@ -7208,6 +7282,11 @@ jest-get-type@^26.3.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
+jest-get-type@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
+  integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
+
 jest-haste-map@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-26.6.2.tgz#dd7e60fe7dc0e9f911a23d79c5ff7fb5c2cafeaa"
@@ -7270,6 +7349,16 @@ jest-matcher-utils@^26.6.2:
     jest-diff "^26.6.2"
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
+
+jest-matcher-utils@^27.0.0:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
+  integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
 
 jest-message-util@^25.5.0:
   version "25.5.0"
@@ -8370,6 +8459,11 @@ min-document@^2.19.0:
   integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
   dependencies:
     dom-walk "^0.1.0"
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 mini-create-react-context@^0.4.0:
   version "0.4.1"
@@ -9775,6 +9869,15 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
+pretty-format@^27.0.0, pretty-format@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -10449,6 +10552,14 @@ readdirp@^3.1.1, readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 redux-mock-store@1.5.4:
   version "1.5.4"
@@ -11267,6 +11378,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
+
 source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
@@ -11630,6 +11749,13 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@2.0.1, strip-json-comments@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/67680939/157022069-f62e7675-5273-4888-bf3b-57fde001a437.png)

On a passé 3 jours de plus que l'estimation sur cette feature qui a demandé pas mal d'energie, soyez assez "light" sur les retours svp  🙏🙏🙏 ;)

Les composants suivants devraient être dans cozy-ui :
- DropdownButton
- DropdownMenuButton
- SelectDates
- SelectDatesWithLoader
- EmptySelectDates

Comme le SelectDates est censé être dans cozy-ui, il a été construit comme tel (il attend des props d'un context qui vient de l'app)