### PR TITLE
Change wording in CO2EmissionsChart legend and color box

### DIFF
--- a/src/components/CO2EmissionsChart/helpers.js
+++ b/src/components/CO2EmissionsChart/helpers.js
@@ -65,5 +65,10 @@ export const makeOptions = theme => ({
         }
       }
     }
+  },
+  plugins: {
+    tooltip: {
+      displayColors: false
+    }
   }
 })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -134,7 +134,7 @@
     "title": "CO2 emissions",
     "legend": {
       "yours": "Your emissions",
-      "average": "Average user emissions"
+      "average": "User averages"
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -134,7 +134,7 @@
     "title": "Émissions de CO2",
     "legend": {
       "yours": "Vos émissions",
-      "average": "Émissions moyennes des utilisateurs"
+      "average": "Moyennes des utilisateurs"
     }
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/67680939/175008596-fbed0631-0b8a-48d8-a7bc-2edc6ef9f344.png)
petit souci de chevauchement de la color box dans le tooltip au clic sur une barre du graphique.

Quick fix qui consiste à la supprimer pour faire simple car : 
- Le tooltip n'est pas conforme aux specs
- pas de temps alloué à corriger ça
- pas d'autre solution convenable rapide
- le fait de cliquer sur les barres en mobile n'est pas une UX convenable (à terme l'idée étant de pouvoir cliquer sur la colonne et d'avoir un toolti plus personnalisé)