### PR TITLE
fix: Compute duration based on aggregation duration

### DIFF
--- a/src/lib/timeseries.js
+++ b/src/lib/timeseries.js
@@ -304,9 +304,8 @@ export const getTotalDuration = timeserie => {
 }
 
 export const getFormattedDuration = timeserie => {
-  const startDate = getStartDate(timeserie)
-  const endDate = getEndDate(timeserie)
-  return dateFnsFormatDistance(endDate, startDate)
+  const duration = timeserie?.aggregation?.totalDuration
+  return duration ? dateFnsFormatDistance(0, duration * 1000) : ''
 }
 
 export const getFormattedDistance = timeserie => {

--- a/src/lib/timeseries.spec.js
+++ b/src/lib/timeseries.spec.js
@@ -32,7 +32,8 @@ import {
   getFormattedTotalCO2,
   computeTotalCO2ByMode,
   computeAndFormatTotalCO2ByMode,
-  getFormattedTotalCalories
+  getFormattedTotalCalories,
+  getFormattedDuration
 } from 'src/lib/timeseries'
 
 describe('transformSerieToTrip', () => {
@@ -704,5 +705,27 @@ describe('getFormattedTotalCalories', () => {
       aggregation: { totalCalories: 22.7456 }
     })
     expect(wCalories).toBe('23 kcal')
+  })
+})
+
+describe('getFormattedDuration', () => {
+  it('should format the duration', () => {
+    expect(
+      getFormattedDuration({
+        aggregation: {
+          totalDuration: 60
+        }
+      })
+    ).toEqual('1 minute')
+    expect(
+      getFormattedDuration({
+        aggregation: {
+          totalDuration: 4000
+        }
+      })
+    ).toEqual('about 1 hour')
+  })
+  it('should handle empty duration', () => {
+    expect(getFormattedDuration({})).toEqual('')
   })
 })


### PR DESCRIPTION
There are 2 queries retrieving trips on the home page:

1. buildAggregatedTimeseriesQueryByAccountId
2. buildOneYearOldTimeseriesWithAggregationByAccountId

The first one requires both startDate and endDate attributes and is
limited to 50 results, while the second one only require startDate but
involves the whole past year.

When the second query is run, there are trips in the store without the
endDate attribute. In the meantime, the Trips component will see those
new trips and display them ; but as the endDate attribute is required,
this was causing an error and a blank page.

This behaviour raises questions about the store management that should
be discussed. In the meantime, this fixes the app issue by removing the
need of endDate.