### PR TITLE
fix: Index on endDate rather than startDate

### DIFF
--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -109,7 +109,7 @@ export const buildSettingsQuery = () => ({
 export const buildTimeseriesWithoutAggregation = ({ limit = 1000 }) => ({
   definition: Q(GEOJSON_DOCTYPE)
     .where({
-      startDate: {
+      endDate: {
         $gt: null
       }
     })
@@ -118,8 +118,8 @@ export const buildTimeseriesWithoutAggregation = ({ limit = 1000 }) => ({
         $exists: false
       }
     })
-    .indexFields(['startDate'])
-    .sortBy([{ startDate: 'desc' }])
+    .indexFields(['endDate'])
+    .sortBy([{ endDate: 'desc' }])
     .limitBy(limit)
 })
 


### PR DESCRIPTION
We have side-effects on instances already having an index on
`startDate` but without a partial index. In this situation, CouchDB will
fallback on this index, and won't apply the partial filter, leading to
unexpected results.
By the time we fix this issue in cozy-client, we use `endDate` as index
attribute.