### PR TITLE
fix: Remove aggregation prop before save doc

### DIFF
--- a/src/components/Providers/TripProvider.jsx
+++ b/src/components/Providers/TripProvider.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useContext } from 'react'
+import { removeAggregationFromTimeseries } from 'src/components/Providers/helpers'
 
 export const TripContext = React.createContext()
 
@@ -12,12 +13,14 @@ export const useTrip = () => {
 }
 
 const TripProvider = ({ geojson, trip, children }) => {
+  const cleanedGeojson = removeAggregationFromTimeseries(geojson)
+
   const value = useMemo(
     () => ({
-      geojson,
+      geojson: cleanedGeojson,
       trip
     }),
-    [geojson, trip]
+    [cleanedGeojson, trip]
   )
 
   return <TripContext.Provider value={value}>{children}</TripContext.Provider>

--- a/src/components/Providers/helpers.js
+++ b/src/components/Providers/helpers.js
@@ -6,3 +6,13 @@ export const saveAccountToSettings = ({ client, setting, account }) =>
     account,
     _type: SETTINGS_DOCTYPE
   })
+
+// TODO Temporary fix, waiting for the refactor.
+// TODO For more info: https://trello.com/c/9TbGwYne/2137-enregistrement-de-donn%C3%A9es-non-voulues-dans-le-doctype-io-cozy-timeseries-geojson
+export const removeAggregationFromTimeseries = geojson => {
+  if (!geojson.aggregation) return geojson
+
+  // eslint-disable-next-line no-unused-vars
+  const { aggregation, ...cleanGeojson } = geojson
+  return cleanGeojson
+}

--- a/src/components/Providers/helpers.spec.js
+++ b/src/components/Providers/helpers.spec.js
@@ -1,0 +1,26 @@
+import { removeAggregationFromTimeseries } from 'src/components/Providers/helpers'
+import { mockSerie, mockTimeserie } from 'test/mockTrip'
+
+describe('Helpers Providers', () => {
+  describe('removeAggregationFromTimeseries', () => {
+    const timeseriesOriginal = mockTimeserie('timeserieId01', [mockSerie()])
+    const timeseriesWithAggregation = { ...timeseriesOriginal, aggregation: {} }
+
+    it('should return new timeseries object without aggregation property if exists', () => {
+      const timeseriesCleaned = removeAggregationFromTimeseries(
+        timeseriesWithAggregation
+      )
+
+      expect(timeseriesCleaned).toStrictEqual(timeseriesOriginal)
+      expect(timeseriesCleaned).not.toBe(timeseriesOriginal)
+    })
+    it('should return original timeseries object if aggregation property does not exists', () => {
+      const timeseriesCleaned = removeAggregationFromTimeseries(
+        timeseriesOriginal
+      )
+
+      expect(timeseriesCleaned).toStrictEqual(timeseriesOriginal)
+      expect(timeseriesCleaned).toBe(timeseriesOriginal)
+    })
+  })
+})


### PR DESCRIPTION
Temporary fix, waiting for a bigger refactor.
We don't want to save a `timeseries` document with the `aggregation` prop