### PR TITLE
fix: Do not convert average speed for display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Locales when installing the app the first time
 * Purpose locale and icon with lowercase purpose
 * Remove square color in tooltip for PieChart
+* Fix speed values
 
 ## 🔧 Tech
 

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -42,8 +42,8 @@ export const formatDuration = (duration, lang) => {
   })
 }
 
-// The speed is given in m/s
-export const formatAvgSpeed = avgSpeed => `${Math.round(avgSpeed * 3.6)} km/h`
+// The average speed is given in km/h
+export const formatAvgSpeed = avgSpeed => `${Math.round(avgSpeed)} km/h`
 
 export const formatDate = ({ f, lang, date }) => {
   if (lang === 'fr') {


### PR DESCRIPTION
Average speed used to be computed by the front-end, that was also in
charge to convert it from m/s to km/h. This is now computed by the
backend, and the front does not need to convert it anymore.