### PR TITLE
Remove square color in tooltip for PieChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 * Locales when installing the app the first time
 * Purpose locale and icon with lowercase purpose
+* Remove square color in tooltip for PieChart
 
 ## 🔧 Tech
 

--- a/src/components/Analysis/helpers.js
+++ b/src/components/Analysis/helpers.js
@@ -24,6 +24,7 @@ export const makeChartProps = (sortedTimeseries, type, t) => {
   const options = {
     plugins: {
       tooltip: {
+        displayColors: false,
         callbacks: {
           label: tooltipItems =>
             `${tooltipItems.label} ${formatCO2(tooltipItems.raw)}`


### PR DESCRIPTION
C'est pas normal de faire ça, ça fonctionne dans cozy-ui... solution temporaire ici.

voir l'issue : https://github.com/cozy/coachCO2/issues/166