### PR TITLE
fix: Timeline order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Purpose locale and icon with lowercase purpose
 * Remove square color in tooltip for PieChart
 * Fix speed values
+* Timeline is correctly sorted by date
 
 ## 🔧 Tech
 

--- a/src/components/Providers/TripProvider.jsx
+++ b/src/components/Providers/TripProvider.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useContext } from 'react'
+import { sortTimeserieSections } from './helpers'
 
 export const TripContext = React.createContext()
 
@@ -14,7 +15,7 @@ export const useTrip = () => {
 const TripProvider = ({ timeserie, children }) => {
   const value = useMemo(
     () => ({
-      timeserie
+      timeserie: sortTimeserieSections(timeserie)
     }),
     [timeserie]
   )

--- a/src/components/Providers/helpers.js
+++ b/src/components/Providers/helpers.js
@@ -6,3 +6,17 @@ export const saveAccountToSettings = ({ client, setting, account }) =>
     account,
     _type: SETTINGS_DOCTYPE
   })
+
+export const sortTimeserieSections = timeserie => {
+  const unorderedSections = timeserie?.aggregation?.sections
+  if (!unorderedSections) {
+    return timeserie
+  }
+  const orderedSections = unorderedSections.sort((a, b) => {
+    return new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+  })
+  const timeserieWithSortedSections = { ...timeserie }
+  timeserieWithSortedSections.aggregation.sections = orderedSections
+
+  return timeserieWithSortedSections
+}

--- a/src/components/Providers/helpers.spec.js
+++ b/src/components/Providers/helpers.spec.js
@@ -1,0 +1,37 @@
+import { sortTimeserieSections } from './helpers'
+
+describe('sortTimeserieSections', () => {
+  it('should return timeserie with sorted sections by date', () => {
+    const sections = [
+      {
+        CO2: 42,
+        startDate: '2022-01-02T12:00:00'
+      },
+      {
+        CO2: 28,
+        startDate: '2022-01-01T12:00:00'
+      },
+      {
+        CO2: 12,
+        startDate: '2022-01-01T18:00:00'
+      }
+    ]
+    const timeserie = { aggregation: { sections } }
+    const sortedTS = sortTimeserieSections(timeserie)
+    expect(sortedTS.aggregation.sections[0].startDate).toEqual(
+      '2022-01-01T12:00:00'
+    )
+    expect(sortedTS.aggregation.sections[1].startDate).toEqual(
+      '2022-01-01T18:00:00'
+    )
+    expect(sortedTS.aggregation.sections[2].startDate).toEqual(
+      '2022-01-02T12:00:00'
+    )
+  })
+
+  it('should return timeserie if there is no section', () => {
+    const timeserie = { aggregation: { sections: [] } }
+    const TS = sortTimeserieSections(timeserie)
+    expect(TS).toEqual(timeserie)
+  })
+})


### PR DESCRIPTION
The sections array might be unordered, thus it is required to sort it by
date, so it is correctly displayed to the user.