### PR TITLE
fix: Typo in CSV content-type

### DIFF
--- a/src/lib/exportTripsToCSV.js
+++ b/src/lib/exportTripsToCSV.js
@@ -103,7 +103,7 @@ export const exportTripsToCSV = async (client, t, accountName) => {
       tripsCSV,
       {
         name: CSVFilename,
-        contentType: 'text/css',
+        contentType: 'text/csv',
         dirId: appFolder._id,
         conflictStrategy: 'rename'
       }


### PR DESCRIPTION
The file was correctly saved in .csv in Drive, but was turned into .css when downloading it 