### PR TITLE
feat: Display global user average CO2 emissions in chart

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -67,12 +67,12 @@
       "verbs": ["POST"]
     },
     "dacc": {
-      "type": "cc.cozycloud.dacc",
+      "type": "cc.cozycloud.dacc_v2",
       "verbs": ["POST"],
       "description": "Remote-doctype required to send anonymized CO2 contributions"
     },
     "dacc-dev": {
-      "type": "cc.cozycloud.dacc.dev",
+      "type": "cc.cozycloud.dacc.dev_v2",
       "verbs": ["POST"],
       "description": "Remote-doctype required to send anonymized CO2 contributions, for developement purposes"
     }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@material-ui/core": "4",
     "chart.js": "3.7.1",
-    "cozy-client": "^29.1.3",
+    "cozy-client": "^31.0.1",
     "cozy-device-helper": "^2.1.0",
     "cozy-flags": "^2.8.7",
     "cozy-intent": "^1.17.1",

--- a/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
+++ b/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
@@ -5,6 +5,7 @@ import { isQueryLoading, useQueryAll } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import useSettings from 'src/hooks/useSettings'
+import useFetchDACCAggregates from 'src/hooks/useFetchDACCAggregates'
 import { buildOneYearOldTimeseriesWithAggregationByAccountId } from 'src/queries/queries'
 import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import ChartLegend from 'src/components/CO2EmissionsChart/VerticalBarChart/ChartLegend'
@@ -29,6 +30,8 @@ const CO2EmissionsChart = () => {
     }
   )
 
+  const { data: globalAverages } = useFetchDACCAggregates(allowSendDataToDacc)
+
   const isLoading =
     !account || isQueryLoading(queryResult) || queryResult.hasMore
 
