### PR TITLE
feat: Update aggregation after manual edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Optimize aggregation query to select only required fields
 * Send aggregated CO2 values to the DACC under user consent
 * Add app version number and DACC alerter switch in admin mode (flag `coachco2.admin-mode`)
+* Update CO2 values after manual mode edition
 
 ## 🐛 Bug Fixes
 

--- a/src/components/EditDialogs/ModeEditDialog/helpers.js
+++ b/src/components/EditDialogs/ModeEditDialog/helpers.js
@@ -1,5 +1,6 @@
 import set from 'lodash/set'
 import cloneDeep from 'lodash/cloneDeep'
+import { computeAggregatedTimeseries } from 'src/lib/timeseries'
 
 export const createGeojsonWithModifiedMode = ({
   timeserie,
@@ -34,11 +35,15 @@ export const createGeojsonWithModifiedMode = ({
       mode
     )
 
-    return set(
+    const updatedTimeserie = set(
       cloneDeep(timeserie),
       `series[${serieIndex}].features[${firstIndex}].features[${secondIndex}]`,
       modifiedFeature
     )
+    const timeserieWithUpdatedAggregation = computeAggregatedTimeseries([
+      updatedTimeserie
+    ])[0]
+    return timeserieWithUpdatedAggregation
   }
 
   return timeserie

--- a/src/components/EditDialogs/ModeEditDialog/helpers.spec.js
+++ b/src/components/EditDialogs/ModeEditDialog/helpers.spec.js
@@ -2,7 +2,6 @@ import { createGeojsonWithModifiedMode } from './helpers'
 
 const timeserie = {
   series: [
-    { type: 'FeatureCollection', features: [] },
     {
       type: 'FeatureCollection',
       features: [
@@ -14,13 +13,21 @@ const timeserie = {
           type: 'FeatureCollection',
           features: [
             {
-              type: 'Feature'
+              type: 'Feature',
+              id: 'sectionId1',
+              properties: {
+                sensed_mode: 'PredictedModeTypes.WALKING',
+                distance: 1234,
+                duration: 302
+              }
             },
             {
               type: 'Feature',
-              id: 'sectionId',
+              id: 'sectionId2',
               properties: {
-                sensed_mode: 'PredictedModeTypes.WALKING'
+                sensed_mode: 'PredictedModeTypes.WALKING',
+                distance: 3690,
+                duration: 702
               }
             }
           ]
@@ -34,18 +41,18 @@ describe('createGeojsonWithModifiedMode', () => {
   it('should return the modified timeserie', () => {
     const modifiedTimeserie = createGeojsonWithModifiedMode({
       timeserie,
-      sectionId: 'sectionId',
+      sectionId: 'sectionId2',
       mode: 'BUS'
     })
 
     // to be sure initial timeserie is not mutated
-    expect(timeserie.series[1].features[1].features[1]).toMatchObject({
+    expect(timeserie.series[0].features[1].features[1]).toMatchObject({
       properties: {
         sensed_mode: 'PredictedModeTypes.WALKING'
       }
     })
 
-    expect(modifiedTimeserie.series[1].features[1].features[1]).toMatchObject({
+    expect(modifiedTimeserie.series[0].features[1].features[1]).toMatchObject({
       properties: {
         sensed_mode: 'PredictedModeTypes.WALKING',
         manual_mode: 'BUS'
@@ -61,5 +68,21 @@ describe('createGeojsonWithModifiedMode', () => {
     })
 
     expect(modifiedTimeserie).toMatchObject(timeserie)
+  })
+
+  it('should compute the aggregation', () => {
+    const modifiedTimeserie = createGeojsonWithModifiedMode({
+      timeserie,
+      sectionId: 'sectionId2',
+      mode: 'BUS'
+    })
+
+    expect(modifiedTimeserie).toMatchObject({
+      aggregation: {
+        totalDistance: 4924,
+        totalDuration: 1004,
+        modes: ['WALKING', 'BUS']
+      }
+    })
   })
 })

--- a/src/components/EditDialogs/PurposeEditDialog/helpers.js
+++ b/src/components/EditDialogs/PurposeEditDialog/helpers.js
@@ -15,8 +15,12 @@ export const createGeojsonWithModifiedPurpose = ({
       'properties.manual_purpose',
       purpose.toUpperCase()
     )
-
-    return set(cloneDeep(timeserie), `series[${index}]`, modifiedSerie)
+    const modifiedTimeserie = set(
+      cloneDeep(timeserie),
+      `series[${index}]`,
+      modifiedSerie
+    )
+    return set(modifiedTimeserie, 'aggregation.purpose', purpose.toUpperCase())
   }
 
   return timeserie

--- a/src/components/EditDialogs/PurposeEditDialog/helpers.spec.js
+++ b/src/components/EditDialogs/PurposeEditDialog/helpers.spec.js
@@ -1,30 +1,27 @@
 import { createGeojsonWithModifiedPurpose } from './helpers'
 
-const timeserie = {
-  series: [
-    {
-      type: 'FeatureCollection',
-      id: 'otherId',
-      features: [],
-      properties: { manual_purpose: 'HOME' }
-    },
-    {
-      type: 'FeatureCollection',
-      id: 'tripId',
-      features: [],
-      properties: { manual_purpose: 'WORK' }
-    },
-    {
-      type: 'FeatureCollection',
-      id: 'tripWithNoManualPurpose',
-      features: [],
-      properties: {}
-    }
-  ]
+const buildTimeserieWithPurpose = purpose => {
+  const timeserie = {
+    aggregation: {},
+    series: [
+      {
+        type: 'FeatureCollection',
+        id: 'tripId',
+        features: [],
+        properties: {}
+      }
+    ]
+  }
+  if (purpose) {
+    timeserie.series[0].properties = { manual_purpose: purpose }
+    timeserie.aggregation.purpose = purpose
+  }
+  return timeserie
 }
 
 describe('createGeojsonWithModifiedPurpose', () => {
   it('should return the modified timeserie', () => {
+    const timeserie = buildTimeserieWithPurpose('WORK')
     const modifiedTimeserie = createGeojsonWithModifiedPurpose({
       timeserie,
       tripId: 'tripId',
@@ -32,28 +29,29 @@ describe('createGeojsonWithModifiedPurpose', () => {
     })
 
     // to be sure initial timeserie is not mutated
-    expect(timeserie.series[1].properties.manual_purpose).toBe('WORK')
-    // to be sure other series are not impacted
-    expect(timeserie.series[0].properties.manual_purpose).toBe('HOME')
+    expect(timeserie.series[0].properties.manual_purpose).toBe('WORK')
 
-    expect(modifiedTimeserie.series[1].properties.manual_purpose).toBe(
+    expect(modifiedTimeserie.series[0].properties.manual_purpose).toBe(
       'SHOPPING'
     )
+    expect(modifiedTimeserie.aggregation.purpose).toBe('SHOPPING')
   })
 
   it("should create the manual_purpose if it doesn't exist", () => {
+    const timeserie = buildTimeserieWithPurpose()
     const modifiedTimeserie = createGeojsonWithModifiedPurpose({
       timeserie,
-      tripId: 'tripWithNoManualPurpose',
+      tripId: 'tripId',
       purpose: 'SHOPPING'
     })
 
-    expect(modifiedTimeserie.series[2].properties.manual_purpose).toBe(
+    expect(modifiedTimeserie.series[0].properties.manual_purpose).toBe(
       'SHOPPING'
     )
   })
 
   it("should returns a not modified timeserie if tripId doesn't exist", () => {
+    const timeserie = buildTimeserieWithPurpose()
     const modifiedTimeserie = createGeojsonWithModifiedPurpose({
       timeserie,
       tripId: 'idNotFound',
@@ -64,13 +62,14 @@ describe('createGeojsonWithModifiedPurpose', () => {
   })
 
   it('should create the purpose in upper case', () => {
+    const timeserie = buildTimeserieWithPurpose()
     const modifiedTimeserie = createGeojsonWithModifiedPurpose({
       timeserie,
       tripId: 'tripId',
       purpose: 'shopping'
     })
 
-    expect(modifiedTimeserie.series[1].properties.manual_purpose).toBe(
+    expect(modifiedTimeserie.series[0].properties.manual_purpose).toBe(
       'SHOPPING'
     )
   })


### PR DESCRIPTION
When the user change a mode or a purpose, the `aggregation` object should be updated accordingly to the new value