### PR TITLE
Remove `geojson` object and use timeserie instead of trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## 🔧 Tech
 
+* Refactor to fix https://github.com/cozy/coachCO2/issues/94 and first step to use only `timeserie` object in the application
+
 # 0.6.0
 
 ## 🔧 Tech

--- a/src/components/Analysis/Modes/LoadedModesList.jsx
+++ b/src/components/Analysis/Modes/LoadedModesList.jsx
@@ -10,8 +10,7 @@ import Box from 'cozy-ui/transpiled/react/Box'
 import {
   computeAggregatedTimeseries,
   sortTimeseriesByCO2GroupedByMode,
-  computeCO2Timeseries,
-  transformTimeseriesToTrips
+  computeCO2Timeseries
 } from 'src/lib/timeseries'
 import { formatCO2 } from 'src/lib/trips'
 import { makeChartProps } from 'src/components/Analysis/helpers'
@@ -40,16 +39,15 @@ const LoadedModesList = ({ timeseries }) => {
     [t, timeseriesSortedByModes]
   )
 
-  const trips = useMemo(() => {
-    if (mode) {
-      return transformTimeseriesToTrips(
-        timeseriesSortedByModes[mode].timeseries
-      ).sort((a, b) =>
-        a.properties.start_fmt_time.localeCompare(b.properties.start_fmt_time)
-      )
-    }
-    return []
-  }, [mode, timeseriesSortedByModes])
+  const tripsListTimeseries = useMemo(
+    () =>
+      mode
+        ? timeseriesSortedByModes[mode].timeseries.sort((a, b) =>
+            a.startDate.localeCompare(b.startDate)
+          )
+        : [],
+    [mode, timeseriesSortedByModes]
+  )
 
   if (!mode) {
     return (
@@ -87,10 +85,7 @@ const LoadedModesList = ({ timeseries }) => {
 
   return (
     <div className="u-mt-2">
-      <TripsList
-        trips={trips}
-        timeseries={timeseriesSortedByModes[mode].timeseries}
-      />
+      <TripsList timeseries={tripsListTimeseries} />
     </div>
   )
 }

--- a/src/components/Analysis/Purposes/LoadedPurposesList.jsx
+++ b/src/components/Analysis/Purposes/LoadedPurposesList.jsx
@@ -10,8 +10,7 @@ import Box from 'cozy-ui/transpiled/react/Box'
 import {
   computeAggregatedTimeseries,
   sortTimeseriesByCO2GroupedByPurpose,
-  computeCO2Timeseries,
-  transformTimeseriesToTrips
+  computeCO2Timeseries
 } from 'src/lib/timeseries'
 import { formatCO2 } from 'src/lib/trips'
 import { makeChartProps } from 'src/components/Analysis/helpers'
@@ -40,16 +39,15 @@ const LoadedPurposesList = ({ timeseries }) => {
     [t, timeseriesSortedByPurposes]
   )
 
-  const trips = useMemo(() => {
-    if (purpose) {
-      return transformTimeseriesToTrips(
-        timeseriesSortedByPurposes[purpose].timeseries
-      ).sort((a, b) =>
-        a.properties.start_fmt_time.localeCompare(b.properties.start_fmt_time)
-      )
-    }
-    return []
-  }, [purpose, timeseriesSortedByPurposes])
+  const tripsListTimeseries = useMemo(
+    () =>
+      purpose
+        ? timeseriesSortedByPurposes[purpose].timeseries.sort((a, b) =>
+            a.startDate.localeCompare(b.startDate)
+          )
+        : [],
+    [purpose, timeseriesSortedByPurposes]
+  )
 
   if (!purpose) {
     return (
@@ -87,10 +85,7 @@ const LoadedPurposesList = ({ timeseries }) => {
 
   return (
     <div className="u-mt-2">
-      <TripsList
-        trips={trips}
-        timeseries={timeseriesSortedByPurposes[purpose].timeseries}
-      />
+      <TripsList timeseries={tripsListTimeseries} />
     </div>
   )
 }

--- a/src/components/EditDialogs/ModeEditDialog/ModeEditDialog.jsx
+++ b/src/components/EditDialogs/ModeEditDialog/ModeEditDialog.jsx
@@ -22,19 +22,19 @@ const makeOptions = t => {
 const ModeEditDialog = ({ section, onClose }) => {
   const { t } = useI18n()
   const client = useClient()
-  const { geojson } = useTrip()
+  const { timeserie } = useTrip()
 
   const handleSelect = useCallback(
     async item => {
-      const geojsonWithModifiedMode = createGeojsonWithModifiedMode({
-        geojson,
+      const newTimeserie = createGeojsonWithModifiedMode({
+        timeserie,
         sectionId: section.id,
         mode: item.id
       })
-      await client.save(geojsonWithModifiedMode)
+      await client.save(newTimeserie)
       onClose()
     },
-    [client, geojson, onClose, section.id]
+    [client, timeserie, onClose, section.id]
   )
 
   const isSelected = useMemo(() => item => item.id === section.mode, [

--- a/src/components/EditDialogs/ModeEditDialog/helpers.js
+++ b/src/components/EditDialogs/ModeEditDialog/helpers.js
@@ -1,8 +1,12 @@
 import set from 'lodash/set'
 import cloneDeep from 'lodash/cloneDeep'
 
-export const createGeojsonWithModifiedMode = ({ geojson, sectionId, mode }) => {
-  const matchedSection = geojson.series
+export const createGeojsonWithModifiedMode = ({
+  timeserie,
+  sectionId,
+  mode
+}) => {
+  const matchedSection = timeserie.series
     .flatMap((serie, serieIndex) => {
       return serie.features.flatMap((feature, firstIndex) => {
         if (feature.features) {
@@ -31,11 +35,11 @@ export const createGeojsonWithModifiedMode = ({ geojson, sectionId, mode }) => {
     )
 
     return set(
-      cloneDeep(geojson),
+      cloneDeep(timeserie),
       `series[${serieIndex}].features[${firstIndex}].features[${secondIndex}]`,
       modifiedFeature
     )
   }
 
-  return geojson
+  return timeserie
 }

--- a/src/components/EditDialogs/ModeEditDialog/helpers.spec.js
+++ b/src/components/EditDialogs/ModeEditDialog/helpers.spec.js
@@ -1,6 +1,6 @@
 import { createGeojsonWithModifiedMode } from './helpers'
 
-const geojson = {
+const timeserie = {
   series: [
     { type: 'FeatureCollection', features: [] },
     {
@@ -31,21 +31,21 @@ const geojson = {
 }
 
 describe('createGeojsonWithModifiedMode', () => {
-  it('should return the modified geojson', () => {
-    const modifiedGeojson = createGeojsonWithModifiedMode({
-      geojson,
+  it('should return the modified timeserie', () => {
+    const modifiedTimeserie = createGeojsonWithModifiedMode({
+      timeserie,
       sectionId: 'sectionId',
       mode: 'BUS'
     })
 
-    // to be sure initial geojson is not mutated
-    expect(geojson.series[1].features[1].features[1]).toMatchObject({
+    // to be sure initial timeserie is not mutated
+    expect(timeserie.series[1].features[1].features[1]).toMatchObject({
       properties: {
         sensed_mode: 'PredictedModeTypes.WALKING'
       }
     })
 
-    expect(modifiedGeojson.series[1].features[1].features[1]).toMatchObject({
+    expect(modifiedTimeserie.series[1].features[1].features[1]).toMatchObject({
       properties: {
         sensed_mode: 'PredictedModeTypes.WALKING',
         manual_mode: 'BUS'
@@ -53,13 +53,13 @@ describe('createGeojsonWithModifiedMode', () => {
     })
   })
 
-  it('should returns a not modified geojson', () => {
-    const modifiedGeojson = createGeojsonWithModifiedMode({
-      geojson,
+  it('should returns a not modified timeserie', () => {
+    const modifiedTimeserie = createGeojsonWithModifiedMode({
+      timeserie,
       sectionId: 'idNotFound',
       mode: 'BUS'
     })
 
-    expect(modifiedGeojson).toMatchObject(geojson)
+    expect(modifiedTimeserie).toMatchObject(timeserie)
   })
 })

--- a/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
+++ b/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
@@ -9,6 +9,7 @@ import { createGeojsonWithModifiedPurpose } from 'src/components/EditDialogs/Pur
 import { PurposeAvatar } from 'src/components/Avatar'
 import { useTrip } from 'src/components/Providers/TripProvider'
 import { OTHER_PURPOSE } from 'src/constants'
+import { getGeoJSONData, getManualPurpose } from 'src/lib/timeseries'
 
 const makeOptions = t => {
   const options = purposes.map(purpose => ({
@@ -23,29 +24,29 @@ const makeOptions = t => {
 const PurposeEditDialog = ({ onClose }) => {
   const { t } = useI18n()
   const client = useClient()
-  const { timeserie, trip } = useTrip()
+  const { timeserie } = useTrip()
 
   const handleSelect = useCallback(
     async item => {
       const newTimeserie = createGeojsonWithModifiedPurpose({
         timeserie,
-        tripId: trip.id,
+        tripId: getGeoJSONData(timeserie).id,
         purpose: item.id
       })
       await client.save(newTimeserie)
       onClose()
     },
-    [client, timeserie, onClose, trip.id]
+    [client, timeserie, onClose]
   )
 
   const isSelected = useMemo(
     () => item => {
-      const manualPurpose = trip.properties.manual_purpose
+      const manualPurpose = getManualPurpose(timeserie)
       return manualPurpose
         ? item.id === manualPurpose
         : item.id === OTHER_PURPOSE
     },
-    [trip.properties.manual_purpose]
+    [timeserie]
   )
 
   return (

--- a/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
+++ b/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
@@ -23,19 +23,19 @@ const makeOptions = t => {
 const PurposeEditDialog = ({ onClose }) => {
   const { t } = useI18n()
   const client = useClient()
-  const { geojson, trip } = useTrip()
+  const { timeserie, trip } = useTrip()
 
   const handleSelect = useCallback(
     async item => {
-      const newGeojson = createGeojsonWithModifiedPurpose({
-        geojson,
+      const newTimeserie = createGeojsonWithModifiedPurpose({
+        timeserie,
         tripId: trip.id,
         purpose: item.id
       })
-      await client.save(newGeojson)
+      await client.save(newTimeserie)
       onClose()
     },
-    [client, geojson, onClose, trip.id]
+    [client, timeserie, onClose, trip.id]
   )
 
   const isSelected = useMemo(

--- a/src/components/EditDialogs/PurposeEditDialog/helpers.js
+++ b/src/components/EditDialogs/PurposeEditDialog/helpers.js
@@ -2,22 +2,22 @@ import set from 'lodash/set'
 import cloneDeep from 'lodash/cloneDeep'
 
 export const createGeojsonWithModifiedPurpose = ({
-  geojson,
+  timeserie,
   tripId,
   purpose
 }) => {
-  const index = geojson.series.findIndex(serie => serie.id === tripId)
+  const index = timeserie.series.findIndex(serie => serie.id === tripId)
 
   if (index > -1) {
-    const serie = geojson.series[index]
+    const serie = timeserie.series[index]
     const modifiedSerie = set(
       cloneDeep(serie),
       'properties.manual_purpose',
       purpose.toUpperCase()
     )
 
-    return set(cloneDeep(geojson), `series[${index}]`, modifiedSerie)
+    return set(cloneDeep(timeserie), `series[${index}]`, modifiedSerie)
   }
 
-  return geojson
+  return timeserie
 }

--- a/src/components/EditDialogs/PurposeEditDialog/helpers.spec.js
+++ b/src/components/EditDialogs/PurposeEditDialog/helpers.spec.js
@@ -1,6 +1,6 @@
 import { createGeojsonWithModifiedPurpose } from './helpers'
 
-const geojson = {
+const timeserie = {
   series: [
     {
       type: 'FeatureCollection',
@@ -24,48 +24,54 @@ const geojson = {
 }
 
 describe('createGeojsonWithModifiedPurpose', () => {
-  it('should return the modified geojson', () => {
-    const modifiedGeojson = createGeojsonWithModifiedPurpose({
-      geojson,
+  it('should return the modified timeserie', () => {
+    const modifiedTimeserie = createGeojsonWithModifiedPurpose({
+      timeserie,
       tripId: 'tripId',
       purpose: 'SHOPPING'
     })
 
-    // to be sure initial geojson is not mutated
-    expect(geojson.series[1].properties.manual_purpose).toBe('WORK')
+    // to be sure initial timeserie is not mutated
+    expect(timeserie.series[1].properties.manual_purpose).toBe('WORK')
     // to be sure other series are not impacted
-    expect(geojson.series[0].properties.manual_purpose).toBe('HOME')
+    expect(timeserie.series[0].properties.manual_purpose).toBe('HOME')
 
-    expect(modifiedGeojson.series[1].properties.manual_purpose).toBe('SHOPPING')
+    expect(modifiedTimeserie.series[1].properties.manual_purpose).toBe(
+      'SHOPPING'
+    )
   })
 
   it("should create the manual_purpose if it doesn't exist", () => {
-    const modifiedGeojson = createGeojsonWithModifiedPurpose({
-      geojson,
+    const modifiedTimeserie = createGeojsonWithModifiedPurpose({
+      timeserie,
       tripId: 'tripWithNoManualPurpose',
       purpose: 'SHOPPING'
     })
 
-    expect(modifiedGeojson.series[2].properties.manual_purpose).toBe('SHOPPING')
+    expect(modifiedTimeserie.series[2].properties.manual_purpose).toBe(
+      'SHOPPING'
+    )
   })
 
-  it("should returns a not modified geojson if tripId doesn't exist", () => {
-    const modifiedGeojson = createGeojsonWithModifiedPurpose({
-      geojson,
+  it("should returns a not modified timeserie if tripId doesn't exist", () => {
+    const modifiedTimeserie = createGeojsonWithModifiedPurpose({
+      timeserie,
       tripId: 'idNotFound',
       purpose: 'SHOPPING'
     })
 
-    expect(modifiedGeojson).toMatchObject(geojson)
+    expect(modifiedTimeserie).toMatchObject(timeserie)
   })
 
   it('should create the purpose in upper case', () => {
-    const modifiedGeojson = createGeojsonWithModifiedPurpose({
-      geojson,
+    const modifiedTimeserie = createGeojsonWithModifiedPurpose({
+      timeserie,
       tripId: 'tripId',
       purpose: 'shopping'
     })
 
-    expect(modifiedGeojson.series[1].properties.manual_purpose).toBe('SHOPPING')
+    expect(modifiedTimeserie.series[1].properties.manual_purpose).toBe(
+      'SHOPPING'
+    )
   })
 })

--- a/src/components/Providers/TripProvider.jsx
+++ b/src/components/Providers/TripProvider.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useContext } from 'react'
+
 import { removeAggregationFromTimeseries } from 'src/components/Providers/helpers'
 
 export const TripContext = React.createContext()
@@ -12,12 +13,12 @@ export const useTrip = () => {
   return context
 }
 
-const TripProvider = ({ geojson, trip, children }) => {
-  const cleanedGeojson = removeAggregationFromTimeseries(geojson)
+const TripProvider = ({ timeserie, trip, children }) => {
+  const cleanedGeojson = removeAggregationFromTimeseries(timeserie)
 
   const value = useMemo(
     () => ({
-      geojson: cleanedGeojson,
+      timeserie: cleanedGeojson,
       trip
     }),
     [cleanedGeojson, trip]

--- a/src/components/Providers/TripProvider.jsx
+++ b/src/components/Providers/TripProvider.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useContext } from 'react'
 
 import { removeAggregationFromTimeseries } from 'src/components/Providers/helpers'
+import { transformTimeseriesToTrips } from 'src/lib/timeseries'
 
 export const TripContext = React.createContext()
 
@@ -13,15 +14,15 @@ export const useTrip = () => {
   return context
 }
 
-const TripProvider = ({ timeserie, trip, children }) => {
+const TripProvider = ({ timeserie, children }) => {
   const cleanedGeojson = removeAggregationFromTimeseries(timeserie)
 
   const value = useMemo(
     () => ({
       timeserie: cleanedGeojson,
-      trip
+      trip: transformTimeseriesToTrips([timeserie])[0]
     }),
-    [cleanedGeojson, trip]
+    [cleanedGeojson, timeserie]
   )
 
   return <TripContext.Provider value={value}>{children}</TripContext.Provider>

--- a/src/components/Providers/TripProvider.jsx
+++ b/src/components/Providers/TripProvider.jsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useContext } from 'react'
 
 import { removeAggregationFromTimeseries } from 'src/components/Providers/helpers'
-import { transformTimeseriesToTrips } from 'src/lib/timeseries'
 
 export const TripContext = React.createContext()
 
@@ -19,10 +18,9 @@ const TripProvider = ({ timeserie, children }) => {
 
   const value = useMemo(
     () => ({
-      timeserie: cleanedGeojson,
-      trip: transformTimeseriesToTrips([timeserie])[0]
+      timeserie: cleanedGeojson
     }),
-    [cleanedGeojson, timeserie]
+    [cleanedGeojson]
   )
 
   return <TripContext.Provider value={value}>{children}</TripContext.Provider>

--- a/src/components/Timeline/TimelineSections.jsx
+++ b/src/components/Timeline/TimelineSections.jsx
@@ -7,12 +7,14 @@ import { formatDate, getSectionsFormatedFromTrip } from 'src/lib/trips.js'
 import { pickModeIcon } from 'src/components/helpers'
 import ModeEditDialog from 'src/components/EditDialogs/ModeEditDialog'
 import { useTrip } from 'src/components/Providers/TripProvider'
+import { getGeoJSONData } from 'src/lib/timeseries'
 
 const TimelineSections = () => {
-  const { trip } = useTrip()
+  const { timeserie } = useTrip()
   const { t, f, lang } = useI18n()
   const [showModal, setShowModal] = useState(false)
   const [section, setSection] = useState(null)
+  const trip = getGeoJSONData(timeserie)
 
   const formatedSections = useMemo(
     () => getSectionsFormatedFromTrip(trip, lang),

--- a/src/components/Trip/BottomSheet/BottomSheetContent.jsx
+++ b/src/components/Trip/BottomSheet/BottomSheetContent.jsx
@@ -12,8 +12,8 @@ import TimelineSections from 'src/components/Timeline/TimelineSections'
 import {
   getStartPlaceDisplayName,
   getEndPlaceDisplayName,
-  getStartDate,
-  getEndDate,
+  getTripStartDate,
+  getTripEndDate,
   formatDate
 } from 'src/lib/trips'
 import { useTrip } from 'src/components/Providers/TripProvider'
@@ -35,11 +35,11 @@ const BottomSheetContent = () => {
   const startPlaceName = useMemo(() => getStartPlaceDisplayName(trip), [trip])
   const endPlaceName = useMemo(() => getEndPlaceDisplayName(trip), [trip])
   const startTime = useMemo(
-    () => formatDate({ f, lang, date: getStartDate(trip) }),
+    () => formatDate({ f, lang, date: getTripStartDate(trip) }),
     [f, lang, trip]
   )
   const endTime = useMemo(
-    () => formatDate({ f, lang, date: getEndDate(trip) }),
+    () => formatDate({ f, lang, date: getTripEndDate(trip) }),
     [f, lang, trip]
   )
   const purpose = useMemo(() => trip?.properties?.manual_purpose, [

--- a/src/components/Trip/BottomSheet/BottomSheetContent.jsx
+++ b/src/components/Trip/BottomSheet/BottomSheetContent.jsx
@@ -12,7 +12,8 @@ import TimelineSections from 'src/components/Timeline/TimelineSections'
 import { getTripStartDate, getTripEndDate, formatDate } from 'src/lib/trips'
 import {
   getEndPlaceDisplayName,
-  getStartPlaceDisplayName
+  getStartPlaceDisplayName,
+  getGeoJSONData
 } from 'src/lib/timeseries'
 import { useTrip } from 'src/components/Providers/TripProvider'
 import PurposeItem from 'src/components/Trip/BottomSheet/PurposeItem'
@@ -26,9 +27,10 @@ const styles = {
 
 const BottomSheetContent = () => {
   const { f, lang } = useI18n()
-  const { trip, timeserie } = useTrip()
+  const { timeserie } = useTrip()
   const { isDesktop } = useBreakpoints()
   const [showPurposeDialog, setShowPurposeDialog] = useState(false)
+  const trip = getGeoJSONData(timeserie)
 
   const startTime = useMemo(
     () => formatDate({ f, lang, date: getTripStartDate(trip) }),

--- a/src/components/Trip/BottomSheet/BottomSheetContent.jsx
+++ b/src/components/Trip/BottomSheet/BottomSheetContent.jsx
@@ -9,13 +9,11 @@ import { BottomSheetItem } from 'cozy-ui/transpiled/react/BottomSheet'
 
 import TimelineNode from 'src/components/Timeline/TimelineNode'
 import TimelineSections from 'src/components/Timeline/TimelineSections'
+import { getTripStartDate, getTripEndDate, formatDate } from 'src/lib/trips'
 import {
-  getStartPlaceDisplayName,
   getEndPlaceDisplayName,
-  getTripStartDate,
-  getTripEndDate,
-  formatDate
-} from 'src/lib/trips'
+  getStartPlaceDisplayName
+} from 'src/lib/timeseries'
 import { useTrip } from 'src/components/Providers/TripProvider'
 import PurposeItem from 'src/components/Trip/BottomSheet/PurposeItem'
 import PurposeEditDialog from 'src/components/EditDialogs/PurposeEditDialog'
@@ -28,12 +26,10 @@ const styles = {
 
 const BottomSheetContent = () => {
   const { f, lang } = useI18n()
-  const { trip } = useTrip()
+  const { trip, timeserie } = useTrip()
   const { isDesktop } = useBreakpoints()
   const [showPurposeDialog, setShowPurposeDialog] = useState(false)
 
-  const startPlaceName = useMemo(() => getStartPlaceDisplayName(trip), [trip])
-  const endPlaceName = useMemo(() => getEndPlaceDisplayName(trip), [trip])
   const startTime = useMemo(
     () => formatDate({ f, lang, date: getTripStartDate(trip) }),
     [f, lang, trip]
@@ -54,12 +50,16 @@ const BottomSheetContent = () => {
       <BottomSheetItem disableGutters>
         <Timeline className="u-pb-0 u-mb-0">
           <TimelineNode
-            label={startPlaceName}
+            label={getStartPlaceDisplayName(timeserie)}
             endLabel={startTime}
             type="start"
           />
           <TimelineSections />
-          <TimelineNode label={endPlaceName} endLabel={endTime} type="end" />
+          <TimelineNode
+            label={getEndPlaceDisplayName(timeserie)}
+            endLabel={endTime}
+            type="end"
+          />
         </Timeline>
       </BottomSheetItem>
       {/* TODO: Remove the Divider when we have the real desktop view */}

--- a/src/components/Trip/BottomSheet/BottomSheetHeader.jsx
+++ b/src/components/Trip/BottomSheet/BottomSheetHeader.jsx
@@ -9,11 +9,13 @@ import {
   computeAndformatCaloriesTrip,
   computeAndFormatCO2Trip
 } from 'src/lib/trips'
+import { getGeoJSONData } from 'src/lib/timeseries'
 import { useTrip } from 'src/components/Providers/TripProvider'
 
 const BottomSheetHeader = () => {
-  const { trip } = useTrip()
+  const { timeserie } = useTrip()
   const { t } = useI18n()
+  const trip = getGeoJSONData(timeserie)
 
   const duration = useMemo(() => getFormattedDuration(trip), [trip])
   const distance = useMemo(() => getFormattedTripDistance(trip), [trip])

--- a/src/components/Trip/TripDialogDesktop.jsx
+++ b/src/components/Trip/TripDialogDesktop.jsx
@@ -19,14 +19,14 @@ const styles = {
   }
 }
 
-const TripDialogDesktop = ({ geojson, trip, setShowTripDialog }) => {
+const TripDialogDesktop = ({ timeserie, trip, setShowTripDialog }) => {
   const title = useMemo(() => getEndPlaceDisplayName(trip), [trip])
   const hideModal = useCallback(() => setShowTripDialog(false), [
     setShowTripDialog
   ])
 
   return (
-    <TripProvider geojson={geojson} trip={trip}>
+    <TripProvider timeserie={timeserie} trip={trip}>
       <Dialog
         open={true}
         onClose={hideModal}

--- a/src/components/Trip/TripDialogDesktop.jsx
+++ b/src/components/Trip/TripDialogDesktop.jsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback } from 'react'
 
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 
-import { getEndPlaceDisplayName } from 'src/lib/trips'
+import { getEndPlaceDisplayName } from 'src/lib/timeseries'
 import TripMap from 'src/components/Trip/TripMap'
 import BottomSheetHeader from 'src/components/Trip/BottomSheet/BottomSheetHeader'
 import BottomSheetContent from 'src/components/Trip/BottomSheet/BottomSheetContent'
@@ -19,8 +19,7 @@ const styles = {
   }
 }
 
-const TripDialogDesktop = ({ timeserie, trip, setShowTripDialog }) => {
-  const title = useMemo(() => getEndPlaceDisplayName(trip), [trip])
+const TripDialogDesktop = ({ timeserie, setShowTripDialog }) => {
   const hideModal = useCallback(() => setShowTripDialog(false), [
     setShowTripDialog
   ])
@@ -30,7 +29,7 @@ const TripDialogDesktop = ({ timeserie, trip, setShowTripDialog }) => {
       <Dialog
         open={true}
         onClose={hideModal}
-        title={title}
+        title={getEndPlaceDisplayName(timeserie)}
         size="large"
         content={
           <>

--- a/src/components/Trip/TripDialogDesktop.jsx
+++ b/src/components/Trip/TripDialogDesktop.jsx
@@ -26,7 +26,7 @@ const TripDialogDesktop = ({ timeserie, trip, setShowTripDialog }) => {
   ])
 
   return (
-    <TripProvider timeserie={timeserie} trip={trip}>
+    <TripProvider timeserie={timeserie}>
       <Dialog
         open={true}
         onClose={hideModal}

--- a/src/components/Trip/TripDialogMobile.jsx
+++ b/src/components/Trip/TripDialogMobile.jsx
@@ -1,18 +1,16 @@
-import React, { useMemo, useCallback, useRef } from 'react'
+import React, { useCallback, useRef } from 'react'
 import { useHistory } from 'react-router-dom'
 
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 
-import { getEndPlaceDisplayName } from 'src/lib/trips'
+import { getEndPlaceDisplayName } from 'src/lib/timeseries'
 import { useTrip } from 'src/components/Providers/TripProvider'
 import TripDialogMobileContent from 'src/components/Trip/TripDialogMobileContent'
 
 const TripDialogMobile = () => {
-  const { trip } = useTrip()
+  const { timeserie } = useTrip()
   const history = useHistory()
   const titleRef = useRef(null)
-
-  const title = useMemo(() => getEndPlaceDisplayName(trip), [trip])
 
   const historyBack = useCallback(() => history.goBack(), [history])
 
@@ -22,7 +20,7 @@ const TripDialogMobile = () => {
       transitionDuration={0}
       disableGutters
       onBack={historyBack}
-      title={title}
+      title={getEndPlaceDisplayName(timeserie)}
       titleRef={titleRef}
       content={<TripDialogMobileContent titleRef={titleRef} />}
     />

--- a/src/components/Trip/TripMap.jsx
+++ b/src/components/Trip/TripMap.jsx
@@ -10,6 +10,7 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import { useTrip } from 'src/components/Providers/TripProvider'
 import { bottomSheetSettings } from 'src/components/Trip/TripDialogMobileContent'
+import { getGeoJSONData } from 'src/lib/timeseries'
 
 import './tripmap.styl'
 
@@ -39,7 +40,7 @@ const makeGeoJsonOptions = theme => ({
 
 const TripMap = () => {
   const { isMobile } = useBreakpoints()
-  const { trip } = useTrip()
+  const { timeserie } = useTrip()
   const theme = useTheme()
   const mapRef = useRef()
   const geojsonRef = useRef()
@@ -74,7 +75,7 @@ const TripMap = () => {
       />
       <GeoJSON
         ref={geojsonRef}
-        data={trip}
+        data={getGeoJSONData(timeserie)}
         pointToLayer={pointToLayer}
         style={style}
       />

--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -20,7 +20,7 @@ import {
   getFormattedDuration,
   getModesSortedByDistance,
   getFormattedTripDistance,
-  getStartDate,
+  getTripStartDate,
   computeAndFormatCO2Trip,
   computeAndFormatCO2TripByMode
 } from 'src/lib/trips'
@@ -61,7 +61,10 @@ export const TripItem = ({ timeserie, trip, hasDateHeader }) => {
   const duration = useMemo(() => getFormattedDuration(trip), [trip])
   const modes = useMemo(() => getModesSortedByDistance(trip), [trip])
   const distance = useMemo(() => getFormattedTripDistance(trip), [trip])
-  const day = useMemo(() => f(getStartDate(trip), 'dddd DD MMMM'), [f, trip])
+  const day = useMemo(() => f(getTripStartDate(trip), 'dddd DD MMMM'), [
+    f,
+    trip
+  ])
 
   const formattedCO2 = useMemo(() => {
     if (mode) {

--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -49,7 +49,7 @@ const TripItemSecondary = ({ tripModeIcons, duration, distance }) => {
   )
 }
 
-export const TripItem = ({ geojson, trip, hasDateHeader }) => {
+export const TripItem = ({ timeserie, trip, hasDateHeader }) => {
   const { f } = useI18n()
   const history = useHistory()
   const { mode } = useParams()
@@ -106,7 +106,7 @@ export const TripItem = ({ geojson, trip, hasDateHeader }) => {
       <Divider />
       {showTripDialog && (
         <TripDialogDesktop
-          geojson={geojson}
+          timeserie={timeserie}
           trip={trip}
           setShowTripDialog={setShowTripDialog}
         />

--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -16,7 +16,6 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import { PurposeAvatar } from 'src/components/Avatar'
 import {
-  getEndPlaceDisplayName,
   getFormattedDuration,
   getModesSortedByDistance,
   getFormattedTripDistance,
@@ -24,7 +23,10 @@ import {
   computeAndFormatCO2Trip,
   computeAndFormatCO2TripByMode
 } from 'src/lib/trips'
-import { transformTimeseriesToTrips } from 'src/lib/timeseries'
+import {
+  transformTimeseriesToTrips,
+  getEndPlaceDisplayName
+} from 'src/lib/timeseries'
 import { pickModeIcon } from 'src/components/helpers'
 import TripDialogDesktop from 'src/components/Trip/TripDialogDesktop'
 import { OTHER_PURPOSE } from 'src/constants'
@@ -61,7 +63,6 @@ export const TripItem = ({ timeserie, hasDateHeader }) => {
   ])
 
   const purpose = get(trip, 'properties.manual_purpose', OTHER_PURPOSE)
-  const endPlace = useMemo(() => getEndPlaceDisplayName(trip), [trip])
   const duration = useMemo(() => getFormattedDuration(trip), [trip])
   const modes = useMemo(() => getModesSortedByDistance(trip), [trip])
   const distance = useMemo(() => getFormattedTripDistance(trip), [trip])
@@ -83,10 +84,10 @@ export const TripItem = ({ timeserie, hasDateHeader }) => {
 
   const handleClick = useCallback(() => {
     if (isMobile) {
-      return history.push(`/trip/${trip.timeserieId}`)
+      return history.push(`/trip/${timeserie._id}`)
     }
     setShowTripDialog(true)
-  }, [history, isMobile, trip.timeserieId])
+  }, [history, isMobile, timeserie._id])
 
   return (
     <>
@@ -96,7 +97,7 @@ export const TripItem = ({ timeserie, hasDateHeader }) => {
           <PurposeAvatar attribute={purpose} />
         </ListItemIcon>
         <ListItemText
-          primary={endPlace}
+          primary={getEndPlaceDisplayName(timeserie)}
           secondary={
             <TripItemSecondary
               tripModeIcons={tripModeIcons}
@@ -114,7 +115,6 @@ export const TripItem = ({ timeserie, hasDateHeader }) => {
       {showTripDialog && (
         <TripDialogDesktop
           timeserie={timeserie}
-          trip={trip}
           setShowTripDialog={setShowTripDialog}
         />
       )}

--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -24,6 +24,7 @@ import {
   computeAndFormatCO2Trip,
   computeAndFormatCO2TripByMode
 } from 'src/lib/trips'
+import { transformTimeseriesToTrips } from 'src/lib/timeseries'
 import { pickModeIcon } from 'src/components/helpers'
 import TripDialogDesktop from 'src/components/Trip/TripDialogDesktop'
 import { OTHER_PURPOSE } from 'src/constants'
@@ -49,12 +50,15 @@ const TripItemSecondary = ({ tripModeIcons, duration, distance }) => {
   )
 }
 
-export const TripItem = ({ timeserie, trip, hasDateHeader }) => {
+export const TripItem = ({ timeserie, hasDateHeader }) => {
   const { f } = useI18n()
   const history = useHistory()
   const { mode } = useParams()
   const { isMobile } = useBreakpoints()
   const [showTripDialog, setShowTripDialog] = useState(false)
+  const trip = useCallback(transformTimeseriesToTrips([timeserie])[0], [
+    timeserie
+  ])
 
   const purpose = get(trip, 'properties.manual_purpose', OTHER_PURPOSE)
   const endPlace = useMemo(() => getEndPlaceDisplayName(trip), [trip])
@@ -119,7 +123,7 @@ export const TripItem = ({ timeserie, trip, hasDateHeader }) => {
 }
 
 TripItem.propTypes = {
-  trip: PropTypes.object.isRequired,
+  timeserie: PropTypes.object.isRequired,
   hasDateHeader: PropTypes.bool.isRequired
 }
 

--- a/src/components/TripsList.jsx
+++ b/src/components/TripsList.jsx
@@ -5,29 +5,26 @@ import isSameDay from 'date-fns/is_same_day'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 
 import TripItem from 'src/components/TripItem'
-import { getTripStartDate } from 'src/lib/trips'
+import { getStartDate } from 'src/lib/timeseries'
 
-export const TripsList = ({ trips, timeseries }) => {
+export const TripsList = ({ timeseries }) => {
   const hasDateHeader = useCallback(
-    (trip, idx) =>
-      idx === 0 ||
-      !isSameDay(getTripStartDate(trip), getTripStartDate(trips[idx - 1])),
-    [trips]
-  )
-
-  const getTimeserie = useCallback(
-    trip => timeseries.find(e => e._id === trip.timeserieId),
+    (timeserie, index) => {
+      return (
+        index === 0 ||
+        !isSameDay(getStartDate(timeserie), getStartDate(timeseries[index - 1]))
+      )
+    },
     [timeseries]
   )
 
   return (
     <List>
-      {trips.map((trip, idx) => (
+      {timeseries.map((timeserie, index) => (
         <TripItem
-          key={`${trip.id}${idx}`}
-          timeserie={getTimeserie(trip)}
-          trip={trip}
-          hasDateHeader={hasDateHeader(trip, idx)}
+          key={`${timeserie.id}${index}`}
+          timeserie={timeserie}
+          hasDateHeader={hasDateHeader(timeserie, index)}
         />
       ))}
     </List>
@@ -35,8 +32,7 @@ export const TripsList = ({ trips, timeseries }) => {
 }
 
 TripsList.propTypes = {
-  trips: PropTypes.arrayOf(PropTypes.object).isRequired,
-  timeseries: PropTypes.arrayOf(PropTypes.object)
+  timeseries: PropTypes.arrayOf(PropTypes.object).isRequired
 }
 
 export default TripsList

--- a/src/components/TripsList.jsx
+++ b/src/components/TripsList.jsx
@@ -14,7 +14,7 @@ export const TripsList = ({ trips, timeseries }) => {
     [trips]
   )
 
-  const getGeojson = useCallback(
+  const getTimeserie = useCallback(
     trip => timeseries.find(e => e._id === trip.timeserieId),
     [timeseries]
   )
@@ -24,7 +24,7 @@ export const TripsList = ({ trips, timeseries }) => {
       {trips.map((trip, idx) => (
         <TripItem
           key={`${trip.id}${idx}`}
-          geojson={getGeojson(trip)}
+          timeserie={getTimeserie(trip)}
           trip={trip}
           hasDateHeader={hasDateHeader(trip, idx)}
         />

--- a/src/components/TripsList.jsx
+++ b/src/components/TripsList.jsx
@@ -5,12 +5,13 @@ import isSameDay from 'date-fns/is_same_day'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 
 import TripItem from 'src/components/TripItem'
-import { getStartDate } from 'src/lib/trips'
+import { getTripStartDate } from 'src/lib/trips'
 
 export const TripsList = ({ trips, timeseries }) => {
   const hasDateHeader = useCallback(
     (trip, idx) =>
-      idx === 0 || !isSameDay(getStartDate(trip), getStartDate(trips[idx - 1])),
+      idx === 0 ||
+      !isSameDay(getTripStartDate(trip), getTripStartDate(trips[idx - 1])),
     [trips]
   )
 

--- a/src/components/Views/Trip.jsx
+++ b/src/components/Views/Trip.jsx
@@ -36,7 +36,7 @@ const Trip = () => {
   }
 
   return (
-    <TripProvider geojson={data[0]} trip={trip}>
+    <TripProvider timeserie={data[0]} trip={trip}>
       <TripDialogMobile />
     </TripProvider>
   )

--- a/src/components/Views/Trip.jsx
+++ b/src/components/Views/Trip.jsx
@@ -6,7 +6,6 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import TripDialogMobile from 'src/components/Trip/TripDialogMobile'
 import { buildTimeserieQueryById } from 'src/queries/queries'
-import { transformTimeseriesToTrips } from 'src/lib/timeseries'
 import TripProvider from 'src/components/Providers/TripProvider'
 
 const Trip = () => {
@@ -19,14 +18,6 @@ const Trip = () => {
     timeserieQuery.options
   )
 
-  const trip = useMemo(() => {
-    if (!data || !data.length) {
-      return null
-    } else {
-      return transformTimeseriesToTrips(data)[0]
-    }
-  }, [data])
-
   const isLoading = isQueryLoading(tripQueryResult)
 
   if (isLoading) {
@@ -36,7 +27,7 @@ const Trip = () => {
   }
 
   return (
-    <TripProvider timeserie={data[0]} trip={trip}>
+    <TripProvider timeserie={data[0]}>
       <TripDialogMobile />
     </TripProvider>
   )

--- a/src/components/Views/Trips.jsx
+++ b/src/components/Views/Trips.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import {
   hasQueryBeenLoaded,
@@ -13,7 +13,6 @@ import LoadMore from 'cozy-ui/transpiled/react/LoadMore'
 
 import { buildTimeseriesQueryByAccountId } from 'src/queries/queries'
 import TripsList from 'src/components/TripsList'
-import { transformTimeseriesToTrips } from 'src/lib/timeseries'
 import Titlebar from 'src/components/Titlebar'
 import {
   useAccountContext,
@@ -42,13 +41,6 @@ export const Trips = () => {
   const isLoadingTimeseriesQuery =
     isQueryLoading(timeseriesQueryLeft) &&
     !hasQueryBeenLoaded(timeseriesQueryLeft)
-
-  const trips = useMemo(() => {
-    if (Array.isArray(timeseries)) {
-      return transformTimeseriesToTrips(timeseries)
-    }
-    return []
-  }, [timeseries])
 
   if (isAccountLoading) {
     return (
@@ -83,7 +75,7 @@ export const Trips = () => {
   return (
     <>
       <Titlebar label={t('trips.from') + ' ' + getAccountLabel(account)} />
-      <TripsList trips={trips} timeseries={timeseries} />
+      <TripsList timeseries={timeseries} />
       {timeseriesQueryLeft.hasMore && (
         <LoadMore
           label={t('loadMore')}

--- a/src/components/Views/Trips.jsx
+++ b/src/components/Views/Trips.jsx
@@ -31,7 +31,7 @@ export const Trips = () => {
     accountId: account?._id,
     limitBy: 50
   })
-  const { data: timeseriesQueryResult, ...timeseriesQueryLeft } = useQuery(
+  const { data: timeseries, ...timeseriesQueryLeft } = useQuery(
     timeseriesQuery.definition,
     {
       ...timeseriesQuery.options,
@@ -44,11 +44,11 @@ export const Trips = () => {
     !hasQueryBeenLoaded(timeseriesQueryLeft)
 
   const trips = useMemo(() => {
-    if (Array.isArray(timeseriesQueryResult)) {
-      return transformTimeseriesToTrips(timeseriesQueryResult)
+    if (Array.isArray(timeseries)) {
+      return transformTimeseriesToTrips(timeseries)
     }
     return []
-  }, [timeseriesQueryResult])
+  }, [timeseries])
 
   if (isAccountLoading) {
     return (
@@ -71,7 +71,7 @@ export const Trips = () => {
     )
   }
 
-  if (timeseriesQueryResult.length === 0) {
+  if (timeseries.length === 0) {
     return (
       <>
         {isMobile && <Titlebar label={client.appMetadata.slug} />}
@@ -83,7 +83,7 @@ export const Trips = () => {
   return (
     <>
       <Titlebar label={t('trips.from') + ' ' + getAccountLabel(account)} />
-      <TripsList trips={trips} timeseries={timeseriesQueryResult} />
+      <TripsList trips={trips} timeseries={timeseries} />
       {timeseriesQueryLeft.hasMore && (
         <LoadMore
           label={t('loadMore')}

--- a/src/lib/exportTripsToCSV.js
+++ b/src/lib/exportTripsToCSV.js
@@ -12,8 +12,8 @@ import {
   getEndPlaceDisplayName,
   getPurpose,
   getSectionsFromTrip,
-  getStartDate,
-  getEndDate
+  getTripStartDate,
+  getTripEndDate
 } from 'src/lib/trips'
 import { COLUMNS_NAMES_CSV } from 'src/constants'
 import { transformTimeseriesToTrips } from 'src/lib/timeseries'
@@ -64,8 +64,8 @@ const makeTripsForExport = trips => {
       }
       const tripData = {
         [COLUMNS_NAMES_CSV.tripId]: trip.id,
-        [COLUMNS_NAMES_CSV.tripStartDate]: getStartDate(trip),
-        [COLUMNS_NAMES_CSV.tripEndDate]: getEndDate(trip),
+        [COLUMNS_NAMES_CSV.tripStartDate]: getTripStartDate(trip),
+        [COLUMNS_NAMES_CSV.tripEndDate]: getTripEndDate(trip),
         [COLUMNS_NAMES_CSV.tripStartDisplayName]: getStartPlaceDisplayName(
           trip
         ),

--- a/src/lib/timeseries.js
+++ b/src/lib/timeseries.js
@@ -257,3 +257,11 @@ export const getStartPlaceDisplayName = timeserie => {
 export const getEndPlaceDisplayName = timeserie => {
   return get(timeserie, 'series[0].features[1].properties.display_name')
 }
+
+export const getGeoJSONData = timeserie => {
+  return get(timeserie, 'series[0]')
+}
+
+export const getManualPurpose = timeserie => {
+  return get(timeserie, 'series[0].properties.manual_purpose')
+}

--- a/src/lib/timeseries.js
+++ b/src/lib/timeseries.js
@@ -241,3 +241,11 @@ export const sortTimeseriesByCO2GroupedByPurpose = aggregatedTimeseries => {
 
   return sortGroupedTimeseries(timeseriesByPurposes, OTHER_PURPOSE)
 }
+
+export const getStartDate = timeserie => {
+  return new Date(timeserie.startDate)
+}
+
+export const getEndDate = timeserie => {
+  return new Date(timeserie.endDate)
+}

--- a/src/lib/timeseries.js
+++ b/src/lib/timeseries.js
@@ -249,3 +249,11 @@ export const getStartDate = timeserie => {
 export const getEndDate = timeserie => {
   return new Date(timeserie.endDate)
 }
+
+export const getStartPlaceDisplayName = timeserie => {
+  return get(timeserie, 'series[0].features[0].properties.display_name')
+}
+
+export const getEndPlaceDisplayName = timeserie => {
+  return get(timeserie, 'series[0].features[1].properties.display_name')
+}

--- a/src/lib/trips.js
+++ b/src/lib/trips.js
@@ -187,11 +187,11 @@ export const getSectionsFormatedFromTrip = (trip, lang) => {
   })
 }
 
-export const getStartDate = trip => {
+export const getTripStartDate = trip => {
   return new Date(trip.properties.start_fmt_time)
 }
 
-export const getEndDate = trip => {
+export const getTripEndDate = trip => {
   return new Date(trip.properties.end_fmt_time)
 }
 


### PR DESCRIPTION
Nous avons plusieurs notions et objets manipulés aujourd'hui dans CCO2 ce qui nous embrouille plus qu'autre chose. L'objectif à terme et de n'utiliser que le timeserie, qui est le doc tel que fetché depuis couch.

Ceci est une première étape low cost

fix https://github.com/cozy/coachCO2/issues/94