### PR TITLE
feat: Do not send value to DACC if there is no consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * CSV export filtered by sensor
 * Display global average CO2 emissions, thanks to DACC
 * Optimize aggregation query to select only required fields
+* Send aggregated CO2 values to the DACC under user consent
 
 ## 🐛 Bug Fixes
 

--- a/src/lib/dacc.spec.js
+++ b/src/lib/dacc.spec.js
@@ -278,7 +278,25 @@ describe('runDACCService', () => {
       .spyOn(global.Date, 'now')
       .mockImplementation(() => new Date(mockedCurrentDate).valueOf())
   })
+
+  it('should do nothing when there is no consent', async () => {
+    jest.spyOn(mockClient, 'queryAll').mockResolvedValueOnce(null)
+    let shouldRestart = await dacc.runDACCService(mockClient)
+    expect(sendMeasureToDACC).toHaveBeenCalledTimes(0)
+    expect(shouldRestart).toBe(false)
+
+    jest
+      .spyOn(mockClient, 'queryAll')
+      .mockResolvedValueOnce([{ allowSendDataToDacc: false }])
+    shouldRestart = await dacc.runDACCService(mockClient)
+    expect(sendMeasureToDACC).toHaveBeenCalledTimes(0)
+    expect(shouldRestart).toBe(false)
+  })
+
   it('should return false when there is no more measure to send', async () => {
+    jest
+      .spyOn(mockClient, 'queryAll')
+      .mockResolvedValueOnce([{ allowSendDataToDacc: true }])
     jest
       .spyOn(mockClient, 'queryAll')
       .mockResolvedValueOnce([
@@ -294,6 +312,9 @@ describe('runDACCService', () => {
   })
 
   it('should return true when there are no more measure to send', async () => {
+    jest
+      .spyOn(mockClient, 'queryAll')
+      .mockResolvedValueOnce([{ allowSendDataToDacc: true }])
     jest
       .spyOn(mockClient, 'queryAll')
       .mockResolvedValueOnce([


### PR DESCRIPTION
The user has to explicitely give consent to the DACC so the service can
be run