### PR TITLE
fix: Revert partialIndex

### DIFF
--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -36,11 +36,9 @@ export const buildAccountQuery = ({
     })
     .indexFields(['account_type'])
     .limitBy(limit)
-
   if (withOnlyLogin) {
     queryDef.select(['auth.login', 'account_type'])
   }
-
   return {
     definition: queryDef,
     options: {
@@ -82,11 +80,9 @@ export const buildTimeseriesQueryByDateAndAccountId = (
     })
     .indexFields(['cozyMetadata.sourceAccount', 'startDate'])
     .limitBy(limit)
-
   if (withOnlyAggregation) {
     queryDef.select(['aggregation', 'cozyMetadata.sourceAccount', 'startDate'])
   }
-
   return {
     definition: queryDef,
     options: {
@@ -144,15 +140,17 @@ export const buildOneYearOldTimeseriesWithAggregationByAccountId =
           'cozyMetadata.sourceAccount': accountId,
           startDate: {
             $gte: dateOneYearAgoFromNow.toISOString()
-          }
-        })
-        .partialIndex({
+          },
           aggregation: {
             $exists: true
           }
         })
-        .indexFields(['cozyMetadata.sourceAccount', 'startDate'])
-        .sortBy([{ 'cozyMetadata.sourceAccount': 'asc' }, { startDate: 'asc' }])
+        .indexFields(['cozyMetadata.sourceAccount', 'startDate', 'aggregation']) // aggregation should be in partialIndex, but we need to fix https://github.com/cozy/cozy-client/issues/1054 first
+        .sortBy([
+          { 'cozyMetadata.sourceAccount': 'asc' },
+          { startDate: 'asc' },
+          { aggregation: 'asc' }
+        ])
         .select(['startDate', 'aggregation', 'cozyMetadata.sourceAccount'])
         .limitBy(1000),
       options: {


### PR DESCRIPTION
This reverts commit 516c7fce33b5a5a12b72fba2ad7877117a9f0f6d.
This is because we discovered a bug with the usage of partial indexes
that should be fixed with https://github.com/cozy/cozy-client/pull/1193
In the meantime this is merged, let's disable the partial index