### PR TITLE
feat: Use select on aggregation query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Migrate timeseries without aggregation
 * Update cozy-client to get useQueryAll hook https://github.com/cozy/cozy-client/commit/590f18abbf13db372b3d3a1c517a7795957a1808
 * CSV export filtered by sensor
+* Display global average CO2 emissions, thanks to DACC
+* Optimize aggregation query to select only required fields
 
 ## 🐛 Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,24 @@ This is used to compare average CO2 emissions: if the user gives consent, her mo
 Then, she can compare herself with the average emissions of all the participating users.
 All data sent to the DACC is anonymized, and only aggregated values under a certain threshold can be queried.
 
+### Develop with the DACC
+
+To develop locally with the DACC, you first need to get an access token to the dev server. Then, you need to:
+
+- Set the flag `coachco2.dacc-dev_v2`. You can do it by running `cozy-stack features flags '{"coachco2.dacc-dev_v2": true}'`.
+- Add a secret document containing the DACC token:
+  - Create a database `secrets/io-cozy-remote-secrets` if it does not exist yet. You may need to replace the `/` with `%2F` depending on your client.
+  - Add the following document:
+  ```
+  {
+    "_id": "cc.cozycloud.dacc.dev_v2",
+    "token": "<dacc_token>"
+  }
+  ```
+
+Now, thanks to this, you should be able to use the DACC's remote-doctype! 
+
+
 ## Community
 
 ### What's Cozy?

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@material-ui/core": "4",
     "chart.js": "3.7.1",
-    "cozy-client": "^31.0.1",
+    "cozy-client": "^32.0.0",
     "cozy-device-helper": "^2.1.0",
     "cozy-flags": "^2.8.7",
     "cozy-intent": "^1.17.1",

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -151,7 +151,7 @@ export const buildOneYearOldTimeseriesWithAggregationByAccountId =
           { startDate: 'asc' },
           { aggregation: 'asc' }
         ])
-        // .select(['startDate', 'aggregation']) should be used after https://github.com/cozy/cozy-client/issues/1175 fixed
+        .select(['startDate', 'aggregation', 'cozyMetadata.sourceAccount'])
         .limitBy(1000),
       options: {
         as: `${GEOJSON_DOCTYPE}/sourceAccount/${accountId}/withAggregation/fromDate/${dateOneYearAgoFromNow.getFullYear()}-${dateOneYearAgoFromNow.getMonth()}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4910,16 +4910,16 @@ cozy-client@^27.26.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^31.0.1:
-  version "31.0.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-31.0.1.tgz#72762df7988299262e9e3051d537aa6f4b0b5718"
-  integrity sha512-aOB+GTWdY1OInlXrUfTUg0SGkpHfZHIZW3i3iudxbUzNl9qGGkuGxQ5+LtJqG9hUse5XHShGqwrfS47oreXkjA==
+cozy-client@^32.0.0:
+  version "32.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-32.0.0.tgz#4c4c80d9b23a49ccbb90d4da9f2dc4c5ecbf04b8"
+  integrity sha512-Dhr1Rl8odxkN+FxpgCsZAKIR5Yaw1YI46jwwiCt+9zKuZMa4/70VYjm3YDsVTFy7yYb+hlOR2jVml4WWsU0dVw==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^31.0.0"
+    cozy-stack-client "^32.0.0"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -5200,10 +5200,10 @@ cozy-stack-client@^27.26.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^31.0.0:
-  version "31.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-31.0.0.tgz#663d51a63df4979e2e70c83b4535cc58cffa084f"
-  integrity sha512-dB0f1uhPA4etCTCoAkT3hf8bUmjneb4JumOA4K2XXX6ytYbtRf0CRhaYuIV3QECLPdr/OsQfs+YNdwpHZ7gD/A==
+cozy-stack-client@^32.0.0:
+  version "32.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-32.0.0.tgz#bb8d3059af6a778dab9a5dbb10ddd467d3cdafee"
+  integrity sha512-xri2V36t2kYwuTBKuMZq/ZNm+2TDjyta0/k5hjNFBH7uOX3StAUaN6HqzJN+VsZ40v9y9EGE+K8vdhqWSM8Y3A==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
This is very useful to avoid querying full documents on the heavy aggregation 
request. Indeed, we require the timeseries for a whole year to build the
graph.
On a dataset of 926 timeseries, the query goes from 8.4 MB of data
retrieved in 2.35s, to 595 KB of data retrieved in 1.16s.