### PR TITLE
Properly handle not supported purposes and modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * No blinking on analysis pages if more than 1000 travels
 * Correctly handle not supported purposes
+* Correctly handle not supported manual modes
+
 
 ## 🔧 Tech
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 🐛 Bug Fixes
 
 * No blinking on analysis pages if more than 1000 travels
+* Correctly handle not supported purposes
 
 ## 🔧 Tech
 

--- a/src/lib/timeseries.js
+++ b/src/lib/timeseries.js
@@ -3,6 +3,7 @@ import keyBy from 'lodash/keyBy'
 import sortBy from 'lodash/sortBy'
 import fromPairs from 'lodash/fromPairs'
 import toPairs from 'lodash/toPairs'
+import get from 'lodash/get'
 
 import { computeCO2Section } from 'src/lib/metrics'
 import { getSectionsFromTrip } from 'src/lib/trips'
@@ -188,9 +189,14 @@ export const sortTimeseriesByCO2GroupedByMode = aggregatedTimeseries => {
 // Purpose usages
 
 export const getTimeseriePurpose = timeserie => {
-  const manualPurpose = timeserie.series[0].properties.manual_purpose
+  const manualPurpose = get(
+    timeserie,
+    'series[0].properties.manual_purpose',
+    ''
+  ).toUpperCase()
+  const isSupportedPurpose = purposes.includes(manualPurpose)
 
-  return (manualPurpose && manualPurpose.toUpperCase()) || OTHER_PURPOSE
+  return (isSupportedPurpose && manualPurpose) || OTHER_PURPOSE
 }
 
 /**

--- a/src/lib/timeseries.spec.js
+++ b/src/lib/timeseries.spec.js
@@ -479,4 +479,18 @@ describe('getTimeseriePurpose', () => {
 
     expect(result).toBe('OTHER_PURPOSE')
   })
+
+  it('should return other purpose when not supported', () => {
+    const result = getTimeseriePurpose({
+      series: [{ properties: { manual_purpose: 'NOT_SUPPORTED_PURPOSE' } }]
+    })
+    expect(result).toBe('OTHER_PURPOSE')
+  })
+
+  it('should return other purpose when empty string', () => {
+    const result = getTimeseriePurpose({
+      series: [{ properties: { manual_purpose: '' } }]
+    })
+    expect(result).toBe('OTHER_PURPOSE')
+  })
 })

--- a/src/lib/trips.js
+++ b/src/lib/trips.js
@@ -65,14 +65,23 @@ export const getFormattedTripDistance = trip => {
  * @returns The feature's mode depending on whether it has been changed manually
  */
 export const getFeatureMode = feature => {
-  const manualMode = get(feature, 'properties.manual_mode')
-  const sensedOriginalMode = get(feature, 'properties.sensed_mode')
+  const manualMode = get(feature, 'properties.manual_mode', '').toUpperCase()
+  const sensedOriginalMode = get(
+    feature,
+    'properties.sensed_mode',
+    ''
+  ).toUpperCase()
 
-  const sensedMode =
-    sensedOriginalMode && sensedOriginalMode.split('PredictedModeTypes.')[1]
+  const isSupportedManualMode = modes.includes(manualMode)
+
+  const sensedMode = sensedOriginalMode.split('PREDICTEDMODETYPES.')[1]
   const isSupportedSensedMode = modes.includes(sensedMode)
 
-  return manualMode || (isSupportedSensedMode && sensedMode) || UNKNOWN_MODE
+  return (
+    (isSupportedManualMode && manualMode) ||
+    (isSupportedSensedMode && sensedMode) ||
+    UNKNOWN_MODE
+  )
 }
 
 const getFeatureModes = feature => {

--- a/src/lib/trips.spec.js
+++ b/src/lib/trips.spec.js
@@ -140,12 +140,12 @@ describe('getFeatureMode', () => {
   it('should return the manual mode if present', () => {
     const result = getFeatureMode({
       properties: {
-        manual_mode: 'BIKE',
+        manual_mode: 'BICYCLING',
         sensed_mode: 'PredictedModeTypes.CAR'
       }
     })
 
-    expect(result).toBe('BIKE')
+    expect(result).toBe('BICYCLING')
   })
 
   it('should return the sensed mode if no manual mode', () => {
@@ -184,6 +184,39 @@ describe('getFeatureMode', () => {
   it('should return the default mode for undefined manual and sensed mode', () => {
     const result = getFeatureMode({
       properties: { manual_mode: undefined, sensed_mode: undefined }
+    })
+
+    expect(result).toBe('UNKNOWN')
+  })
+
+  it('should return sensed mode when manual mode is not supported', () => {
+    const result = getFeatureMode({
+      properties: {
+        manual_mode: 'NOT_SUPPORTED_MODE',
+        sensed_mode: 'PredictedModeTypes.CAR'
+      }
+    })
+
+    expect(result).toBe('CAR')
+  })
+
+  it('should return the default mode when manual mode and sensed mode are not supported', () => {
+    const result = getFeatureMode({
+      properties: {
+        manual_mode: 'NOT_SUPPORTED_MODE',
+        sensed_mode: 'PredictedModeTypes.NOT_SUPPORTED_MODE'
+      }
+    })
+
+    expect(result).toBe('UNKNOWN')
+  })
+
+  it('should return the default mode when manual mode is not supported and sensed mode has incorrect value', () => {
+    const result = getFeatureMode({
+      properties: {
+        manual_mode: 'NOT_SUPPORTED_MODE',
+        sensed_mode: 'UNCORRECT_FORMATED_VALUE'
+      }
     })
 
     expect(result).toBe('UNKNOWN')


### PR DESCRIPTION
When a purpose or manual mode was set by the user from the mobile app that is not supported by the app, the user was experiencing a blank page in the Analysis page once the data was loaded.
We now properly handle the different cases for manual purposes and modes and fallback on the default unknown mode when it is not supported. 