### PR TITLE
feat: Memo TripItem according to timeserie rev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## 🔧 Tech
 
 * Refactor to fix https://github.com/cozy/coachCO2/issues/94 and first step to use only `timeserie` object in the application
+* Memo TripItem and Boost performance when modifying a trip (purpose or mode)
 
 # 0.6.0
 

--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -127,4 +127,6 @@ TripItem.propTypes = {
   hasDateHeader: PropTypes.bool.isRequired
 }
 
-export default TripItem
+export default React.memo(TripItem, (prevProps, nextProps) => {
+  return prevProps.timeserie._rev === nextProps.timeserie._rev
+})


### PR DESCRIPTION
part of https://github.com/cozy/coachCO2/issues/26
Force not to render the tripItem if the rev does not change. For the record, we can't change the data without using save.client, so the rev is bound to change.
This greatly improves performance when modifying a trip and removes the freeze that was present after this operation.