### PR TITLE
feat: Add service to send monthly CO2 emissions to DACC

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ The doc returned from `io.cozy.timeseries.geojson` is a `timeserie`. The `series
 }
 ```
 
+## DACC
+
+This app uses the [DACC](https://github.com/cozy/DACC) to send and received anonymized contributions. 
+This is used to compare average CO2 emissions: if the user gives consent, her monthly CO2 emissions are sent to the DACC.
+Then, she can compare herself with the average emissions of all the participating users.
+All data sent to the DACC is anonymized, and only aggregated values under a certain threshold can be queried.
+
 ## Community
 
 ### What's Cozy?

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -39,7 +39,7 @@
       "description": "Required to get konnector account",
       "type": "io.cozy.accounts",
       "verbs": [
-        "GET"
+        "GET", "PUT"
       ]
     },
     "files": {
@@ -65,6 +65,16 @@
       "description": "Used in services to start other services",
       "type": "io.cozy.jobs",
       "verbs": ["POST"]
+    },
+    "dacc": {
+      "type": "cc.cozycloud.dacc",
+      "verbs": ["POST"],
+      "description": "Remote-doctype required to send anonymized CO2 contributions"
+    },
+    "dacc-dev": {
+      "type": "cc.cozycloud.dacc.dev",
+      "verbs": ["POST"],
+      "description": "Remote-doctype required to send anonymized CO2 contributions, for developement purposes"
     }
   },
   "services": {
@@ -73,6 +83,11 @@
       "file": "services/timeseriesWithoutAggregateMigration/coachco2.js",
       "trigger": "@event io.cozy.timeseries.geojson:CREATED,UPDATED",
       "debounce": "5m"
+    },
+    "dacc": {
+      "type": "node",
+      "file": "services/dacc/coachco2.js",
+      "trigger": "@every 720h"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cozy-logger": "^1.9.0",
     "cozy-scripts": "5.13.0",
     "cozy-ui": "^67.0.4",
-    "date-fns": "^1.30.1",
+    "date-fns": "^2.28.0",
     "humanize-duration": "3.27.1",
     "leaflet": "^1.7.1",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@material-ui/core": "4",
     "chart.js": "3.7.1",
-    "cozy-client": "^29.1.1",
+    "cozy-client": "^29.1.3",
     "cozy-device-helper": "^2.1.0",
     "cozy-flags": "^2.8.7",
     "cozy-intent": "^1.17.1",

--- a/src/components/TripsList.jsx
+++ b/src/components/TripsList.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
-import isSameDay from 'date-fns/is_same_day'
+import isSameDay from 'date-fns/isSameDay'
 
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -163,3 +163,13 @@ export const COLUMNS_NAMES_CSV = {
   sectionTimestamps: 'Section_Timestamps',
   sectionSpeeds: 'Section_Speeds'
 }
+
+export const DACC_MEASURE_NAME_CO2_MONTHLY = 'co2-emissions-monthly'
+export const DACC_MEASURE_GROUP1_CO2_MONTHLY = Object.freeze({
+  is_tracemob_expe: true
+})
+
+export const TIMESERIE_MIGRATION_SERVICE_NAME =
+  'timeseriesWithoutAggregateMigration'
+export const DACC_SERVICE_NAME = 'dacc'
+export const MAX_DACC_MEASURES_SENT = 12

--- a/src/doctypes/index.js
+++ b/src/doctypes/index.js
@@ -5,6 +5,9 @@ export const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
 export const SETTINGS_DOCTYPE = 'io.cozy.coachco2.settings'
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
 
+export const DACC_REMOTE_DOCTYPE = 'cc.cozycloud.dacc'
+export const DACC_REMOTE_DOCTYPE_DEV = 'cc.cozycloud.dacc.dev'
+
 // the documents schema, necessary for CozyClient
 export default {
   timeseries: {

--- a/src/lib/dacc.js
+++ b/src/lib/dacc.js
@@ -1,0 +1,179 @@
+import log from 'cozy-logger'
+import flag from 'cozy-flags'
+import { models } from 'cozy-client'
+import addMonths from 'date-fns/addMonths'
+import subMonths from 'date-fns/subMonths'
+import startOfMonth from 'date-fns/startOfMonth'
+import isThisMonth from 'date-fns/isThisMonth'
+import format from 'date-fns/format'
+import {
+  buildAccountQuery,
+  buildTimeseriesQueryByDateAndAccountId,
+  buildOldestTimeseriesQueryByAccountId
+} from 'src/queries/queries'
+import { computeCO2Timeseries } from 'src/lib/timeseries'
+import {
+  APP_SLUG,
+  DACC_MEASURE_NAME_CO2_MONTHLY,
+  DACC_MEASURE_GROUP1_CO2_MONTHLY,
+  TIMESERIE_MIGRATION_SERVICE_NAME,
+  MAX_DACC_MEASURES_SENT
+} from 'src/constants'
+import { DACC_REMOTE_DOCTYPE, DACC_REMOTE_DOCTYPE_DEV } from 'src/doctypes'
+import { restartService } from 'src/lib/services'
+
+const { sendMeasureToDACC } = models.dacc
+
+export const sendCO2MeasureToDACC = async (client, measure) => {
+  try {
+    await flag.initialize(client)
+    const remoteDoctype =
+      flag('coachco2.dacc-dev') === true
+        ? DACC_REMOTE_DOCTYPE_DEV
+        : DACC_REMOTE_DOCTYPE
+    log('info', `Send measure to ${remoteDoctype} on ${measure.startDate}`)
+
+    await sendMeasureToDACC(client, remoteDoctype, measure)
+  } catch (error) {
+    log(
+      'error',
+      `Error while sending measure to remote doctype: ${error.message}`
+    )
+    throw error
+  }
+}
+
+const createMeasureForDACC = (startDate, value) => {
+  return {
+    createdBy: APP_SLUG,
+    measureName: DACC_MEASURE_NAME_CO2_MONTHLY,
+    startDate: format(startDate, 'yyyy-MM-dd'),
+    value,
+    group1: DACC_MEASURE_GROUP1_CO2_MONTHLY
+  }
+}
+
+const fetchTimeseriesForMonth = async (client, accountId, startDate) => {
+  const query = buildTimeseriesQueryByDateAndAccountId(startDate, accountId, {
+    withOnlyAggregation: true,
+    limit: 1000
+  }).definition
+  return client.queryAll(query)
+}
+
+export const hasNonAggregatedTimeseries = timeseries => {
+  const timeseriesWithAggregation = timeseries.filter(
+    timeserie => timeserie.aggregation
+  )
+  return timeseriesWithAggregation.length < timeseries.length
+}
+
+const getNextMonthStartDate = date => {
+  return startOfMonth(addMonths(date, 1))
+}
+
+export const getNextMeasureStartDate = date => {
+  const nextMonthStartDate = getNextMonthStartDate(date)
+  if (
+    nextMonthStartDate.getTime() > Date.now() ||
+    isThisMonth(nextMonthStartDate)
+  ) {
+    return null
+  }
+  return nextMonthStartDate
+}
+
+export const getStartDate = async (client, account) => {
+  const accountDate = account.data?.lastDACCMeasureStartDate
+  const lastDACCMeasureStartDate = accountDate ? new Date(accountDate) : null
+  if (lastDACCMeasureStartDate) {
+    return new Date(lastDACCMeasureStartDate)
+  }
+
+  const query = buildOldestTimeseriesQueryByAccountId(account._id).definition
+  const oldestDoc = await client.query(query)
+  if (!oldestDoc.data || oldestDoc.data.length < 1) {
+    return null
+  }
+  const startDate = new Date(oldestDoc.data[0].startDate)
+
+  return startOfMonth(subMonths(startDate, 1))
+}
+
+const saveStartDateInAccount = async (client, account, date) => {
+  const newAccount = {
+    ...account,
+    data: {
+      ...account.data,
+      lastDACCMeasureStartDate: date
+    }
+  }
+  await client.save(newAccount)
+}
+
+export const sendMeasuresForAccount = async (client, account) => {
+  let nMeasuresSent = 0
+  let startDate = await getStartDate(client, account)
+  if (!startDate) {
+    log('info', `No data to process for account ${account._id}.`)
+    return nMeasuresSent
+  }
+  let nextStartDate = getNextMeasureStartDate(startDate)
+  while (nextStartDate && nMeasuresSent < MAX_DACC_MEASURES_SENT) {
+    startDate = nextStartDate
+    const timeseries = await fetchTimeseriesForMonth(
+      client,
+      account._id,
+      nextStartDate
+    )
+    if (timeseries.length < 1) {
+      // No trips to process for this month
+      log('info', `No trips for ${startDate.toISOString()}`)
+      nextStartDate = getNextMeasureStartDate(startDate)
+      continue
+    }
+    if (hasNonAggregatedTimeseries(timeseries)) {
+      // There are timeseries without aggregation: interrupt service execution to run migration service
+      log(
+        'warning',
+        `Timeseries for ${startDate.toISOString} does not have aggregation`
+      )
+      await restartService(client, TIMESERIE_MIGRATION_SERVICE_NAME)
+      return nMeasuresSent
+    }
+    const CO2 = computeCO2Timeseries(timeseries)
+    const measure = createMeasureForDACC(startDate, CO2)
+
+    await sendCO2MeasureToDACC(client, measure)
+    nMeasuresSent++
+    nextStartDate = getNextMeasureStartDate(startDate)
+  }
+  await saveStartDateInAccount(client, account, startDate)
+  log('info', `Saved  ${startDate.toISOString()} in account`)
+
+  return nMeasuresSent
+}
+
+export const runDACCService = async client => {
+  const accounts = await client.queryAll(
+    buildAccountQuery({ limit: 1000, withOnlyLogin: false }).definition
+  )
+  if (!accounts) {
+    log('info', 'No account found: Nothing to do')
+    return
+  }
+
+  let shouldRestartService = false
+
+  for (const account of accounts) {
+    const nMeasuresSent = await sendMeasuresForAccount(client, account)
+    if (nMeasuresSent >= MAX_DACC_MEASURES_SENT) {
+      shouldRestartService = true
+    }
+    log(
+      'info',
+      `${nMeasuresSent} measures sent to DACC for account ${account._id}`
+    )
+  }
+  return shouldRestartService
+}

--- a/src/lib/dacc.spec.js
+++ b/src/lib/dacc.spec.js
@@ -1,0 +1,306 @@
+import { createMockClient, models } from 'cozy-client'
+const { sendMeasureToDACC } = models.dacc
+
+import * as dacc from './dacc'
+jest.mock('cozy-client', () => ({
+  ...jest.requireActual('cozy-client'),
+  models: {
+    dacc: {
+      sendMeasureToDACC: jest.fn()
+    }
+  }
+}))
+jest.mock('cozy-flags')
+
+const mockedCurrentDate = '2022-04-12T11:01:58.135Z'
+
+jest.mock('date-fns/isThisMonth', () => date => {
+  if (!date) {
+    return false
+  }
+  return (
+    new Date(mockedCurrentDate).getMonth() === date.getMonth() &&
+    new Date(mockedCurrentDate).getYear() === date.getYear()
+  )
+})
+
+const mockClient = createMockClient({})
+
+const januaryTimeseries = [
+  {
+    _id: 'timeserie1',
+    startDate: '2022-01-01T12:00:00',
+    endDate: '2022-01-01T16:00:00',
+    aggregation: {
+      totalCO2: 13
+    }
+  },
+  {
+    _id: 'timeserie2',
+    startDate: '2022-01-03T08:00:00',
+    endDate: '2022-01-03T09:00:00',
+    aggregation: {
+      totalCO2: 0
+    }
+  },
+  {
+    _id: 'timeserie3',
+    startDate: '2022-01-04T17:00:00',
+    endDate: '2022-01-04T19:00:00',
+    aggregation: {
+      totalCO2: 26
+    }
+  }
+]
+const februaryTimeseries = [
+  {
+    _id: 'timeserie4',
+    startDate: '2022-02-12T14:00:00',
+    endDate: '2022-02-12T18:00:00',
+    aggregation: {
+      totalCO2: 53
+    }
+  }
+]
+const marchTimeseries = [
+  {
+    _id: 'timeserie5',
+    startDate: '2022-03-01T02:00:00',
+    endDate: '2022-02-12T03:00:00',
+    aggregation: {
+      totalCO2: 126
+    }
+  }
+]
+
+describe('getNextMeasureStartDate', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementation(() => new Date('2022-05-12T11:01:58.135Z').valueOf())
+  })
+  it('should give next start date', () => {
+    const startMonth = new Date('2022-01-01T00:00:00')
+    expect(dacc.getNextMeasureStartDate(startMonth)).toEqual(
+      new Date('2022-02-01T00:00:00')
+    )
+    const middleMonth = new Date('2022-01-15T00:00:00')
+    expect(dacc.getNextMeasureStartDate(middleMonth)).toEqual(
+      new Date('2022-02-01T00:00:00')
+    )
+    const endMonth = new Date('2022-01-31T00:00:00')
+    expect(dacc.getNextMeasureStartDate(endMonth)).toEqual(
+      new Date('2022-02-01T00:00:00')
+    )
+  })
+
+  it('should return null when date is after start of current month', async () => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementation(() => new Date(mockedCurrentDate).valueOf())
+
+    const afterMonth = new Date('2022-05-01')
+    expect(dacc.getNextMeasureStartDate(afterMonth)).toBe(null)
+
+    const sameMonth = new Date('2022-04-02')
+    expect(dacc.getNextMeasureStartDate(sameMonth)).toBe(null)
+  })
+})
+
+describe('getStartDate', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(mockClient, 'query')
+      .mockResolvedValue({ data: [januaryTimeseries[0]] })
+  })
+  it('should return the date stored in acount when defined', async () => {
+    const account = {
+      _id: 'my-account',
+      data: { lastDACCMeasureStartDate: '2020-12-01' }
+    }
+    const date = await dacc.getStartDate(mockClient, account)
+    expect(date).toEqual(new Date('2020-12-01'))
+  })
+  it('should return the startdate based on oldest timeserie when no date is on account', async () => {
+    const account = {
+      _id: 'my-account',
+      data: {}
+    }
+    const date = await dacc.getStartDate(mockClient, account)
+    expect(date).toEqual(new Date('2021-12-01'))
+  })
+})
+
+describe('hasNonAggregatedTimeseries', () => {
+  it('should return true when a timeserie does not have aggregation', () => {
+    const timeseries = [
+      {
+        aggregation: { totalCO2: 10 }
+      },
+      {}
+    ]
+    expect(dacc.hasNonAggregatedTimeseries(timeseries)).toBe(true)
+  })
+  it('should return false when all timeseries have aggregation', () => {
+    const timeseries = [
+      {
+        aggregation: { totalCO2: 10 }
+      },
+      { aggregation: { totalCO2: 310 } }
+    ]
+    expect(dacc.hasNonAggregatedTimeseries(timeseries)).toBe(false)
+  })
+})
+
+describe('sendMeasuresForAccount', () => {
+  const expectedMeasure = {
+    createdBy: 'coachco2',
+    measureName: 'co2-emissions-monthly',
+    group1: { is_tracemob_expe: true }
+  }
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.spyOn(mockClient, 'queryAll').mockResolvedValueOnce(januaryTimeseries)
+    jest.spyOn(mockClient, 'queryAll').mockResolvedValueOnce(februaryTimeseries)
+    jest.spyOn(mockClient, 'queryAll').mockResolvedValueOnce(marchTimeseries)
+    jest.spyOn(mockClient, 'save').mockImplementation(jest.fn())
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementation(() => new Date(mockedCurrentDate).valueOf())
+  })
+
+  it('should send measures for all the months before current date', async () => {
+    const account = {
+      _id: 'account-id',
+      data: {
+        lastDACCMeasureStartDate: '2021-12-01'
+      }
+    }
+    await dacc.sendMeasuresForAccount(mockClient, account)
+    // Send for january, february and march
+    expect(sendMeasureToDACC).toHaveBeenCalledTimes(3)
+    expect(sendMeasureToDACC).toHaveBeenNthCalledWith(
+      1,
+      mockClient,
+      'cc.cozycloud.dacc',
+      {
+        ...expectedMeasure,
+        value: 39,
+        startDate: '2022-01-01'
+      }
+    )
+    expect(sendMeasureToDACC).toHaveBeenNthCalledWith(
+      2,
+      mockClient,
+      'cc.cozycloud.dacc',
+      {
+        ...expectedMeasure,
+        value: 53,
+        startDate: '2022-02-01'
+      }
+    )
+    expect(sendMeasureToDACC).toHaveBeenNthCalledWith(
+      3,
+      mockClient,
+      'cc.cozycloud.dacc',
+      {
+        ...expectedMeasure,
+        value: 126,
+        startDate: '2022-03-01'
+      }
+    )
+  })
+
+  it('should send measures even if date is not in account', async () => {
+    const account = {
+      _id: 'account-id',
+      data: {}
+    }
+    jest
+      .spyOn(mockClient, 'query')
+      .mockResolvedValue({ data: [januaryTimeseries[0]] })
+    await dacc.sendMeasuresForAccount(mockClient, account)
+    expect(sendMeasureToDACC).toHaveBeenCalledTimes(3)
+  })
+
+  it('should not send measure if date is after current date', async () => {
+    const account = {
+      _id: 'account-id',
+      data: {
+        lastDACCMeasureStartDate: '2022-05-01'
+      }
+    }
+    await dacc.sendMeasuresForAccount(mockClient, account)
+    expect(sendMeasureToDACC).toHaveBeenCalledTimes(0)
+  })
+
+  it('should not send measure if date is in current month', async () => {
+    const account = {
+      _id: 'account-id',
+      data: {
+        lastDACCMeasureStartDate: '2022-04-01'
+      }
+    }
+    await dacc.sendMeasuresForAccount(mockClient, account)
+    expect(sendMeasureToDACC).toHaveBeenCalledTimes(0)
+  })
+
+  it('should save the last processed date', async () => {
+    const account = {
+      _id: 'account-id',
+      data: {
+        lastDACCMeasureStartDate: '2021-12-01'
+      }
+    }
+    const expectedSavedAccount = {
+      _id: 'account-id',
+      data: {
+        lastDACCMeasureStartDate: new Date('2022-03-01')
+      }
+    }
+    await dacc.sendMeasuresForAccount(mockClient, account)
+    expect(sendMeasureToDACC).toHaveBeenCalledTimes(3)
+    expect(mockClient.save).toHaveBeenCalledWith(expectedSavedAccount)
+  })
+})
+
+describe('runDACCService', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.spyOn(mockClient, 'save').mockImplementation(jest.fn())
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementation(() => new Date(mockedCurrentDate).valueOf())
+  })
+  it('should return false when there is no more measure to send', async () => {
+    jest
+      .spyOn(mockClient, 'queryAll')
+      .mockResolvedValueOnce([
+        { _id: 'my-account1', data: { lastDACCMeasureStartDate: '2022-01-01' } }
+      ])
+
+    jest
+      .spyOn(mockClient, 'queryAll')
+      .mockResolvedValue([{ aggregation: { totalCO2: 0 } }])
+    const shouldRestart = await dacc.runDACCService(mockClient)
+    expect(sendMeasureToDACC).toHaveBeenCalledTimes(2)
+    expect(shouldRestart).toBe(false)
+  })
+
+  it('should return true when there are no more measure to send', async () => {
+    jest
+      .spyOn(mockClient, 'queryAll')
+      .mockResolvedValueOnce([
+        { _id: 'my-account1', data: { lastDACCMeasureStartDate: '2021-01-01' } }
+      ])
+    jest
+      .spyOn(mockClient, 'queryAll')
+      .mockResolvedValue([{ aggregation: { totalCO2: 0 } }])
+
+    const shouldRestart = await dacc.runDACCService(mockClient)
+    expect(sendMeasureToDACC).toHaveBeenCalledTimes(12)
+    expect(shouldRestart).toBe(true)
+  })
+})

