### PR TITLE
feat: Migrate timeseries without aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## ✨ Features
 
+* Migrate timeseries without aggregation
 * Update cozy-client to get useQueryAll hook https://github.com/cozy/cozy-client/commit/590f18abbf13db372b3d3a1c517a7795957a1808
 
 ## 🐛 Bug Fixes

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -39,7 +39,7 @@
       "description": "Required to get konnector account",
       "type": "io.cozy.accounts",
       "verbs": [
-        "GET", "PUT"
+        "GET"
       ]
     },
     "files": {

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -39,7 +39,7 @@
       "description": "Required to get konnector account",
       "type": "io.cozy.accounts",
       "verbs": [
-        "GET"
+        "GET", "PUT"
       ]
     },
     "files": {
@@ -60,6 +60,19 @@
       "description": "Used to manage your Coach CO2 settings",
       "type": "io.cozy.contacts",
       "verbs": ["POST"]
+    },
+    "jobs": {
+      "description": "Used in services to start other services",
+      "type": "io.cozy.jobs",
+      "verbs": ["POST"]
+    }
+  },
+  "services": {
+    "timeseriesWithoutAggregateMigration": {
+      "type": "node",
+      "file": "services/timeseriesWithoutAggregateMigration/coachco2.js",
+      "trigger": "@event io.cozy.timeseries.geojson:CREATED,UPDATED",
+      "debounce": "5s"
     }
   }
 }

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -72,7 +72,7 @@
       "type": "node",
       "file": "services/timeseriesWithoutAggregateMigration/coachco2.js",
       "trigger": "@event io.cozy.timeseries.geojson:CREATED,UPDATED",
-      "debounce": "5s"
+      "debounce": "5m"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@material-ui/core": "4",
     "chart.js": "3.7.1",
-    "cozy-client": "^29.0.1",
+    "cozy-client": "^29.1.1",
     "cozy-device-helper": "^2.1.0",
     "cozy-flags": "^2.8.7",
     "cozy-intent": "^1.17.1",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,5 @@
+export const APP_SLUG = 'coachco2'
+
 export const AIR_MODE = 'AIR_OR_HSR'
 export const BICYCLING_MODE = 'BICYCLING'
 export const CAR_MODE = 'CAR'

--- a/src/doctypes/index.js
+++ b/src/doctypes/index.js
@@ -3,6 +3,7 @@ export const FILES_DOCTYPE = 'io.cozy.files'
 export const GEOJSON_DOCTYPE = 'io.cozy.timeseries.geojson'
 export const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
 export const SETTINGS_DOCTYPE = 'io.cozy.coachco2.settings'
