### PR TITLE
fix: Check hasMore on result for useFullyLoadedQuery to avoid blinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 🐛 Bug Fixes
 
+* No blinking on analysis pages if more than 1000 travels
+
 ## 🔧 Tech
 
 # 0.4.0

--- a/src/components/Analysis/Modes/ModesList.jsx
+++ b/src/components/Analysis/Modes/ModesList.jsx
@@ -22,7 +22,7 @@ const ModesList = () => {
     timeserieQuery.options
   )
 
-  const isLoading = isQueryLoading(queryResult)
+  const isLoading = isQueryLoading(queryResult) || queryResult.hasMore
 
   if (isLoading) {
     return (

--- a/src/components/Analysis/Purposes/PurposesList.jsx
+++ b/src/components/Analysis/Purposes/PurposesList.jsx
@@ -22,7 +22,7 @@ const PurposesList = () => {
     timeserieQuery.options
   )
 
-  const isLoading = isQueryLoading(queryResult)
+  const isLoading = isQueryLoading(queryResult) || queryResult.hasMore
 
   if (isLoading) {
     return (

--- a/src/components/SelectDatesWrapper.jsx
+++ b/src/components/SelectDatesWrapper.jsx
@@ -30,7 +30,10 @@ const SelectDatesWrapper = () => {
     }
   )
 
-  const isLoading = !account || isQueryLoading(timeseriesQueryResult)
+  const isLoading =
+    !account ||
+    isQueryLoading(timeseriesQueryResult) ||
+    timeseriesQueryResult.hasMore
 
   const options = useCallback(computeOptions(isLoading, timeseries), [
     isLoading,


### PR DESCRIPTION
Si on a plus de document à fetcher que le limitBy indiqué dans la query, useFullyLoadedQuery va fetchMore après la pagination. Or en faisant ça, le fetchStatus passe de loaded à loading (après être passé initialement de loading à loaded). Si on ne fait que checker le fetchStatus dans la vue (via isQueryLoading) on passe donc d'un true à false puis true.