### PR TITLE
fix purpose icon with lowercase purpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## 🐛 Bug Fixes
 
 * Locales when installing the app the first time
-* Locales to get trip purpose/mode
+* Purpose locale and icon with lowercase purpose
 
 ## 🔧 Tech
 

--- a/src/components/EditDialogs/ModeEditDialog/ModeEditDialog.jsx
+++ b/src/components/EditDialogs/ModeEditDialog/ModeEditDialog.jsx
@@ -12,7 +12,7 @@ import { useTrip } from 'src/components/Providers/TripProvider'
 const makeOptions = t => {
   const options = modes.map(mode => ({
     id: mode,
-    title: t(`trips.modes.${mode.toUpperCase()}`),
+    title: t(`trips.modes.${mode}`),
     icon: <ModeAvatar attribute={mode} />
   }))
 

--- a/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
+++ b/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
@@ -9,12 +9,12 @@ import { createGeojsonWithModifiedPurpose } from 'src/components/EditDialogs/Pur
 import { PurposeAvatar } from 'src/components/Avatar'
 import { useTrip } from 'src/components/Providers/TripProvider'
 import { OTHER_PURPOSE } from 'src/constants'
-import { getGeoJSONData, getManualPurpose } from 'src/lib/timeseries'
+import { getGeoJSONData, getTimeseriePurpose } from 'src/lib/timeseries'
 
 const makeOptions = t => {
   const options = purposes.map(purpose => ({
     id: purpose,
-    title: t(`trips.purposes.${purpose.toUpperCase()}`),
+    title: t(`trips.purposes.${purpose}`),
     icon: <PurposeAvatar attribute={purpose} />
   }))
 
@@ -41,7 +41,7 @@ const PurposeEditDialog = ({ onClose }) => {
 
   const isSelected = useMemo(
     () => item => {
-      const manualPurpose = getManualPurpose(timeserie)
+      const manualPurpose = getTimeseriePurpose(timeserie)
       return manualPurpose
         ? item.id === manualPurpose
         : item.id === OTHER_PURPOSE

--- a/src/components/Timeline/TimelineSections.jsx
+++ b/src/components/Timeline/TimelineSections.jsx
@@ -35,9 +35,9 @@ const TimelineSections = () => {
       {formatedSections.map((section, index) => (
         <TimelineIcon
           key={index}
-          label={`${t(`trips.modes.${section.mode.toUpperCase()}`)} - ${
-            section.duration
-          } - ${section.distance} - ${section.averageSpeed}`}
+          label={`${t(`trips.modes.${section.mode}`)} - ${section.duration} - ${
+            section.distance
+          } - ${section.averageSpeed}`}
           endLabel={formatDate({ f, lang, date: new Date(section.endDate) })}
           icon={pickModeIcon(section.mode)}
           onClick={handleClick(section)}

--- a/src/components/Trip/BottomSheet/BottomSheetContent.jsx
+++ b/src/components/Trip/BottomSheet/BottomSheetContent.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback } from 'react'
+import React, { useState, useCallback } from 'react'
 
 import Timeline from '@material-ui/lab/Timeline'
 
@@ -13,9 +13,9 @@ import { formatDate } from 'src/lib/trips'
 import {
   getEndPlaceDisplayName,
   getStartPlaceDisplayName,
-  getGeoJSONData,
   getStartDate,
-  getEndDate
+  getEndDate,
+  getTimeseriePurpose
 } from 'src/lib/timeseries'
 import { useTrip } from 'src/components/Providers/TripProvider'
 import PurposeItem from 'src/components/Trip/BottomSheet/PurposeItem'
@@ -32,12 +32,8 @@ const BottomSheetContent = () => {
   const { timeserie } = useTrip()
   const { isDesktop } = useBreakpoints()
   const [showPurposeDialog, setShowPurposeDialog] = useState(false)
-  const trip = getGeoJSONData(timeserie)
 
-  const purpose = useMemo(() => trip?.properties?.manual_purpose, [
-    trip.properties.manual_purpose
-  ])
-
+  const purpose = getTimeseriePurpose(timeserie)
   const openPurposeDialog = useCallback(() => setShowPurposeDialog(true), [])
   const closePurposeDialog = useCallback(() => setShowPurposeDialog(false), [])
 

--- a/src/components/Trip/BottomSheet/PurposeItem.jsx
+++ b/src/components/Trip/BottomSheet/PurposeItem.jsx
@@ -29,7 +29,7 @@ const PurposeItem = ({ purpose, onClick }) => {
         <ListItemText
           primary={t('purpose')}
           primaryTypographyProps={{ variant: 'caption' }}
-          secondary={t(`trips.purposes.${purpose.toUpperCase()}`)}
+          secondary={t(`trips.purposes.${purpose}`)}
           secondaryTypographyProps={{ variant: 'body1', color: 'textPrimary' }}
         />
       </ListItem>

--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useCallback, useState } from 'react'
 import PropTypes from 'prop-types'
 import { useHistory, useParams } from 'react-router-dom'
-import get from 'lodash/get'
 
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
@@ -25,11 +24,11 @@ import {
 import {
   transformTimeseriesToTrips,
   getEndPlaceDisplayName,
-  getStartDate
+  getStartDate,
+  getTimeseriePurpose
 } from 'src/lib/timeseries'
 import { pickModeIcon } from 'src/components/helpers'
 import TripDialogDesktop from 'src/components/Trip/TripDialogDesktop'
-import { OTHER_PURPOSE } from 'src/constants'
 
 const styles = {
   co2: {
@@ -62,7 +61,7 @@ export const TripItem = ({ timeserie, hasDateHeader }) => {
     timeserie
   ])
 
-  const purpose = get(trip, 'properties.manual_purpose', OTHER_PURPOSE)
+  const purpose = getTimeseriePurpose(timeserie)
   const duration = useMemo(() => getFormattedDuration(trip), [trip])
   const modes = useMemo(() => getModesSortedByDistance(trip), [trip])
   const distance = useMemo(() => getFormattedTripDistance(trip), [trip])

--- a/src/lib/timeseries.js
+++ b/src/lib/timeseries.js
@@ -261,7 +261,3 @@ export const getEndPlaceDisplayName = timeserie => {
 export const getGeoJSONData = timeserie => {
   return get(timeserie, 'series[0]')
 }
-
-export const getManualPurpose = timeserie => {
-  return get(timeserie, 'series[0].properties.manual_purpose')
-}


### PR DESCRIPTION
lorsqu'on avait un purpose en lowercase dans couch, l'affichage du purpose et 
de son icone était mal géré. On harmonise ici l'approche on utilisant le getter 
partout.