### PR TITLE
feat: Add nowrap on TripItem CO2

### DIFF
--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -29,7 +29,10 @@ import TripDialogDesktop from 'src/components/Trip/TripDialogDesktop'
 import { OTHER_PURPOSE } from 'src/constants'
 
 const styles = {
-  co2: { fontWeight: 700 },
+  co2: {
+    fontWeight: 700,
+    whiteSpace: 'nowrap'
+  },
   tripIcon: {
     marginRight: '4px'
   }


### PR DESCRIPTION
pour éviter un retour à la ligne entre la valeur et l'unité du CO2