+export const JOBS_DOCTYPE = 'io.cozy.jobs'
 
 // the documents schema, necessary for CozyClient
 export default {

--- a/src/lib/metrics.js
+++ b/src/lib/metrics.js
@@ -132,6 +132,43 @@ export const caloriesFormula = (MET, durationInMinutes) => {
   return CBM * durationInMinutes
 }
 
+export const computeCaloriesSection = section => {
+  const speed = section.averageSpeed
+  const durationInMinutes = section.duration / 60 // duration is in seconds
+  let MET
+  switch (section.mode) {
+    case WALKING_MODE:
+      if (speed <= SLOW_WALKING_MAX_SPEED) {
+        MET = MET_WALKING_SLOW
+      } else if (speed <= MEDIUM_WALKING_MAX_SPEED) {
+        MET = MET_WALKING_MEDIUM
+      } else if (speed <= FAST_WALKING_MAX_SPEED) {
+        MET = MET_WALKING_FAST
+      } else {
+        MET = MET_WALKING_VERY_FAST
+      }
+      break
+    case BICYCLING_MODE:
+      if (speed <= SLOW_BICYCLING_MAX_SPEED) {
+        MET = MET_BICYCLING_SLOW
+      } else if (speed <= SLOW_BICYCLING_MAX_MEDIUM) {
+        MET = MET_BICYCLING_MEDIUM
+      } else if (speed <= SLOW_BICYCLING_MAX_FAST) {
+        MET = MET_BICYCLING_FAST
+      } else {
+        MET = MET_BICYCLING_VERY_FAST
+      }
+      break
+    default:
+      break
+  }
+  if (!MET) {
+    // No relevant MET found for this section
+    return 0
+  }
+  return caloriesFormula(MET, durationInMinutes)
+}
+
 /**
  * Compute the total number of burned calories during the trip.
  *
@@ -145,40 +182,8 @@ export const computeCaloriesTrip = trip => {
   const sections = getSectionsFromTrip(trip)
   let totalCalories = 0
   for (const section of sections) {
-    const speed = section.averageSpeed
-    const durationInMinutes = section.duration / 60 // duration is in seconds
-    let MET
-    switch (section.mode) {
-      case WALKING_MODE:
-        if (speed <= SLOW_WALKING_MAX_SPEED) {
-          MET = MET_WALKING_SLOW
-        } else if (speed <= MEDIUM_WALKING_MAX_SPEED) {
-          MET = MET_WALKING_MEDIUM
-        } else if (speed <= FAST_WALKING_MAX_SPEED) {
-          MET = MET_WALKING_FAST
-        } else {
-          MET = MET_WALKING_VERY_FAST
-        }
-        break
-      case BICYCLING_MODE:
-        if (speed <= SLOW_BICYCLING_MAX_SPEED) {
-          MET = MET_BICYCLING_SLOW
-        } else if (speed <= SLOW_BICYCLING_MAX_MEDIUM) {
-          MET = MET_BICYCLING_MEDIUM
-        } else if (speed <= SLOW_BICYCLING_MAX_FAST) {
-          MET = MET_BICYCLING_FAST
-        } else {
-          MET = MET_BICYCLING_VERY_FAST
-        }
-        break
-      default:
-        break
-    }
-    if (!MET) {
-      // No relevant MET found for this section
-      continue
-    }
-    totalCalories += caloriesFormula(MET, durationInMinutes)
+    const calories = computeCaloriesSection(section)
+    totalCalories += calories
   }
   return totalCalories
 }

--- a/src/lib/timeseries.spec.js
+++ b/src/lib/timeseries.spec.js
@@ -136,12 +136,18 @@ describe('transformTimeseriesToTrips', () => {
 })
 
 describe('Aggregation', () => {
-  const serie01 = mockSerie('serie01', [
-    mockStartPlaceFeature('startPlace01', makeStartPlaceFeature()),
-    mockEndPlaceFeature('endPlace01', makeEndPlaceFeature()),
-    mockFeatureCollection('featureCol01', [makePlaneFeature('planeFeature01')]),
-    mockFeatureCollection('featureCol02', [makeCarFeature('CarFeature01')])
-  ])
+  const serie01 = mockSerie(
+    'serie01',
+    [
+      mockStartPlaceFeature('startPlace01', makeStartPlaceFeature()),
+      mockEndPlaceFeature('endPlace01', makeEndPlaceFeature()),
+      mockFeatureCollection('featureCol01', [
+        makePlaneFeature('planeFeature01')
+      ]),
+      mockFeatureCollection('featureCol02', [makeCarFeature('CarFeature01')])
+    ],
+    { manual_purpose: purposes[1] }
+  )
   const serie02 = mockSerie(
     'serie02',
     [
@@ -152,6 +158,7 @@ describe('Aggregation', () => {
         makeCarFeature('CarFeature02')
       ]),
       mockFeatureCollection('featureCol04', [
+        makeWalkingFeature('WalkingFeature01'),
         makeWalkingFeature('WalkingFeature01')
       ])
     ],
@@ -175,6 +182,9 @@ describe('Aggregation', () => {
         totalCO2: expect.any(Number),
         totalDistance: expect.any(Number),
         totalDuration: expect.any(Number),
+        totalCalories: expect.any(Number),
+        purpose: expect.any(String),
+        modes: expect.any(Array),
         sections: expect.any(Array)
       })
     })
@@ -187,20 +197,36 @@ describe('Aggregation', () => {
         duration: expect.any(Number),
         startDate: expect.any(Date),
         endDate: expect.any(Date),
-        averageSpeed: expect.any(Number),
-        totalCO2: expect.any(Number)
+        avgSpeed: expect.any(Number),
+        CO2: expect.any(Number),
+        calories: expect.any(Number)
       })
     })
 
-    it('should compute correct totalCO2 in the timeseries aggregates', () => {
+    it('should compute correct CO2 in the timeseries aggregates', () => {
       expect(aggregatedTimeseries[0].aggregation).toMatchObject({
-        sections: [{ totalCO2: 130.235562 }, { totalCO2: 2.839488 }]
+        sections: [{ CO2: 130.235562 }, { CO2: 2.839488 }]
       })
       expect(aggregatedTimeseries[1].aggregation).toMatchObject({
         sections: [
-          { id: 'CarFeature02', totalCO2: 2.839488 },
-          { id: 'CarFeature02', totalCO2: 2.839488 },
-          { id: 'WalkingFeature01', totalCO2: 0 }
+          { id: 'CarFeature02', CO2: 2.839488 },
+          { id: 'CarFeature02', CO2: 2.839488 },
+          { id: 'WalkingFeature01', CO2: 0 },
+          { id: 'WalkingFeature01', CO2: 0 }
+        ]
+      })
+    })
+
+    it('should compute correct calories in the timeseries aggregates', () => {
+      expect(aggregatedTimeseries[0].aggregation).toMatchObject({
+        sections: [{ calories: 0 }, { calories: 0 }]
+      })
+      expect(aggregatedTimeseries[1].aggregation).toMatchObject({
+        sections: [
+          { id: 'CarFeature02', calories: 0 },
+          { id: 'CarFeature02', calories: 0 },
+          { id: 'WalkingFeature01', calories: 23.388749999999998 },
+          { id: 'WalkingFeature01', calories: 23.388749999999998 }
         ]
       })
     })
@@ -214,6 +240,33 @@ describe('Aggregation', () => {
     it('should compute correct totalDuration in the timeseries aggregates', () => {
       expect(aggregatedTimeseries[0].aggregation).toMatchObject({
         totalDuration: 3600
+      })
+    })
+    it('should compute correct totalCO2 in the timeseries aggregates', () => {
+      expect(aggregatedTimeseries[0].aggregation).toMatchObject({
+        totalCO2: 133.07504999999998
+      })
+    })
+    it('should compute correct totalCalories in the timeseries aggregates', () => {
+      expect(aggregatedTimeseries[0].aggregation).toMatchObject({
+        totalCalories: 0
+      })
+      expect(aggregatedTimeseries[1].aggregation).toMatchObject({
+        totalCalories: 46.777499999999996
+      })
+    })
+    it('should have the start/end display names in the timeseries aggregates', () => {
+      expect(aggregatedTimeseries[0].aggregation).toMatchObject({
+        startPlaceDisplayName: 'Avenue Jean Guiton, La Rochelle',
+        endPlaceDisplayName: 'Rue Ampère, La Rochelle'
+      })
+    })
+    it('should have the sections modes in the timeseries aggregate', () => {
+      expect(aggregatedTimeseries[0].aggregation).toMatchObject({
+        modes: ['AIR_OR_HSR', 'CAR']
+      })
+      expect(aggregatedTimeseries[1].aggregation).toMatchObject({
+        modes: ['CAR', 'CAR', 'WALKING', 'WALKING']
       })
     })
   })

--- a/src/lib/timeseries.spec.js
+++ b/src/lib/timeseries.spec.js
@@ -1,10 +1,14 @@
 import {
   mockTimeserie,
   mockSerie,
+  mockStartPlaceFeature,
+  mockEndPlaceFeature,
   makePlaneFeature,
   mockFeatureCollection,
   makeCarFeature,
-  makeWalkingFeature
+  makeWalkingFeature,
+  makeStartPlaceFeature,
+  makeEndPlaceFeature
 } from 'test/mockTrip'
 
 import { purposes } from 'src/components/helpers'
@@ -25,21 +29,21 @@ import {
 describe('transformSerieToTrip', () => {
   it('should return correct value', () => {
     const trip = transformSerieToTrip(mockSerie())
-
     expect(trip).toMatchObject({
+      type: 'FeatureCollection',
       properties: {
         start_place: {
+          $oid: 'startPlace01',
           data: {
-            id: 'sectionId01',
-            type: 'Feature',
+            id: 'startPlace01',
             geometry: {},
             properties: {}
           }
         },
         end_place: {
+          $oid: 'endPlace01',
           data: {
-            id: 'sectionId02',
-            type: 'Feature',
+            id: 'endPlace01',
             geometry: {},
             properties: {}
           }
@@ -68,16 +72,14 @@ describe('transformTimeseriesToTrips', () => {
         properties: {
           start_place: {
             data: {
-              id: 'sectionId01',
-              type: 'Feature',
+              id: 'startPlace01',
               geometry: {},
               properties: {}
             }
           },
           end_place: {
             data: {
-              id: 'sectionId02',
-              type: 'Feature',
+              id: 'endPlace01',
               geometry: {},
               properties: {}
             }
@@ -92,16 +94,14 @@ describe('transformTimeseriesToTrips', () => {
         properties: {
           start_place: {
             data: {
-              id: 'sectionId01',
-              type: 'Feature',
+              id: 'startPlace01',
               geometry: {},
               properties: {}
             }
           },
           end_place: {
             data: {
-              id: 'sectionId02',
-              type: 'Feature',
+              id: 'endPlace01',
               geometry: {},
               properties: {}
             }
@@ -116,16 +116,14 @@ describe('transformTimeseriesToTrips', () => {
         properties: {
           start_place: {
             data: {
-              id: 'sectionId01',
-              type: 'Feature',
+              id: 'startPlace01',
               geometry: {},
               properties: {}
             }
           },
           end_place: {
             data: {
-              id: 'sectionId02',
-              type: 'Feature',
+              id: 'endPlace01',
               geometry: {},
               properties: {}
             }
@@ -138,30 +136,31 @@ describe('transformTimeseriesToTrips', () => {
 })
 
 describe('Aggregation', () => {
-  const serie01Features = [
+  const serie01 = mockSerie('serie01', [
+    mockStartPlaceFeature('startPlace01', makeStartPlaceFeature()),
+    mockEndPlaceFeature('endPlace01', makeEndPlaceFeature()),
     mockFeatureCollection('featureCol01', [makePlaneFeature('planeFeature01')]),
     mockFeatureCollection('featureCol02', [makeCarFeature('CarFeature01')])
-  ]
-  const serie01 = mockSerie('serie01', serie01Features)
+  ])
+  const serie02 = mockSerie(
+    'serie02',
+    [
+      mockStartPlaceFeature('startPlace02'),
+      mockEndPlaceFeature('endPlace02'),
+      mockFeatureCollection('featureCol03', [
+        makeCarFeature('CarFeature02'),
+        makeCarFeature('CarFeature02')
+      ]),
+      mockFeatureCollection('featureCol04', [
+        makeWalkingFeature('WalkingFeature01')
+      ])
+    ],
+    { manual_purpose: purposes[0] }
+  )
+
   const timeseries = [
     mockTimeserie('timeserieId01', [serie01]),
-    mockTimeserie('timeserieId02', [
-      mockSerie(
-        'serie02',
-        [
-          mockFeatureCollection('featureCol03', [
-            makeCarFeature('CarFeature02'),
-            makeCarFeature('CarFeature02')
-          ]),
-          mockFeatureCollection('featureCol04', [
-            makeWalkingFeature('WalkingFeature01')
-          ])
-        ],
-        {
-          manual_purpose: purposes[0]
-        }
-      )
-    ])
+    mockTimeserie('timeserieId02', [serie02])
   ]
 
   const aggregatedTimeseries = computeAggregatedTimeseries(timeseries)

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -103,16 +103,11 @@ export const buildSettingsQuery = () => ({
 })
 
 // Note there is no need for fetchPolicy here, as this query is only used in node service
-export const buildTimeseriesWithoutAggregationByAccountAndDate = ({
-  accountId,
-  date,
-  limit = 1000
-}) => ({
+export const buildTimeseriesWithoutAggregation = ({ limit = 1000 }) => ({
   definition: Q(GEOJSON_DOCTYPE)
     .where({
-      'cozyMetadata.sourceAccount': accountId,
-      'cozyMetadata.updatedAt': {
-        $gt: date
+      startDate: {
+        $gt: null
       }
     })
     .partialIndex({
@@ -120,10 +115,7 @@ export const buildTimeseriesWithoutAggregationByAccountAndDate = ({
         $exists: false
       }
     })
-    .indexFields(['cozyMetadata.sourceAccount', 'cozyMetadata.updatedAt'])
-    .sortBy([
-      { 'cozyMetadata.sourceAccount': 'asc' },
-      { 'cozyMetadata.updatedAt': 'asc' }
-    ])
+    .indexFields(['startDate'])
+    .sortBy([{ startDate: 'desc' }])
     .limitBy(limit)
 })

--- a/src/targets/services/timeseriesWithoutAggregateMigration.js
+++ b/src/targets/services/timeseriesWithoutAggregateMigration.js
@@ -1,0 +1,92 @@
+import CozyClient from 'cozy-client'
+import log from 'cozy-logger'
+import schema, { JOBS_DOCTYPE } from 'src/doctypes'
+import { APP_SLUG } from 'src/constants'
+import { computeAggregatedTimeseries } from 'src/lib/timeseries'
+import {
+  buildTimeseriesWithoutAggregationByAccountAndDate,
+  buildAccountQuery
+} from 'src/queries/queries'
+
+import fetch from 'node-fetch'
+global.fetch = fetch
+
+const BATCH_DOCS_LIMIT = 1000 // to avoid processing too many files and get timeouts
+const SERVICE_NAME = 'timeseriesWithoutAggregateMigration'
+
+const migrateTimeSeriesWithoutAggregation = async () => {
+  log('info', `Start migrateTimeSeriesWithoutAggregation service`)
+  const client = CozyClient.fromEnv(process.env, { schema })
+
+  // Get all existing accounts
+  const accounts = await client.queryAll(
+    buildAccountQuery({ limit: null, withOnlyLogin: false }).definition
+  )
+  if (!accounts) {
+    log('info', 'No account found: Nothing to do')
+    return
+  }
+  let moreDocsToProcess = false
+  for (const account of accounts) {
+    // Query timeseries without aggregation from the last saved date for this account
+    const updatedAt = account.data?.lastMigratedTimeserieUpdatedAt || null
+
+    log(
+      'info',
+      `Query timeseries updated since: ${updatedAt} for account ${account._id}`
+    )
+    const query = buildTimeseriesWithoutAggregationByAccountAndDate({
+      accountId: account._id,
+      date: updatedAt,
+      limit: BATCH_DOCS_LIMIT
+    }).definition
+    const resp = await client.query(query)
+
+    if (!resp.data || resp.data.length < 1) {
+      log('info', 'Nothing to migrate')
+      continue
+    }
+    log('info', `Found ${resp.data.length} timeseries to migrate...`)
+
+    // Compute aggregation for all retrieved timeseries
+    const migratedTimeseries = computeAggregatedTimeseries(resp.data)
+
+    // Save the migrated timeseries
+    await client.saveAll(migratedTimeseries)
+
+    // Save in account the startDate of the last processed timeserie
+    const moreRecentUpdatedAt =
+      migratedTimeseries[migratedTimeseries.length - 1].cozyMetadata.updatedAt
+
+    const newAccountDoc = {
+      ...account,
+      data: {
+        ...account.data,
+        lastMigratedTimeserieUpdatedAt: moreRecentUpdatedAt
+      }
+    }
+    await client.save(newAccountDoc)
+
+    log(
+      'info',
+      `${migratedTimeseries.length} timeseries migrated until ${moreRecentUpdatedAt}`
+    )
+    if (migratedTimeseries.length >= BATCH_DOCS_LIMIT) {
+      moreDocsToProcess = true
+    }
+  }
+
+  // Restart the service, if necessary
+  if (moreDocsToProcess) {
+    log('info', 'There are more timeseries to migrate: restart the service')
+    await client.collection(JOBS_DOCTYPE).create('service', {
+      name: SERVICE_NAME,
+      slug: APP_SLUG
+    })
+  }
+}
+
+migrateTimeSeriesWithoutAggregation().catch(e => {
+  log('critical', e)
+  process.exit(1)
+})

--- a/test/mockTrip.js
+++ b/test/mockTrip.js
@@ -73,6 +73,22 @@ export const createTripFromTemplate = (
   return trip
 }
 
+export const makeStartPlaceFeature = () => ({
+  feature_type: 'start_place',
+  display_name: 'Avenue Jean Guiton, La Rochelle',
+  enter_fmt_time: '2022-04-02T14:56:05',
+  exit_fmt_time: '2022-04-02T16:00:13',
+  duration: 3848.2966425418854,
+  coordinates: [2.31251, 48.7799432]
+})
+
+export const makeEndPlaceFeature = () => ({
+  feature_type: 'start_place',
+  display_name: 'Rue Ampère, La Rochelle',
+  enter_fmt_time: '2022-04-02T16:13:09',
+  coordinates: [-0.7519085, 46.4536633]
+})
+
 export const makeBicycleTrip = () =>
   createTripFromTemplate(tripTemplate, modeProps.bicycle)
 export const makeBicycleFeature = id => mockFeature(id, modeProps.bicycle)
@@ -119,6 +135,48 @@ export const mockFeature = (id, props) => {
   }
 }
 
+export const mockStartPlaceFeature = (id, props) => {
+  return {
+    id,
+    type: 'Feature',
+    geometry: props
+      ? {
+          coordinates: props.coordinates || [2.31251, 48.7799432],
+          type: 'Point'
+        }
+      : {},
+    properties: props
+      ? {
+          feature_type: 'start_place',
+          display_name: props.display_name,
+          enter_fmt_time: props.enter_fmt_time,
+          exit_fmt_time: props.exit_fmt_time,
+          duration: props.duration
+        }
+      : {}
+  }
+}
+
+export const mockEndPlaceFeature = (id, props) => {
+  return {
+    id,
+    type: 'Feature',
+    geometry: props
+      ? {
+          coordinates: props.coordinates || [-0.7519085, 46.4536633],
+          type: 'Point'
+        }
+      : {},
+    properties: props
+      ? {
+          feature_type: 'end_place',
+          display_name: props.display_name,
+          enter_fmt_time: props.enter_fmt_time
+        }
+      : {}
+  }
+}
+
 export const mockFeatureCollection = (id, features) => ({
   id,
   type: 'FeatureCollection',
@@ -135,21 +193,20 @@ export const mockSerie = (
   type: 'FeatureCollection',
   properties: {
     start_place: {
-      $oid: 'sectionId01',
-      data: { properties: { display_name: 'GR9, Isère' } }
+      $oid: 'startPlace01'
     },
     end_place: {
-      $oid: 'sectionId02',
-      data: { properties: { display_name: 'Piste de la Combe Noire, Isère' } }
+      $oid: 'endPlace01'
     },
     manual_purpose,
     start_fmt_time: '2021-06-30T14:47:51.081201+02:00',
     end_fmt_time: '2021-06-30T16:37:05.086000+02:00'
   },
   features: features || [
-    mockFeature('sectionId01'),
-    mockFeature('sectionId02'),
-    mockFeatureCollection('sectionId03', [mockFeature('featureId01')])
+    mockStartPlaceFeature('startPlace01'),
+    mockEndPlaceFeature('endPlace01'),
+    mockFeatureCollection('featureColl1', [mockFeature('sectionId01')]),
+    mockFeatureCollection('featureColl2', [mockFeature('sectionId02')])
   ]
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3892,16 +3892,16 @@ cozy-client@^26.0.2:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^29.0.1:
-  version "29.0.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-29.0.1.tgz#c29828c7358a0f4c275ccf4520a355ce4aec0edb"
-  integrity sha512-wf9UnHjErFerbOBIJMiA6EPlsTTIAm7I3s1h3riEyUPptBNMx7Kcrgvq8HbU8i7U3fWc4yDbzSiWIercJoIi5g==
+cozy-client@^29.1.1:
+  version "29.1.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-29.1.1.tgz#232b72fcbc9d9848b3bc024f668fc4e702672777"
+  integrity sha512-UFbKwbzeu+OxurUyKe0TLxXXlR6XfcqYjPTK9y+GOCGOnKp38Js3uczSTn+Hsd5czLRhc8EXsI99TLkjehPjFQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^29.0.0"
+    cozy-stack-client "^29.1.0"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -4094,10 +4094,10 @@ cozy-stack-client@^26.0.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^29.0.0:
-  version "29.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-29.0.0.tgz#d94ab0f1432d9a6175bbbcde850dafde0d657752"
-  integrity sha512-pGXq+7P/BriMqku43QLQhctQ3lop0GyHLc/82E+APZTMQh6bVO/0tTyggQ45HxfB76vMyZoY+BSubr+vQVLUkQ==
+cozy-stack-client@^29.1.0:
+  version "29.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-29.1.0.tgz#a101e164b45088560df828ff39e369cd9e5a5466"
+  integrity sha512-KxLTdGhqNFDX4TpstzuyROROTGkvvMy4sSiRS5yHir8hfudCuME6pyRIKTslTlMx/y7vjYqcInaEnrwlZP7zaA==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
We now want to store an `aggregation` object in the
`io.cozy.timeseries.geojson` doctype, so it can be directly queried from
the app without having to retrieve the full geojson object, which can
very heavy, with most of the information being useless.
This service queries all the timeseries without the `aggregation` object
thanks to a partial filer and store the date of the last processed
timeserie, so it can be run incrementally.