### PR TITLE
Fix migration service for instances with old index

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@material-ui/core": "4",
     "chart.js": "3.7.1",
-    "cozy-client": "^32.0.0",
+    "cozy-client": "^32.1.0",
     "cozy-device-helper": "^2.1.0",
     "cozy-flags": "^2.8.7",
     "cozy-intent": "^1.17.1",

--- a/src/targets/services/timeseriesWithoutAggregateMigration.js
+++ b/src/targets/services/timeseriesWithoutAggregateMigration.js
@@ -27,7 +27,9 @@ const migrateTimeSeriesWithoutAggregation = async () => {
   const migratedTimeseries = computeAggregatedTimeseries(resp.data)
 
   // Save the migrated timeseries
-  await client.saveAll(migratedTimeseries)
+  for (const timeserie of migratedTimeseries) {
+    await client.save(timeserie)
+  }
 
   log(
     'info',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4910,16 +4910,16 @@ cozy-client@^27.26.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^32.0.0:
-  version "32.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-32.0.0.tgz#4c4c80d9b23a49ccbb90d4da9f2dc4c5ecbf04b8"
-  integrity sha512-Dhr1Rl8odxkN+FxpgCsZAKIR5Yaw1YI46jwwiCt+9zKuZMa4/70VYjm3YDsVTFy7yYb+hlOR2jVml4WWsU0dVw==
+cozy-client@^32.1.0:
+  version "32.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-32.1.0.tgz#d38ee04e0dcae62f11a0e868349bf3f8bd20c117"
+  integrity sha512-dd7UZnX9Uaonq0T+E8mqBEV58j3BMQFaRXIU/gFYVYPHKNB8sHyvcXSh4tLh4RYNNJDECgkWsLmtogkxoPz/jg==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^32.0.0"
+    cozy-stack-client "^32.1.0"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -5200,10 +5200,10 @@ cozy-stack-client@^27.26.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^32.0.0:
-  version "32.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-32.0.0.tgz#bb8d3059af6a778dab9a5dbb10ddd467d3cdafee"
-  integrity sha512-xri2V36t2kYwuTBKuMZq/ZNm+2TDjyta0/k5hjNFBH7uOX3StAUaN6HqzJN+VsZ40v9y9EGE+K8vdhqWSM8Y3A==
+cozy-stack-client@^32.1.0:
+  version "32.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-32.1.0.tgz#2ca35d570f7159a3177db3a8c28565623a855046"
+  integrity sha512-AxwSSIgYhuwW2DqWDA/P2dqsVvsaBx/6SYcmZfgmdTAh/QFzijK4M8jQ9h/qooDZo6M7NXAdgCvIxFHmB2wB2g==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
When an index with a partial filter was created and an other index
already existed with the same selector, it created a conflict and the
index with the partial filter wasn't created and the one without was
actually used. 
We met this situation for the migration service for an instance with an old index, which was stucked with
the first 1000 docs, because the query was returning all the docs, as the
partial index was not evaluated.