### PR TITLE
fix: Vertically center the map on mobile when opening it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 🐛 Bug Fixes
 
+* Vertically center the trip map on mobile when opening it
+
 ## 🔧 Tech
 
 # 0.7.0

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ yarn fixtures
 You can run a migration service to add aggregation data on your timeseries.
 
 ```sh
+$ yarn build
 $ yarn service:timeseriesWithoutAggregateMigration
 ```
 

--- a/src/components/Trip/TripMap.jsx
+++ b/src/components/Trip/TripMap.jsx
@@ -15,6 +15,7 @@ import { getGeoJSONData } from 'src/lib/timeseries'
 import './tripmap.styl'
 
 const mapCenter = [51.505, -0.09]
+const mapPadding = 16
 
 const makeGeoJsonOptions = theme => ({
   style: feature => {
@@ -63,8 +64,15 @@ const TripMap = () => {
   useEffect(() => {
     if (geojsonRef.current) {
       const geojsonL = geojsonRef.current.leafletElement
-      mapL.fitBounds(geojsonL.getBounds(), {
-        paddingBottomRight: [0, mapL.getSize().y * mapPanRatio]
+      const bounds = geojsonL.getBounds()
+      const paddingTopLeft = [mapPadding, mapPadding]
+      const paddingBottomRight = [
+        mapPadding,
+        mapPadding + mapL.getSize().y * mapPanRatio
+      ]
+      mapL.fitBounds(bounds, {
+        paddingTopLeft,
+        paddingBottomRight
       })
     }
   }, [mapL, mapPanRatio])

--- a/src/components/Trip/TripMap.jsx
+++ b/src/components/Trip/TripMap.jsx
@@ -51,7 +51,7 @@ const TripMap = () => {
     [theme]
   )
   const mapPanRatio = useMemo(
-    () => (isMobile ? bottomSheetSettings.mediumHeightRatio / 2 : 0),
+    () => (isMobile ? bottomSheetSettings.mediumHeightRatio : 0),
     [isMobile]
   )
 
@@ -63,8 +63,9 @@ const TripMap = () => {
   useEffect(() => {
     if (geojsonRef.current) {
       const geojsonL = geojsonRef.current.leafletElement
-      mapL.fitBounds(geojsonL.getBounds())
-      mapL.panBy([0, mapL.getSize().y * mapPanRatio])
+      mapL.fitBounds(geojsonL.getBounds(), {
+        paddingBottomRight: [0, mapL.getSize().y * mapPanRatio]
+      })
     }
   }, [mapL, mapPanRatio])
 


### PR DESCRIPTION
This is an approximation. This would likely need to take into account the minimum height of the bottom sheet to be perfect, but it's not exposed by the component.