--- a/src/lib/exportTripsToCSV.js
+++ b/src/lib/exportTripsToCSV.js
@@ -21,7 +21,7 @@ import { getOrCreateAppFolderWithReference } from 'src/lib/getOrCreateAppFolderW
 import { buildTimeseriesQueryNoLimit } from 'src/queries/queries'
 
 const makeCSVFilename = (accountLabel, t) => {
-  const today = format(new Date(), 'YYYY MM DD')
+  const today = format(new Date(), 'yyyy MM dd')
 
   return t('export.filename', { today, accountLabel })
 }

--- a/src/lib/services.js
+++ b/src/lib/services.js
@@ -1,0 +1,9 @@
+import { JOBS_DOCTYPE } from 'src/doctypes'
+import { APP_SLUG } from 'src/constants'
+
+export const restartService = async (client, serviceName) => {
+  await client.collection(JOBS_DOCTYPE).create('service', {
+    name: serviceName,
+    slug: APP_SLUG
+  })
+}

--- a/src/lib/timeseries.js
+++ b/src/lib/timeseries.js
@@ -123,9 +123,8 @@ export const computeCO2Timeseries = aggregatedTimeseries => {
   let totalCO2 = 0
 
   aggregatedTimeseries.forEach(aggregatedTimeserie => {
-    totalCO2 += aggregatedTimeserie.aggregation.totalCO2
+    totalCO2 += aggregatedTimeserie.aggregation?.totalCO2 || 0
   })
-
   return totalCO2
 }
 

