### PR TITLE
fix: Display correct CO2 value

### DIFF
--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useCallback, useState } from 'react'
 import PropTypes from 'prop-types'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 import get from 'lodash/get'
 
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
@@ -20,9 +20,10 @@ import {
   getFormattedDuration,
   getModesSortedByDistance,
   formatTripDistance,
-  getStartDate
+  getStartDate,
+  computeAndFormatCO2Trip,
+  computeAndFormatCO2TripByMode
 } from 'src/lib/trips'
-import { computeCO2Trip } from 'src/lib/metrics'
 import { pickModeIcon } from 'src/components/helpers'
 import TripDialogDesktop from 'src/components/Trip/TripDialogDesktop'
 import { OTHER_PURPOSE } from 'src/constants/const'
@@ -48,6 +49,7 @@ const TripItemSecondary = ({ tripModeIcons, duration, distance }) => {
 export const TripItem = ({ geojson, trip, hasDateHeader }) => {
   const { f } = useI18n()
   const history = useHistory()
+  const { mode } = useParams()
   const { isMobile } = useBreakpoints()
   const [showTripDialog, setShowTripDialog] = useState(false)
 
@@ -58,10 +60,12 @@ export const TripItem = ({ geojson, trip, hasDateHeader }) => {
   const distance = useMemo(() => formatTripDistance(trip), [trip])
   const day = useMemo(() => f(getStartDate(trip), 'dddd DD MMMM'), [f, trip])
 
-  const CO2 = useMemo(() => {
-    const CO2Trip = computeCO2Trip(trip)
-    return Math.round(CO2Trip * 100) / 100
-  }, [trip])
+  const formattedCO2 = useMemo(() => {
+    if (mode) {
+      return computeAndFormatCO2TripByMode(trip, mode)
+    }
+    return computeAndFormatCO2Trip(trip)
+  }, [mode, trip])
 
   const tripModeIcons = useMemo(() => modes.map(mode => pickModeIcon(mode)), [
     modes
@@ -92,7 +96,7 @@ export const TripItem = ({ geojson, trip, hasDateHeader }) => {
           }
         />
         <Typography className="u-mh-half" style={styles.co2} variant="body2">
-          {CO2}&nbsp;kg
+          {formattedCO2}
         </Typography>
         <Icon icon={RightIcon} color={'var(--secondaryTextColor)'} />
       </ListItem>

--- a/src/lib/metrics.js
+++ b/src/lib/metrics.js
@@ -99,6 +99,24 @@ export const computeCO2Trip = trip => {
 }
 
 /**
+ * Compute the total CO2 consumed only by the specified mode on the trip.
+ *
+ * @param {object} trip - The GeoJSON trip
+ * @param {string} mode - The mode of trip
+ * @returns {number} The consumed CO2 only by the specified mode, in kg
+ */
+export const computeCO2TripByMode = (trip, mode) => {
+  const sections = getSectionsFromTrip(trip)
+  let totalCO2 = 0
+  for (const section of sections) {
+    if (section.mode === mode) {
+      totalCO2 += computeCO2Section(section)
+    }
+  }
+  return totalCO2
+}
+
+/**
  * Compute the calories produced based on weight, MET and duration.
  * Source of this formula:
  *  Bushman B PhD. Complete Guide to Fitness and Health 2nd Edition.

--- a/src/lib/metrics.spec.js
+++ b/src/lib/metrics.spec.js
@@ -13,16 +13,52 @@ import {
   MET_BICYCLING_SLOW,
   MET_BICYCLING_MEDIUM,
   MET_BICYCLING_FAST,
-  MET_BICYCLING_VERY_FAST
+  MET_BICYCLING_VERY_FAST,
+  CAR_MODE,
+  AIR_MODE
 } from 'src/constants/const'
 import {
   createTripFromTemplate,
   tripTemplate,
   makeBicycleTrip,
   makeWalkingTrip,
-  makeCarTrip
+  makeCarTrip,
+  mockFeatureCollection,
+  mockFeature,
+  modeProps,
+  mockSerie
 } from 'test/mockTrip'
-import { computeCO2Trip, computeCaloriesTrip, caloriesFormula } from './metrics'
+import {
+  computeCO2Trip,
+  computeCO2TripByMode,
+  computeCaloriesTrip,
+  caloriesFormula
+} from './metrics'
+
+const mockedFeatures = () => [
+  mockFeatureCollection('featureCollectionId01', [
+    mockFeature('featureId05', modeProps.plane)
+  ]),
+  mockFeatureCollection('featureCollectionId02', [
+    mockFeature('featureId06', modeProps.car)
+  ]),
+  mockFeatureCollection('featureCollectionId03', [
+    mockFeature('featureId07', modeProps.car)
+  ])
+]
+
+describe('computeCO2TripByMode', () => {
+  const mockedSerie = mockSerie('serieId01', mockedFeatures())
+  it('should return only CO2 of car', () => {
+    const carCO2 = computeCO2TripByMode(mockedSerie, CAR_MODE)
+    expect(carCO2).toEqual(5.678976)
+  })
+
+  it('should return only CO2 of plane', () => {
+    const carCO2 = computeCO2TripByMode(mockedSerie, AIR_MODE)
+    expect(carCO2).toEqual(130.235562)
+  })
+})
 
 describe('computeCO2Trip', () => {
   it('should correctly compute the bicycling CO2', () => {

--- a/src/lib/trips.js
+++ b/src/lib/trips.js
@@ -6,7 +6,11 @@ import distanceInWords from 'date-fns/distance_in_words'
 import humanizeDuration from 'humanize-duration'
 
 import { UNKNOWN_MODE } from 'src/constants/const'
-import { computeCaloriesTrip, computeCO2Trip } from 'src/lib/metrics'
+import {
+  computeCaloriesTrip,
+  computeCO2Trip,
+  computeCO2TripByMode
+} from 'src/lib/metrics'
 import { modes } from 'src/components/helpers'
 
 /**
@@ -212,4 +216,16 @@ export const formatCO2 = CO2 => `${Math.round(CO2 * 100) / 100} kg`
 export const computeAndFormatCO2Trip = trip => {
   const CO2Trip = computeCO2Trip(trip)
   return formatCO2(CO2Trip)
+}
+
+/**
+ * Computes CO2 and return it formatted in kg
+ *
+ * @param {object} trip - The GeoJSON trip
+ * @param {string} mode - The mode of trip
+ * @returns {string} The CO2 formatted in kg
+ */
+export const computeAndFormatCO2TripByMode = (trip, mode) => {
+  const CO2TripByMode = computeCO2TripByMode(trip, mode)
+  return formatCO2(CO2TripByMode)
 }

--- a/src/lib/trips.spec.js
+++ b/src/lib/trips.spec.js
@@ -16,8 +16,10 @@ import {
   getModesSortedByDistance,
   computeAndFormatCO2Trip,
   getFeatureMode,
-  computeFormatedPercentage
+  computeFormatedPercentage,
+  computeAndFormatCO2TripByMode
 } from 'src/lib/trips'
+import { BICYCLING_MODE, CAR_MODE } from 'src/constants/const'
 
 const mockedFeatures = () => [
   mockFeature('featureId01'),
@@ -63,6 +65,25 @@ describe('computeAndFormatCO2Trip', () => {
 
     const cCO2 = computeAndFormatCO2Trip(makeCarTrip())
     expect(cCO2).toBe('2.84 kg')
+  })
+})
+
+describe('computeAndFormatCO2TripByMode', () => {
+  const mockedSerie = mockSerie('serieId01', mockedFeatures())
+  it('should return formatted value by car mode', () => {
+    const formattedCO2ByCarMode = computeAndFormatCO2TripByMode(
+      mockedSerie,
+      CAR_MODE
+    )
+    expect(formattedCO2ByCarMode).toBe('2.84 kg')
+  })
+
+  it('should return formatted value by bicycle mode', () => {
+    const formattedCO2ByPlaneMode = computeAndFormatCO2TripByMode(
+      mockedSerie,
+      BICYCLING_MODE
+    )
+    expect(formattedCO2ByPlaneMode).toBe('0 kg')
   })
 })
 


### PR DESCRIPTION
On the TripsList by mode, the CO2 value per trip must only indicate the CO2 generated by the mode of transport concerned