@@ -42,7 +45,9 @@ const CO2EmissionsChart = () => {
     theme,
     oneYearOldTimeseries,
     allowSendDataToDacc,
-    f
+    globalAverages,
+    f,
+    t
   })
 
   return (

--- a/src/components/CO2EmissionsChart/helpers.js
+++ b/src/components/CO2EmissionsChart/helpers.js
@@ -3,8 +3,10 @@ import { computeMonthsAndCO2s } from 'src/lib/timeseries'
 export const makeData = ({
   theme,
   oneYearOldTimeseries,
-  // allowSendDataToDacc,
-  f
+  allowSendDataToDacc,
+  globalAverages,
+  f,
+  t
 }) => {
   const { months, CO2s } = computeMonthsAndCO2s(oneYearOldTimeseries, f)
 
@@ -12,7 +14,7 @@ export const makeData = ({
     labels: months,
     datasets: [
       {
-        label: 'Dataset 1',
+        label: t('vericalBarChart.legend.yours'),
         backgroundColor: theme.palette.primary.main,
         borderRadius: 8,
         barThickness: 8,
@@ -21,16 +23,15 @@ export const makeData = ({
     ]
   }
 
-  // TODO: to be refactored when DACC is finished
-  // if (allowSendDataToDacc) {
-  //   data.datasets.push({
-  //     label: 'Dataset 1',
-  //     backgroundColor: theme.palette.border.main,
-  //     borderRadius: 8,
-  //     barThickness: 8,
-  //     data: [0, 1800, 1700, 3600, 1900, 2800, 4000, 1300, 2800, 2700, 660, 2000]
-  //   })
-  // }
+  if (allowSendDataToDacc) {
+    data.datasets.push({
+      label: t('vericalBarChart.legend.average'),
+      backgroundColor: theme.palette.border.main,
+      borderRadius: 8,
+      barThickness: 8,
+      data: globalAverages
+    })
+  }
 
   return data
 }

--- a/src/components/CO2EmissionsChart/helpers.spec.js
+++ b/src/components/CO2EmissionsChart/helpers.spec.js
@@ -1,7 +1,7 @@
 import MockDate from 'mockdate'
 
 import { makeData } from './helpers'
-import { mockF } from 'test/lib/I18n'
+import { mockF, mockT } from 'test/lib/I18n'
 
 const theme = {
   palette: {
@@ -29,7 +29,9 @@ describe('makeData', () => {
           { startDate: '2022-09-08T00:00:00.000Z' }
         ],
         allowSendDataToDacc: false,
-        f: mockF
+        globalAverages: null,
+        f: mockF,
+        t: mockT
       })
 
       expect(data.labels).toStrictEqual([
@@ -46,7 +48,42 @@ describe('makeData', () => {
         'OCT',
         'NOV'
       ])
+      expect(data.datasets.length).toEqual(1)
       expect(data.datasets[0].backgroundColor).toBe('primaryMainColor')
+    })
+  })
+  describe('allowSendDataToDacc is true', () => {
+    it('should return well formated data', () => {
+      const data = makeData({
+        theme,
+        oneYearOldTimeseries: [
+          { startDate: '2022-10-08T00:00:00.000Z' },
+          { startDate: '2022-10-07T00:00:00.000Z' },
+          { startDate: '2022-09-08T00:00:00.000Z' }
+        ],
+        allowSendDataToDacc: true,
+        globalAverages: [42, 96, 78],
+        f: mockF,
+        t: mockT
+      })
+
+      expect(data.labels).toStrictEqual([
+        'DEC',
+        'JAN',
+        'FEB',
+        'MAR',
+        'APR',
+        'MAY',
+        'JUN',
+        'JUL',
+        'AUG',
+        'SEP',
+        'OCT',
+        'NOV'
+      ])
+      expect(data.datasets.length).toEqual(2)
+      expect(data.datasets[0].backgroundColor).toBe('primaryMainColor')
+      expect(data.datasets[1].backgroundColor).toBe('borderMainColor')
     })
   })
 })

--- a/src/components/Views/Trips.jsx
+++ b/src/components/Views/Trips.jsx
@@ -19,9 +19,8 @@ import {
   getAccountLabel
 } from 'src/components/Providers/AccountProvider'
 import EmptyContent from 'src/components/EmptyContent'
-// TODO: uncomment when DACC is finished
-// import CO2EmissionsChart from 'src/components/CO2EmissionsChart/CO2EmissionsChart'
-// import DaccManager from 'src/components/DaccManager/DaccManager'
+import CO2EmissionsChart from 'src/components/CO2EmissionsChart/CO2EmissionsChart'
+import DaccManager from 'src/components/DaccManager/DaccManager'
 
 export const Trips = () => {
   const { account, isAccountLoading } = useAccountContext()
@@ -78,8 +77,8 @@ export const Trips = () => {
   return (
     <>
       <Titlebar label={t('trips.from') + ' ' + getAccountLabel(account)} />
-      {/* <CO2EmissionsChart />
-      <DaccManager /> */}
+      <CO2EmissionsChart />
+      <DaccManager />
       <TripsList timeseries={timeseries} />
       {timeseriesQueryLeft.hasMore && (
         <LoadMore

--- a/src/doctypes/index.js
+++ b/src/doctypes/index.js
@@ -5,8 +5,8 @@ export const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
 export const SETTINGS_DOCTYPE = 'io.cozy.coachco2.settings'
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
 
-export const DACC_REMOTE_DOCTYPE = 'cc.cozycloud.dacc'
-export const DACC_REMOTE_DOCTYPE_DEV = 'cc.cozycloud.dacc.dev'
+export const DACC_REMOTE_DOCTYPE = 'cc.cozycloud.dacc_v2'
+export const DACC_REMOTE_DOCTYPE_DEV = 'cc.cozycloud.dacc.dev_v2'
 
 // the documents schema, necessary for CozyClient
 export default {

--- a/src/hooks/useFetchDACCAggregates.jsx
+++ b/src/hooks/useFetchDACCAggregates.jsx
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react'
+import { useClient } from 'cozy-client'
+
+import { fetchMonthlyAverageCO2FromDACCFor12Month } from 'src/lib/dacc'
+
+const useFetchDACCAggregates = allowSendDataToDacc => {
+  const client = useClient()
+  const [isLoading, setIsLoading] = useState(false)
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    const fetchDataFromDACC = async () => {
+      setIsLoading(true)
+      const results = await fetchMonthlyAverageCO2FromDACCFor12Month(client)
+      const averages = results?.length > 0 ? results.map(agg => agg.avg) : null
+      setIsLoading(false)
+      setData(averages)
+    }
+    if (allowSendDataToDacc) {
+      fetchDataFromDACC()
+    }
+  }, [client, allowSendDataToDacc])
+
+  return { isLoading, data }
+}
+
+export default useFetchDACCAggregates

--- a/src/hooks/useFetchDACCAggregates.spec.jsx
+++ b/src/hooks/useFetchDACCAggregates.spec.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { renderHook } from '@testing-library/react-hooks'
+
+import { createMockClient } from 'cozy-client'
+import { fetchMonthlyAverageCO2FromDACCFor12Month } from 'src/lib/dacc'
+
+import AppLike from 'test/AppLike'
+import useFetchDACCAggregates from 'src/hooks/useFetchDACCAggregates'
+jest.mock('src/lib/dacc')
+
+const client = createMockClient({})
+
+const setup = ({ allowSendDataToDacc }) => {
+  const wrapper = ({ children }) => (
+    <AppLike client={client}>{children}</AppLike>
+  )
+
+  return renderHook(() => useFetchDACCAggregates(allowSendDataToDacc), {
+    wrapper
+  })
+}
+
+describe('useFetchDACCAggregates', () => {
+  it('should return isLoading false and no data when dacc is not allowed', () => {
+    fetchMonthlyAverageCO2FromDACCFor12Month.mockResolvedValue([{ avg: 42 }])
+
+    const { result } = setup({ allowSendDataToDacc: false })
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.data).toBe(null)
+  })
+
+  it('should return average data', async () => {
+    fetchMonthlyAverageCO2FromDACCFor12Month.mockResolvedValue([
+      { avg: 42, sum: 58 },
+      { avg: 64, sum: 102 }
+    ])
+    const { result, waitForNextUpdate } = setup({ allowSendDataToDacc: true })
+    await waitForNextUpdate()
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.data).toEqual([42, 64])
+  })
+})

--- a/src/lib/dacc.js
+++ b/src/lib/dacc.js
@@ -28,7 +28,7 @@ export const sendCO2MeasureToDACC = async (client, measure) => {
   try {
     await flag.initialize(client)
     const remoteDoctype =
-      flag('coachco2.dacc-dev') === true
+      flag('coachco2.dacc-dev_v2') === true
         ? DACC_REMOTE_DOCTYPE_DEV
         : DACC_REMOTE_DOCTYPE
     log('info', `Send measure to ${remoteDoctype} on ${measure.startDate}`)

--- a/src/lib/dacc.js
+++ b/src/lib/dacc.js
@@ -24,13 +24,16 @@ import { restartService } from 'src/lib/services'
 
 const { sendMeasureToDACC, fetchAggregatesFromDACC } = models.dacc
 
+const getDACCRemoteDoctype = () => {
+  return flag('coachco2.dacc-dev_v2') === true
+    ? DACC_REMOTE_DOCTYPE_DEV
+    : DACC_REMOTE_DOCTYPE
+}
+
 export const sendCO2MeasureToDACC = async (client, measure) => {
   try {
     await flag.initialize(client)
-    const remoteDoctype =
-      flag('coachco2.dacc-dev_v2') === true
-        ? DACC_REMOTE_DOCTYPE_DEV
-        : DACC_REMOTE_DOCTYPE
+    const remoteDoctype = getDACCRemoteDoctype()
     log('info', `Send measure to ${remoteDoctype} on ${measure.startDate}`)
 
     await sendMeasureToDACC(client, remoteDoctype, measure)
@@ -57,10 +60,7 @@ export const sendCO2MeasureToDACC = async (client, measure) => {
  */
 export const fetchMonthlyAverageCO2FromDACCFor12Month = async client => {
   try {
-    const remoteDoctype =
-      flag('coachco2.dacc-dev_v2') === true
-        ? DACC_REMOTE_DOCTYPE_DEV
-        : DACC_REMOTE_DOCTYPE
+    const remoteDoctype = getDACCRemoteDoctype()
     const startDate = format(
       startOfMonth(subMonths(Date.now(), 12)),
       'yyyy-MM-dd'

--- a/src/lib/dacc.spec.js
+++ b/src/lib/dacc.spec.js
@@ -1,12 +1,16 @@
 import { createMockClient, models } from 'cozy-client'
-const { sendMeasureToDACC } = models.dacc
+const { sendMeasureToDACC, fetchAggregatesFromDACC } = models.dacc
 import { DACC_REMOTE_DOCTYPE } from 'src/doctypes'
+import { DACC_MEASURE_NAME_CO2_MONTHLY } from 'src/constants'
 import * as dacc from './dacc'
+import MockDate from 'mockdate'
+
 jest.mock('cozy-client', () => ({
   ...jest.requireActual('cozy-client'),
   models: {
     dacc: {
-      sendMeasureToDACC: jest.fn()
+      sendMeasureToDACC: jest.fn(),
+      fetchAggregatesFromDACC: jest.fn()
     }
   }
 }))
@@ -302,5 +306,23 @@ describe('runDACCService', () => {
     const shouldRestart = await dacc.runDACCService(mockClient)
     expect(sendMeasureToDACC).toHaveBeenCalledTimes(12)
     expect(shouldRestart).toBe(true)
+  })
+})
+
+describe('fetchMonthlyAverageCO2FromDACCFor12Month', () => {
+  beforeEach(() => {
+    MockDate.set(mockedCurrentDate)
+  })
+
+  afterEach(() => {
+    MockDate.reset()
+  })
+  it('should call fetchAggregatesFromDACC with the correct args', async () => {
+    dacc.fetchMonthlyAverageCO2FromDACCFor12Month(mockClient)
+    expect(fetchAggregatesFromDACC).toHaveBeenCalledWith(
+      mockClient,
+      DACC_REMOTE_DOCTYPE,
+      { measureName: DACC_MEASURE_NAME_CO2_MONTHLY, startDate: '2021-04-01' }
+    )
   })
 })

--- a/src/lib/dacc.spec.js
+++ b/src/lib/dacc.spec.js
@@ -1,6 +1,6 @@
 import { createMockClient, models } from 'cozy-client'
 const { sendMeasureToDACC } = models.dacc
-
+import { DACC_REMOTE_DOCTYPE } from 'src/doctypes'
 import * as dacc from './dacc'
 jest.mock('cozy-client', () => ({
   ...jest.requireActual('cozy-client'),
@@ -183,7 +183,7 @@ describe('sendMeasuresForAccount', () => {
     expect(sendMeasureToDACC).toHaveBeenNthCalledWith(
       1,
       mockClient,
-      'cc.cozycloud.dacc',
+      DACC_REMOTE_DOCTYPE,
       {
         ...expectedMeasure,
         value: 39,
@@ -193,7 +193,7 @@ describe('sendMeasuresForAccount', () => {
     expect(sendMeasureToDACC).toHaveBeenNthCalledWith(
       2,
       mockClient,
-      'cc.cozycloud.dacc',
+      DACC_REMOTE_DOCTYPE,
       {
         ...expectedMeasure,
         value: 53,
@@ -203,7 +203,7 @@ describe('sendMeasuresForAccount', () => {
     expect(sendMeasureToDACC).toHaveBeenNthCalledWith(
       3,
       mockClient,
-      'cc.cozycloud.dacc',
+      DACC_REMOTE_DOCTYPE,
       {
         ...expectedMeasure,
         value: 126,

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -37,7 +37,7 @@ export const buildAccountQuery = ({
     .indexFields(['account_type'])
     .limitBy(limit)
   if (withOnlyLogin) {
-    queryDef.select(['auth.login'])
+    queryDef.select(['auth.login', 'account_type'])
   }
   return {
     definition: queryDef,
@@ -81,7 +81,7 @@ export const buildTimeseriesQueryByDateAndAccountId = (
     .indexFields(['cozyMetadata.sourceAccount', 'startDate'])
     .limitBy(limit)
   if (withOnlyAggregation) {
-    queryDef.select(['aggregation'])
+    queryDef.select(['aggregation', 'cozyMetadata.sourceAccount', 'startDate'])
   }
   return {
     definition: queryDef,

--- a/src/targets/browser/setupApp.jsx
+++ b/src/targets/browser/setupApp.jsx
@@ -4,6 +4,7 @@ import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
 
 import { getClient } from 'src/utils/client'
 import { getValues, initBar } from 'src/utils/bar'
+import flag from 'cozy-flags'
 
 /**
  * Memoize this function in its own file so that it is correctly memoized
@@ -13,6 +14,7 @@ const setupApp = memoize(() => {
   const { lang, appName } = getValues(JSON.parse(root.dataset.cozy))
   const polyglot = initTranslation(lang, lang => require(`locales/${lang}`))
   const client = getClient()
+  client.registerPlugin(flag.plugin)
 
   initBar({ client, root, lang, appName })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4910,16 +4910,16 @@ cozy-client@^27.26.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^29.1.3:
-  version "29.1.3"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-29.1.3.tgz#f5040ef291df24d4b8ee7d920f79a400b36bf862"
-  integrity sha512-rhZXyA9Qd+IW5Chu8unewXtn9di3YmGJv30LFf+B4h/v0SdQQzvLyQNBqvVD1f7K1dDcbLUYuq3lrnQblkecMg==
+cozy-client@^31.0.1:
+  version "31.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-31.0.1.tgz#72762df7988299262e9e3051d537aa6f4b0b5718"
+  integrity sha512-aOB+GTWdY1OInlXrUfTUg0SGkpHfZHIZW3i3iudxbUzNl9qGGkuGxQ5+LtJqG9hUse5XHShGqwrfS47oreXkjA==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^29.1.0"
+    cozy-stack-client "^31.0.0"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -5200,10 +5200,10 @@ cozy-stack-client@^27.26.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^29.1.0:
-  version "29.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-29.1.0.tgz#a101e164b45088560df828ff39e369cd9e5a5466"
-  integrity sha512-KxLTdGhqNFDX4TpstzuyROROTGkvvMy4sSiRS5yHir8hfudCuME6pyRIKTslTlMx/y7vjYqcInaEnrwlZP7zaA==
+cozy-stack-client@^31.0.0:
+  version "31.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-31.0.0.tgz#663d51a63df4979e2e70c83b4535cc58cffa084f"
+  integrity sha512-dB0f1uhPA4etCTCoAkT3hf8bUmjneb4JumOA4K2XXX6ytYbtRf0CRhaYuIV3QECLPdr/OsQfs+YNdwpHZ7gD/A==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
When the user consents to anonymously contribute to the CO2 global
emissions computations, the global average of all participating users
are displayed on the emissions chart, thanks to the DACC.