--- a/src/lib/trips.js
+++ b/src/lib/trips.js
@@ -2,7 +2,8 @@ import get from 'lodash/get'
 import flatten from 'lodash/flatten'
 import uniq from 'lodash/uniq'
 import memoize from 'lodash/memoize'
-import distanceInWords from 'date-fns/distance_in_words'
+import dateFnsFormatDistance from 'date-fns/formatDistance'
+
 import humanizeDuration from 'humanize-duration'
 
 import { UNKNOWN_MODE } from 'src/constants'
@@ -42,7 +43,7 @@ export const getEndPlaceDisplayName = trip => {
 export const getFormattedDuration = trip => {
   const startDate = new Date(trip.properties.start_fmt_time)
   const endDate = new Date(trip.properties.end_fmt_time)
-  return distanceInWords(endDate, startDate)
+  return dateFnsFormatDistance(endDate, startDate)
 }
 
 const formatDistance = distance => {

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -41,7 +41,7 @@ export const buildAccountQuery = ({
   return {
     definition: queryDef,
     options: {
-      as: `${ACCOUNTS_DOCTYPE}/account_type`,
+      as: `${ACCOUNTS_DOCTYPE}/account_type/limitedBy/${limit}/withOnlyLogin/${withOnlyLogin}`,
       fetchPolicy: CozyClient.fetchPolicies.olderThan(older30s)
     }
   }

--- a/src/queries/queries.spec.js
+++ b/src/queries/queries.spec.js
@@ -47,14 +47,6 @@ describe('buildTimeseriesQueryByDateAndAccountId', () => {
     const query = buildTimeseriesQueryByDateAndAccountId(undefined, 'accountId')
 
     expect(query).toMatchObject({
-      definition: {
-        selector: {
-          startDate: {
-            $gt: '1970-01-01T00:00:00.000Z',
-            $lt: '1970-01-31T23:59:59.999Z'
-          }
-        }
-      },
       options: {
         as: 'io.cozy.timeseries.geojson/sourceAccount/accountId/date/noDate',
         enabled: false
@@ -66,14 +58,6 @@ describe('buildTimeseriesQueryByDateAndAccountId', () => {
     const query = buildTimeseriesQueryByDateAndAccountId(undefined, undefined)
 
     expect(query).toMatchObject({
-      definition: {
-        selector: {
-          startDate: {
-            $gt: '1970-01-01T00:00:00.000Z',
-            $lt: '1970-01-31T23:59:59.999Z'
-          }
-        }
-      },
       options: {
         as: 'io.cozy.timeseries.geojson/sourceAccount/undefined/date/noDate',
         enabled: false

--- a/src/queries/queries.spec.js
+++ b/src/queries/queries.spec.js
@@ -16,7 +16,8 @@ describe('buildTimeseriesQueryByDateAndAccountId', () => {
         }
       },
       options: {
-        as: 'io.cozy.timeseries.geojson/sourceAccount/accountId/date/2022-1',
+        as:
+          'io.cozy.timeseries.geojson/sourceAccount/accountId/date/2022-1/limitedBy/1000/withOnlyAggregation/true',
         enabled: true
       }
     })
@@ -37,7 +38,8 @@ describe('buildTimeseriesQueryByDateAndAccountId', () => {
         }
       },
       options: {
-        as: 'io.cozy.timeseries.geojson/sourceAccount/undefined/date/2022-1',
+        as:
+          'io.cozy.timeseries.geojson/sourceAccount/undefined/date/2022-1/limitedBy/1000/withOnlyAggregation/true',
         enabled: false
       }
     })
@@ -48,7 +50,8 @@ describe('buildTimeseriesQueryByDateAndAccountId', () => {
 
     expect(query).toMatchObject({
       options: {
-        as: 'io.cozy.timeseries.geojson/sourceAccount/accountId/date/noDate',
+        as:
+          'io.cozy.timeseries.geojson/sourceAccount/accountId/date/noDate/limitedBy/1000/withOnlyAggregation/true',
         enabled: false
       }
     })
@@ -59,7 +62,8 @@ describe('buildTimeseriesQueryByDateAndAccountId', () => {
 
     expect(query).toMatchObject({
       options: {
-        as: 'io.cozy.timeseries.geojson/sourceAccount/undefined/date/noDate',
+        as:
+          'io.cozy.timeseries.geojson/sourceAccount/undefined/date/noDate/limitedBy/1000/withOnlyAggregation/true',
         enabled: false
       }
     })

--- a/src/queries/queries.spec.js
+++ b/src/queries/queries.spec.js
@@ -10,8 +10,8 @@ describe('buildTimeseriesQueryByDateAndAccountId', () => {
       definition: {
         selector: {
           startDate: {
-            $gt: '2022-02-01T00:00:00.000Z',
-            $lt: '2022-02-28T23:59:59.999Z'
+            $gte: '2022-02-01T00:00:00.000Z',
+            $lte: '2022-02-28T23:59:59.999Z'
           }
         }
       },
@@ -31,8 +31,8 @@ describe('buildTimeseriesQueryByDateAndAccountId', () => {
       definition: {
         selector: {
           startDate: {
-            $gt: '2022-02-01T00:00:00.000Z',
-            $lt: '2022-02-28T23:59:59.999Z'
+            $gte: '2022-02-01T00:00:00.000Z',
+            $lte: '2022-02-28T23:59:59.999Z'
           }
         }
       },

--- a/src/targets/services/dacc.js
+++ b/src/targets/services/dacc.js
@@ -1,14 +1,13 @@
 import CozyClient from 'cozy-client'
 import log from 'cozy-logger'
-import schema, { JOBS_DOCTYPE } from 'src/doctypes'
-import { APP_SLUG } from 'src/constants'
+import schema from 'src/doctypes'
 
 import { runDACCService } from 'src/lib/dacc'
+import { restartService } from 'src/lib/services'
+import { DACC_SERVICE_NAME } from 'src/constants'
 
 import fetch from 'node-fetch'
 global.fetch = fetch
-
-const SERVICE_NAME = 'dacc'
 
 const dacc = async () => {
   log('info', 'Start dacc service')
@@ -17,10 +16,7 @@ const dacc = async () => {
   const shouldRestart = await runDACCService(client)
   if (shouldRestart) {
     log('info', 'There are more DACC measures to send: restart the service')
-    await client.collection(JOBS_DOCTYPE).create('service', {
-      name: SERVICE_NAME,
-      slug: APP_SLUG
-    })
+    await restartService(client, DACC_SERVICE_NAME)
   }
 }
 

--- a/src/targets/services/dacc.js
+++ b/src/targets/services/dacc.js
@@ -1,0 +1,30 @@
+import CozyClient from 'cozy-client'
+import log from 'cozy-logger'
+import schema, { JOBS_DOCTYPE } from 'src/doctypes'
+import { APP_SLUG } from 'src/constants'
+
+import { runDACCService } from 'src/lib/dacc'
+
+import fetch from 'node-fetch'
+global.fetch = fetch
+
+const SERVICE_NAME = 'dacc'
+
+const dacc = async () => {
+  log('info', 'Start dacc service')
+  const client = CozyClient.fromEnv(process.env, { schema })
+
+  const shouldRestart = await runDACCService(client)
+  if (shouldRestart) {
+    log('info', 'There are more DACC measures to send: restart the service')
+    await client.collection(JOBS_DOCTYPE).create('service', {
+      name: SERVICE_NAME,
+      slug: APP_SLUG
+    })
+  }
+}
+
+dacc().catch(e => {
+  log('critical', e)
+  process.exit(1)
+})

--- a/src/targets/services/timeseriesWithoutAggregateMigration.js
+++ b/src/targets/services/timeseriesWithoutAggregateMigration.js
@@ -1,15 +1,14 @@
 import CozyClient from 'cozy-client'
 import log from 'cozy-logger'
-import schema, { JOBS_DOCTYPE } from 'src/doctypes'
-import { APP_SLUG } from 'src/constants'
+import schema from 'src/doctypes'
 import { computeAggregatedTimeseries } from 'src/lib/timeseries'
 import { buildTimeseriesWithoutAggregation } from 'src/queries/queries'
-
+import { restartService } from 'src/lib/services'
+import { TIMESERIE_MIGRATION_SERVICE_NAME } from 'src/constants'
 import fetch from 'node-fetch'
 global.fetch = fetch
 
 const BATCH_DOCS_LIMIT = 1000 // to avoid processing too many files and get timeouts
-const SERVICE_NAME = 'timeseriesWithoutAggregateMigration'
 
 const migrateTimeSeriesWithoutAggregation = async () => {
   log('info', `Start migrateTimeSeriesWithoutAggregation service`)
@@ -39,10 +38,7 @@ const migrateTimeSeriesWithoutAggregation = async () => {
   // Restart the service, if necessary
   if (migratedTimeseries.length >= BATCH_DOCS_LIMIT) {
     log('info', 'There are more timeseries to migrate: restart the service')
-    await client.collection(JOBS_DOCTYPE).create('service', {
-      name: SERVICE_NAME,
-      slug: APP_SLUG
-    })
+    await restartService(client, TIMESERIE_MIGRATION_SERVICE_NAME)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4425,10 +4425,15 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@1.30.1, date-fns@^1.28.5, date-fns@^1.30.1:
+date-fns@1.30.1, date-fns@^1.28.5:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
 debounce@^1.2.1:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3892,10 +3892,10 @@ cozy-client@^26.0.2:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^29.1.1:
-  version "29.1.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-29.1.1.tgz#232b72fcbc9d9848b3bc024f668fc4e702672777"
-  integrity sha512-UFbKwbzeu+OxurUyKe0TLxXXlR6XfcqYjPTK9y+GOCGOnKp38Js3uczSTn+Hsd5czLRhc8EXsI99TLkjehPjFQ==
+cozy-client@^29.1.3:
+  version "29.1.3"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-29.1.3.tgz#f5040ef291df24d4b8ee7d920f79a400b36bf862"
+  integrity sha512-rhZXyA9Qd+IW5Chu8unewXtn9di3YmGJv30LFf+B4h/v0SdQQzvLyQNBqvVD1f7K1dDcbLUYuq3lrnQblkecMg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"


### PR DESCRIPTION
This service will be launched every month. For each month, it will
aggregate the CO2 emitted by all the trips for this month, and the send
the result to the DACC.
Eventually, this will give the user the possibility to compare herself
with others contributors.

Note the service can only 12 contributions for each account for a single
execution, to prevent service timeout. If there are more months to
compute, the service relaunch itself.