### PR TITLE
Automatic purpose detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## ✨ Features
 
+* When a trip is edited with a manual purpose, automatically detect and set purpose to similar trips
+
 ## 🐛 Bug Fixes
 
 * Vertically center the trip map on mobile when opening it

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ The doc returned from `io.cozy.timeseries.geojson` is a `timeserie`. The `series
           "$oid": "6248ec5e5d25e718233a509a"
         },
         "confidence_threshold": 0.65,
-        "manual_purpose": "ENTERTAINMENT" // Trip purpose set by the user
+        "manual_purpose": "ENTERTAINMENT", // Trip purpose set by the user
+        "automatic_purpose": "ENTERTAINMENT" // Trip purpose automatically detected
       },
       "features": [
         { // starting place
@@ -210,6 +211,40 @@ The doc returned from `io.cozy.timeseries.geojson` is a `timeserie`. The `series
     }
   ]
 }
+```
+
+### Aggregation
+
+Every timeserie is automatically aggregated by a service, to sum up the `series` content into an `aggregation` object, saved directly inside the `io.cozy.timeseries.geojson` document. Here is an example:
+
+```json
+{
+  "aggregation": {
+    "modes": [
+      "WALKING"
+    ],
+    "sections": [
+      {
+        "CO2": 0,
+        "avgSpeed": 5.204285178716263,
+        "calories": 22.83998061653227,
+        "distance": 377.40909178940984,
+        "duration": 210.9319999217987,
+        "id": "600772889801285fa1f3a7b6",
+        "mode": "WALKING",
+        "startDate": "2021-01-19T16:54:26.068Z",
+        "endDate": "2021-01-19T16:57:57.000Z"
+      }
+    ],
+    "startPlaceDisplayName": "Avenue Jean Guiton, La Rochelle",
+    "endPlaceDisplayName": "Rue Ampère, La Rochelle",
+    "totalCO2": 0,
+    "totalCalories": 22.83998061653227,
+    "totalDistance": 377.40909178940984,
+    "totalDuration": 210.9319999217987
+  }
+}
+
 ```
 
 ## DACC

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -88,6 +88,10 @@
       "type": "node",
       "file": "services/dacc/coachco2.js",
       "trigger": "@every 720h"
+    },
+    "recurringPurposes": {
+      "type": "node",
+      "file": "services/recurringPurposes/coachco2.js"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "cozy-flags": "^2.8.7",
     "cozy-intent": "^1.17.1",
     "cozy-logger": "^1.9.0",
+    "cozy-realtime": "^4.2.1",
     "cozy-ui": "^68.9.1",
     "date-fns": "^2.28.0",
     "humanize-duration": "3.27.1",

--- a/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
+++ b/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
@@ -29,6 +29,7 @@ const PurposeEditDialog = ({ onClose }) => {
 
   const handleSelect = useCallback(
     async item => {
+      const oldPurpose = getTimeseriePurpose(timeserie)
       const newTimeserie = createGeojsonWithModifiedPurpose({
         timeserie,
         tripId: getGeoJSONData(timeserie).id,
@@ -39,7 +40,7 @@ const PurposeEditDialog = ({ onClose }) => {
       startService(client, RECURRING_PURPOSES_SERVICE_NAME, {
         fields: {
           docId: newTimeserie._id,
-          purpose: newTimeserie.purpose
+          oldPurpose
         }
       })
       onClose()

--- a/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
+++ b/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
@@ -8,8 +8,9 @@ import { purposes } from 'src/components/helpers'
 import { createGeojsonWithModifiedPurpose } from 'src/components/EditDialogs/PurposeEditDialog/helpers'
 import { PurposeAvatar } from 'src/components/Avatar'
 import { useTrip } from 'src/components/Providers/TripProvider'
-import { OTHER_PURPOSE } from 'src/constants'
+import { OTHER_PURPOSE, RECURRING_PURPOSES_SERVICE_NAME } from 'src/constants'
 import { getGeoJSONData, getTimeseriePurpose } from 'src/lib/timeseries'
+import { startService } from 'src/lib/services'
 
 const makeOptions = t => {
   const options = purposes.map(purpose => ({
@@ -34,6 +35,13 @@ const PurposeEditDialog = ({ onClose }) => {
         purpose: item.id
       })
       await client.save(newTimeserie)
+      // Start service to set the purpose to similar trips
+      startService(client, RECURRING_PURPOSES_SERVICE_NAME, {
+        fields: {
+          docId: newTimeserie._id,
+          purpose: newTimeserie.purpose
+        }
+      })
       onClose()
     },
     [client, timeserie, onClose]

--- a/src/components/Trip/BottomSheet/BottomSheetContent.jsx
+++ b/src/components/Trip/BottomSheet/BottomSheetContent.jsx
@@ -20,6 +20,7 @@ import {
 import { useTrip } from 'src/components/Providers/TripProvider'
 import PurposeItem from 'src/components/Trip/BottomSheet/PurposeItem'
 import PurposeEditDialog from 'src/components/EditDialogs/PurposeEditDialog'
+import RecurringTripItem from './RecurringTripItem'
 
 const styles = {
   divider: {
@@ -34,6 +35,7 @@ const BottomSheetContent = () => {
   const [showPurposeDialog, setShowPurposeDialog] = useState(false)
 
   const purpose = getTimeseriePurpose(timeserie)
+  const isRecurring = timeserie?.aggregation?.recurring
   const openPurposeDialog = useCallback(() => setShowPurposeDialog(true), [])
   const closePurposeDialog = useCallback(() => setShowPurposeDialog(false), [])
 
@@ -60,6 +62,9 @@ const BottomSheetContent = () => {
         <PurposeItem purpose={purpose} onClick={openPurposeDialog} />
       </BottomSheetItem>
       {showPurposeDialog && <PurposeEditDialog onClose={closePurposeDialog} />}
+      <BottomSheetItem disableGutters>
+        <RecurringTripItem isRecurringTrip={isRecurring} purpose={purpose} />
+      </BottomSheetItem>
     </>
   )
 }

--- a/src/components/Trip/BottomSheet/RecurringTripItem.jsx
+++ b/src/components/Trip/BottomSheet/RecurringTripItem.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { OTHER_PURPOSE } from 'src/constants'
+
+const RecurringTripItem = ({ isRecurringTrip, purpose }) => {
+  const { t } = useI18n()
+
+  if (purpose === OTHER_PURPOSE) {
+    return null
+  }
+  return (
+    <List>
+      <ListItem className="u-c-pointer">
+        <ListItemText
+          primary={t('recurring.title')}
+          primaryTypographyProps={{ variant: 'caption' }}
+          secondary={t(
+            `recurring.${isRecurringTrip ? 'recurringTrip' : 'ocasionnalTrip'}`
+          )}
+          secondaryTypographyProps={{ variant: 'body1', color: 'textPrimary' }}
+        />
+      </ListItem>
+    </List>
+  )
+}
+
+export default RecurringTripItem

--- a/src/constants.js
+++ b/src/constants.js
@@ -173,3 +173,5 @@ export const TIMESERIE_MIGRATION_SERVICE_NAME =
   'timeseriesWithoutAggregateMigration'
 export const DACC_SERVICE_NAME = 'dacc'
 export const MAX_DACC_MEASURES_SENT = 12
+
+export const RECURRING_PURPOSES_SERVICE_NAME = 'recurringPurposes'

--- a/src/lib/dacc.js
+++ b/src/lib/dacc.js
@@ -21,7 +21,7 @@ import {
   MAX_DACC_MEASURES_SENT
 } from 'src/constants'
 import { DACC_REMOTE_DOCTYPE, DACC_REMOTE_DOCTYPE_DEV } from 'src/doctypes'
-import { restartService } from 'src/lib/services'
+import { startService } from 'src/lib/services'
 
 const { sendMeasureToDACC, fetchAggregatesFromDACC } = models.dacc
 
@@ -174,7 +174,7 @@ export const sendMeasuresForAccount = async (client, account) => {
         'warn',
         `Timeseries for ${startDate.toISOString()} does not have aggregation`
       )
-      await restartService(client, TIMESERIE_MIGRATION_SERVICE_NAME)
+      await startService(client, TIMESERIE_MIGRATION_SERVICE_NAME)
       log('info', 'Timeseries migration service started')
       return nMeasuresSent
     }

--- a/src/lib/exportTripsToCSV.js
+++ b/src/lib/exportTripsToCSV.js
@@ -7,7 +7,7 @@ import { models } from 'cozy-client'
 import {
   getStartPlaceDisplayName,
   getEndPlaceDisplayName,
-  getPurpose,
+  getManualPurpose,
   getSectionsFromTrip,
   getTripStartDate,
   getTripEndDate
@@ -70,7 +70,7 @@ export const makeTripsForExport = trips => {
           getStartPlaceDisplayName(trip),
         [COLUMNS_NAMES_CSV.tripArrivalDisplayName]:
           getEndPlaceDisplayName(trip),
-        [COLUMNS_NAMES_CSV.tripPurpose]: getPurpose(trip)
+        [COLUMNS_NAMES_CSV.tripPurpose]: getManualPurpose(trip)
       }
 
       return { ...tripData, ...sectionData }

--- a/src/lib/recurringPurposes.js
+++ b/src/lib/recurringPurposes.js
@@ -1,0 +1,175 @@
+import log from 'cozy-logger'
+
+import { getManualPurpose, getAutomaticPurpose } from 'src/lib/trips'
+import { setAutomaticPurpose } from 'src/lib/timeseries'
+import {
+  builTimeserieQueryByAccountIdAndStartPlaceAndEndPlace,
+  queryTimeserieByDocId
+} from 'src/queries/queries'
+
+// Similar trips = same start/end dipslay name
+const findSimilarTimeseries = async (client, timeserie) => {
+  const accountId = timeserie.cozyMetadata.sourceAccount
+  const startPlaceDisplayName = timeserie.aggregation.startPlaceDisplayName
+  const endPlaceDisplayName = timeserie.aggregation.endPlaceDisplayName
+  const queryDef = builTimeserieQueryByAccountIdAndStartPlaceAndEndPlace({
+    accountId,
+    startPlaceDisplayName,
+    endPlaceDisplayName
+  }).definition
+  const timeseries = await client.queryAll(queryDef)
+  return timeseries.filter(ts => ts._id !== timeserie._id)
+}
+
+export const findClosestWaybackTrips = async (client, timeserie) => {
+  const waybackTrips = []
+  const accountId = timeserie.cozyMetadata.sourceAccount
+  const startPlaceDisplayName = timeserie.aggregation.endPlaceDisplayName
+  const endPlaceDisplayName = timeserie.aggregation.startPlaceDisplayName
+  // Find closest wayback in the future
+  const queryDefForward = builTimeserieQueryByAccountIdAndStartPlaceAndEndPlace(
+    {
+      accountId,
+      startPlaceDisplayName,
+      endPlaceDisplayName,
+      startDate: timeserie.endDate,
+      searchForward: true,
+      limit: 1
+    }
+  ).definition
+  const resforward = await client.query(queryDefForward)
+  if (resforward?.data?.length > 0) {
+    waybackTrips.push(resforward.data[0])
+  }
+  // Find closest wayback in the past
+  const queryDefBackward =
+    builTimeserieQueryByAccountIdAndStartPlaceAndEndPlace({
+      accountId,
+      startPlaceDisplayName,
+      endPlaceDisplayName,
+      startDate: timeserie.endDate,
+      searchForward: false,
+      limit: 1
+    }).definition
+  const resBackward = await client.query(queryDefBackward)
+  if (resBackward?.data?.length > 0) {
+    waybackTrips.push(resBackward.data[0])
+  }
+  return waybackTrips
+}
+
+export const findAndSetWaybackTimeserie = async (client, initialTimeserie) => {
+  const waybackTrips = []
+  const closestInitialWaybackTrips = await findClosestWaybackTrips(
+    client,
+    initialTimeserie
+  )
+  if (closestInitialWaybackTrips.length > 0) {
+    const isRecurringTrip = initialTimeserie.aggregation.recurring
+    const purpose = initialTimeserie.aggregation.purpose
+    for (const waybackTrip of closestInitialWaybackTrips) {
+      waybackTrips.push(
+        setAutomaticPurpose(waybackTrip, purpose, {
+          isRecurringTrip
+        })
+      )
+    }
+  }
+  return waybackTrips
+}
+
+export const findAndSetWaybackRecurringTimeseries = async (
+  client,
+  initialTimeserie,
+  recurringTimeseries
+) => {
+  const waybacks = {}
+
+  for (const trip of recurringTimeseries) {
+    // Find way-back trips
+    const closestWaybackTrips = await findClosestWaybackTrips(client, trip)
+    for (const waybackTrip of closestWaybackTrips) {
+      if (!waybacks[waybackTrip._id])
+        // Avoid duplicates
+        waybacks[waybackTrip._id] = waybackTrip
+    }
+  }
+  return setRecurringPurposes(initialTimeserie, Object.values(waybacks))
+}
+
+const setManuallyUpdatedTrip = (timeserie, recurringTrips, waybackTrips) => {
+  const purpose = getManualPurpose(timeserie.series[0])
+  const isRecurringTrip = recurringTrips.length > 0 || waybackTrips.length > 1
+  return setAutomaticPurpose(timeserie, purpose, { isRecurringTrip })
+}
+
+export const setRecurringPurposes = (timeserie, similarTimeseries) => {
+  const purpose = getManualPurpose(timeserie.series[0])
+  if (!purpose) {
+    log.warn('No manual purpose set for the trip')
+    return []
+  }
+
+  const timeseriesToUpdate = []
+  for (const ts of similarTimeseries) {
+    const trip = ts.series[0]
+    if (getAutomaticPurpose(trip) === purpose) {
+      // No need to update trips with the same automatic purpose
+      continue
+    }
+    const newTS = setAutomaticPurpose(ts, purpose, { isRecurringTrip: true })
+    timeseriesToUpdate.push(newTS)
+  }
+
+  return timeseriesToUpdate
+}
+
+export const runReccuringPurposes = async (client, docId) => {
+  const timeserie = await queryTimeserieByDocId(client, docId)
+  if (!timeserie) {
+    log('error', 'No timeserie found')
+    return []
+  }
+  if (!getManualPurpose(timeserie.series[0])) {
+    log('error', 'No manual purpose found')
+    return []
+  }
+  if (!timeserie.aggregation) {
+    log('warn', 'Timeserie without aggregation')
+    return []
+  }
+
+  // Find similar trips and set their purpose
+  const similarTimeseries = await findSimilarTimeseries(client, timeserie)
+  const similarTimeseriesToUpdate = setRecurringPurposes(
+    timeserie,
+    similarTimeseries
+  )
+  // Find wayback trips (with reverse start/end place) and set their purpose
+  const waybackTimeseries = await findAndSetWaybackTimeserie(client, timeserie)
+  const updatedTS = setManuallyUpdatedTrip(
+    timeserie,
+    similarTimeseries,
+    waybackTimeseries
+  )
+  const recurringWaybackTimeseries = await findAndSetWaybackRecurringTimeseries(
+    client,
+    updatedTS,
+    similarTimeseries
+  )
+
+  // Save trips with new purpose
+  const timeseriesToUpdate = [
+    updatedTS,
+    ...similarTimeseriesToUpdate,
+    ...waybackTimeseries,
+    ...recurringWaybackTimeseries
+  ]
+  if (timeseriesToUpdate.length > 0) {
+    log('info', `${timeseriesToUpdate.length} trips to update`)
+    await client.saveAll(timeseriesToUpdate)
+  } else {
+    log('info', `No trip to update`)
+  }
+  return timeseriesToUpdate
+}

--- a/src/lib/recurringPurposes.js
+++ b/src/lib/recurringPurposes.js
@@ -3,73 +3,114 @@ import log from 'cozy-logger'
 import { getManualPurpose, getAutomaticPurpose } from 'src/lib/trips'
 import { setAutomaticPurpose } from 'src/lib/timeseries'
 import {
-  builTimeserieQueryByAccountIdAndStartPlaceAndEndPlace,
+  builTimeserieQueryByAccountIdAndStartPlaceAndEndPlaceAndStartDate,
   queryTimeserieByDocId
 } from 'src/queries/queries'
+import { OTHER_PURPOSE } from 'src/constants'
+
+export const filterByPurpose = (timeseries, purpose) => {
+  return timeseries
+    ? timeseries.filter(ts => {
+        if (purpose === OTHER_PURPOSE) {
+          return (
+            !ts?.aggregation?.purpose || ts?.aggregation?.purpose === purpose
+          )
+        }
+        return ts?.aggregation?.purpose === purpose
+      })
+    : []
+}
 
 // Similar trips = same start/end dipslay name
-const findSimilarTimeseries = async (client, timeserie) => {
+const findSimilarTimeseries = async (client, timeserie, { oldPurpose }) => {
   const accountId = timeserie?.cozyMetadata?.sourceAccount
   const startPlaceDisplayName = timeserie?.aggregation?.startPlaceDisplayName
   const endPlaceDisplayName = timeserie?.aggregation?.endPlaceDisplayName
-  if (!accountId || !startPlaceDisplayName || !endPlaceDisplayName) {
+  if (
+    !accountId ||
+    !startPlaceDisplayName ||
+    !endPlaceDisplayName ||
+    !oldPurpose
+  ) {
     throw new Error('Missing attributes to run query')
   }
-  const queryDef = builTimeserieQueryByAccountIdAndStartPlaceAndEndPlace({
-    accountId,
-    startPlaceDisplayName,
-    endPlaceDisplayName
-  }).definition
+  const queryDef =
+    builTimeserieQueryByAccountIdAndStartPlaceAndEndPlaceAndStartDate({
+      accountId,
+      startPlaceDisplayName,
+      endPlaceDisplayName,
+      purpose: oldPurpose
+    }).definition
   const timeseries = await client.queryAll(queryDef)
-  return timeseries.filter(ts => ts._id !== timeserie._id)
+  return filterByPurpose(
+    timeseries.filter(ts => ts._id !== timeserie._id),
+    oldPurpose
+  )
 }
 
-export const findClosestWaybackTrips = async (client, timeserie) => {
+export const findClosestWaybackTrips = async (
+  client,
+  timeserie,
+  { oldPurpose }
+) => {
   const waybackTrips = []
   const accountId = timeserie.cozyMetadata.sourceAccount
   const startPlaceDisplayName = timeserie.aggregation.endPlaceDisplayName
   const endPlaceDisplayName = timeserie.aggregation.startPlaceDisplayName
-  if (!accountId || !startPlaceDisplayName || !endPlaceDisplayName) {
+  if (
+    !accountId ||
+    !startPlaceDisplayName ||
+    !endPlaceDisplayName ||
+    !oldPurpose
+  ) {
     throw new Error('Missing attributes to run query')
   }
   // Find closest wayback in the future
-  const queryDefForward = builTimeserieQueryByAccountIdAndStartPlaceAndEndPlace(
-    {
+  const queryDefForward =
+    builTimeserieQueryByAccountIdAndStartPlaceAndEndPlaceAndStartDate({
       accountId,
       startPlaceDisplayName,
       endPlaceDisplayName,
+      purpose: oldPurpose,
       startDate: { $gt: timeserie.endDate },
       limit: 1
-    }
-  ).definition
-  const resforward = await client.query(queryDefForward)
-  if (resforward?.data?.length > 0) {
-    waybackTrips.push(resforward.data[0])
+    }).definition
+  const resForward = await client.query(queryDefForward)
+  const nextWayback = filterByPurpose(resForward?.data, oldPurpose)
+  if (nextWayback.length > 0) {
+    waybackTrips.push(nextWayback[0])
   }
   // Find closest wayback in the past
   const queryDefBackward =
-    builTimeserieQueryByAccountIdAndStartPlaceAndEndPlace({
+    builTimeserieQueryByAccountIdAndStartPlaceAndEndPlaceAndStartDate({
       accountId,
       startPlaceDisplayName,
       endPlaceDisplayName,
+      purpose: oldPurpose,
       startDate: { $lt: timeserie.startDate },
       limit: 1
     }).definition
   const resBackward = await client.query(queryDefBackward)
-  if (resBackward?.data?.length > 0) {
-    waybackTrips.push(resBackward.data[0])
+  const previousWayback = filterByPurpose(resBackward?.data, oldPurpose)
+  if (previousWayback.length > 0) {
+    waybackTrips.push(previousWayback[0])
   }
   return waybackTrips
 }
 
-export const findAndSetWaybackTimeserie = async (client, initialTimeserie) => {
+export const findAndSetWaybackTimeserie = async (
+  client,
+  initialTimeserie,
+  { oldPurpose, similarTimeseries }
+) => {
   const waybackTrips = []
   const closestInitialWaybackTrips = await findClosestWaybackTrips(
     client,
-    initialTimeserie
+    initialTimeserie,
+    { oldPurpose }
   )
   if (closestInitialWaybackTrips.length > 0) {
-    const isRecurringTrip = initialTimeserie.aggregation.recurring
+    const isRecurringTrip = similarTimeseries.length > 0
     const purpose = initialTimeserie.aggregation.purpose
     for (const waybackTrip of closestInitialWaybackTrips) {
       waybackTrips.push(
@@ -85,13 +126,20 @@ export const findAndSetWaybackTimeserie = async (client, initialTimeserie) => {
 export const findAndSetWaybackRecurringTimeseries = async (
   client,
   initialTimeserie,
-  recurringTimeseries
+  recurringTimeseries,
+  { oldPurpose, waybackInitialTimeseries }
 ) => {
   const waybacks = {}
+  // Populate with initial waybacks to avoid conflicts
+  for (const wayback of waybackInitialTimeseries) {
+    waybacks[wayback._id] = wayback
+  }
 
   for (const trip of recurringTimeseries) {
     // Find way-back trips
-    const closestWaybackTrips = await findClosestWaybackTrips(client, trip)
+    const closestWaybackTrips = await findClosestWaybackTrips(client, trip, {
+      oldPurpose
+    })
     for (const waybackTrip of closestWaybackTrips) {
       if (!waybacks[waybackTrip._id])
         // Avoid duplicates
@@ -128,7 +176,7 @@ export const setRecurringPurposes = (timeserie, similarTimeseries) => {
   return timeseriesToUpdate
 }
 
-export const runRecurringPurposes = async (client, docId) => {
+export const runRecurringPurposes = async (client, { docId, oldPurpose }) => {
   const timeserie = await queryTimeserieByDocId(client, docId)
   if (!timeserie) {
     log('error', 'No timeserie found')
@@ -147,29 +195,36 @@ export const runRecurringPurposes = async (client, docId) => {
   }
 
   // Find similar trips and set their purpose
-  const similarTimeseries = await findSimilarTimeseries(client, timeserie)
+  const similarTimeseries = await findSimilarTimeseries(client, timeserie, {
+    oldPurpose
+  })
   const similarTimeseriesToUpdate = setRecurringPurposes(
     timeserie,
     similarTimeseries
   )
   // Find wayback trips (with reverse start/end place) and set their purpose
-  const waybackTimeseries = await findAndSetWaybackTimeserie(client, timeserie)
+  const waybackInitialTimeseries = await findAndSetWaybackTimeserie(
+    client,
+    timeserie,
+    { oldPurpose, similarTimeseries }
+  )
   const updatedTS = setManuallyUpdatedTrip(
     timeserie,
     similarTimeseries,
-    waybackTimeseries
+    waybackInitialTimeseries
   )
   const recurringWaybackTimeseries = await findAndSetWaybackRecurringTimeseries(
     client,
     updatedTS,
-    similarTimeseries
+    similarTimeseries,
+    { oldPurpose, waybackInitialTimeseries }
   )
 
   // Save trips with new purpose
   const timeseriesToUpdate = [
     updatedTS,
     ...similarTimeseriesToUpdate,
-    ...waybackTimeseries,
+    ...waybackInitialTimeseries,
     ...recurringWaybackTimeseries
   ]
   if (timeseriesToUpdate.length > 0) {

--- a/src/lib/recurringPurposes.js
+++ b/src/lib/recurringPurposes.js
@@ -9,9 +9,12 @@ import {
 
 // Similar trips = same start/end dipslay name
 const findSimilarTimeseries = async (client, timeserie) => {
-  const accountId = timeserie.cozyMetadata.sourceAccount
-  const startPlaceDisplayName = timeserie.aggregation.startPlaceDisplayName
-  const endPlaceDisplayName = timeserie.aggregation.endPlaceDisplayName
+  const accountId = timeserie?.cozyMetadata?.sourceAccount
+  const startPlaceDisplayName = timeserie?.aggregation?.startPlaceDisplayName
+  const endPlaceDisplayName = timeserie?.aggregation?.endPlaceDisplayName
+  if (!accountId || !startPlaceDisplayName || !endPlaceDisplayName) {
+    throw new Error('Missing attributes to run query')
+  }
   const queryDef = builTimeserieQueryByAccountIdAndStartPlaceAndEndPlace({
     accountId,
     startPlaceDisplayName,
@@ -26,6 +29,9 @@ export const findClosestWaybackTrips = async (client, timeserie) => {
   const accountId = timeserie.cozyMetadata.sourceAccount
   const startPlaceDisplayName = timeserie.aggregation.endPlaceDisplayName
   const endPlaceDisplayName = timeserie.aggregation.startPlaceDisplayName
+  if (!accountId || !startPlaceDisplayName || !endPlaceDisplayName) {
+    throw new Error('Missing attributes to run query')
+  }
   // Find closest wayback in the future
   const queryDefForward = builTimeserieQueryByAccountIdAndStartPlaceAndEndPlace(
     {
@@ -124,11 +130,14 @@ export const setRecurringPurposes = (timeserie, similarTimeseries) => {
   return timeseriesToUpdate
 }
 
-export const runReccuringPurposes = async (client, docId) => {
+export const runRecurringPurposes = async (client, docId) => {
   const timeserie = await queryTimeserieByDocId(client, docId)
   if (!timeserie) {
     log('error', 'No timeserie found')
     return []
+  }
+  if (timeserie?.series.length != 1) {
+    throw new Error('error', 'The timeserie is malformed')
   }
   if (!getManualPurpose(timeserie.series[0])) {
     log('error', 'No manual purpose found')

--- a/src/lib/recurringPurposes.js
+++ b/src/lib/recurringPurposes.js
@@ -38,8 +38,7 @@ export const findClosestWaybackTrips = async (client, timeserie) => {
       accountId,
       startPlaceDisplayName,
       endPlaceDisplayName,
-      startDate: timeserie.endDate,
-      searchForward: true,
+      startDate: { $gt: timeserie.endDate },
       limit: 1
     }
   ).definition
@@ -53,8 +52,7 @@ export const findClosestWaybackTrips = async (client, timeserie) => {
       accountId,
       startPlaceDisplayName,
       endPlaceDisplayName,
-      startDate: timeserie.endDate,
-      searchForward: false,
+      startDate: { $lt: timeserie.startDate },
       limit: 1
     }).definition
   const resBackward = await client.query(queryDefBackward)

--- a/src/lib/recurringPurposes.spec.js
+++ b/src/lib/recurringPurposes.spec.js
@@ -1,0 +1,294 @@
+import { createMockClient } from 'cozy-client'
+import {
+  runReccuringPurposes,
+  setRecurringPurposes,
+  findAndSetWaybackRecurringTimeseries,
+  findClosestWaybackTrips,
+  findAndSetWaybackTimeserie
+} from './recurringPurposes'
+
+const mockClient = createMockClient({})
+
+const mockTimeserie = ({
+  id,
+  startDate,
+  endDate,
+  startPlace,
+  endPlace,
+  manualPurpose
+} = {}) => {
+  const ts = {
+    _id: id || 1,
+    startDate: startDate || '2021-10-01',
+    endDate: endDate || '2021-10-10',
+    aggregation: {
+      startPlaceDisplayName: startPlace || 'Bag End, The Shire',
+      endPlaceDisplayName: endPlace || 'Rivendell, Eastern Eriador',
+      purpose: manualPurpose || 'HOBBY'
+    },
+    cozyMetadata: {
+      sourceAccount: 'account-id'
+    },
+    series: [{ properties: {} }]
+  }
+  if (manualPurpose) {
+    ts.series[0].properties.manual_purpose = manualPurpose
+  }
+  return ts
+}
+const mockSimilarTimeseries = ({
+  startPlace = 'Bag End, The Shire',
+  endPlace = 'Rivendell, Eastern Eriador'
+} = {}) => {
+  return [
+    mockTimeserie({
+      id: 2,
+      startDate: '2021-12-01',
+      endDate: '2021-12-08',
+      startPlace,
+      endPlace
+    }),
+    mockTimeserie({
+      id: 3,
+      startDate: '2022-02-01',
+      endDate: '2021-02-09',
+      startPlace,
+      endPlace
+    })
+  ]
+}
+
+describe('setRecurringPurposes', () => {
+  it('should set recurring purposes to similar trips', () => {
+    const newTS = setRecurringPurposes(
+      mockTimeserie({ manualPurpose: 'HOBBY' }),
+      mockSimilarTimeseries()
+    )
+    expect(newTS.length).toBe(2)
+    expect(newTS[0]).toMatchObject({
+      aggregation: { recurring: true, purpose: 'HOBBY' },
+      series: [{ properties: { automatic_purpose: 'HOBBY' } }]
+    })
+    expect(newTS[1]).toMatchObject({
+      aggregation: { recurring: true, purpose: 'HOBBY' },
+      series: [{ properties: { automatic_purpose: 'HOBBY' } }]
+    })
+  })
+  it('should return empty array if there is no manual purpose', () => {
+    const timeserie = {
+      aggregation: {
+        startDate: '2021-10-01',
+        endDate: '2021-10-10',
+        startPlaceDisplayName: 'Bag End, The Shire',
+        endPlaceDisplayName: 'Rivendell, Eastern Eriador'
+      },
+      series: [{ properties: {} }]
+    }
+    expect(setRecurringPurposes(timeserie, [])).toEqual([])
+  })
+})
+
+describe('runReccuringPurposes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  it('should do nothing if the timeserie is not well defined', async () => {
+    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({ data: null })
+    let res = await runReccuringPurposes(mockClient, 1)
+    expect(res.length).toEqual(0)
+
+    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({
+      data: { aggregation: {}, series: [{ properties: {} }] }
+    })
+    res = await runReccuringPurposes(mockClient, 1)
+    expect(res.length).toEqual(0)
+
+    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({
+      data: { series: [{ properties: { manual_purpoes: 'HOBBY' } }] }
+    })
+    res = await runReccuringPurposes(mockClient, 1)
+    expect(res.length).toEqual(0)
+  })
+  it('should detect and save recurring trips', async () => {
+    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({
+      data: mockTimeserie({ manualPurpose: 'HOBBY' })
+    })
+    jest
+      .spyOn(mockClient, 'queryAll')
+      .mockResolvedValueOnce(mockSimilarTimeseries())
+    jest.spyOn(mockClient, 'saveAll').mockResolvedValueOnce([])
+
+    const updated = await runReccuringPurposes(mockClient, 1)
+
+    expect(updated.length).toEqual(3)
+    expect(updated[0]).toMatchObject({
+      aggregation: { recurring: true, purpose: 'HOBBY' },
+      series: [
+        { properties: { manual_purpose: 'HOBBY', automatic_purpose: 'HOBBY' } }
+      ]
+    })
+    expect(updated[1]).toMatchObject({
+      aggregation: { recurring: true, purpose: 'HOBBY' },
+      series: [{ properties: { automatic_purpose: 'HOBBY' } }]
+    })
+    expect(updated[2]).toMatchObject({
+      aggregation: { recurring: true, purpose: 'HOBBY' },
+      series: [{ properties: { automatic_purpose: 'HOBBY' } }]
+    })
+  })
+})
+
+describe('findClosestWaybackTrips', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  it('should find closest wayback trip in the future', async () => {
+    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({
+      data: [
+        mockTimeserie({
+          startPlace: 'Mount Doom, Mordor',
+          endPlace: 'Bag End, The Shire',
+          startDate: '2021-02-01',
+          endDate: '2022-02-01'
+        })
+      ]
+    })
+    const waybacks = await findClosestWaybackTrips(
+      mockClient,
+      mockTimeserie({
+        startPlace: 'Bag End, The Shire',
+        endPlace: 'Mount Doom, Mordor',
+        startDate: '2019-01-01',
+        endDate: '2020-01-01'
+      })
+    )
+    expect(waybacks.length).toEqual(1)
+    expect(waybacks[0]).toMatchObject({
+      startDate: '2021-02-01',
+      endDate: '2022-02-01'
+    })
+  })
+  it('should find closest wayback trip in the past', async () => {
+    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({ data: [] })
+    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({
+      data: [
+        mockTimeserie({
+          startPlace: 'Mount Doom, Mordor',
+          endPlace: 'Bag End, The Shire',
+          startDate: '2018-02-01',
+          endDate: '2019-02-01'
+        })
+      ]
+    })
+    const waybacks = await findClosestWaybackTrips(
+      mockClient,
+      mockTimeserie({
+        startPlace: 'Bag End, The Shire',
+        endPlace: 'Mount Doom, Mordor',
+        startDate: '2019-01-01',
+        endDate: '2020-01-01'
+      })
+    )
+    expect(waybacks.length).toEqual(1)
+    expect(waybacks[0]).toMatchObject({
+      startDate: '2018-02-01',
+      endDate: '2019-02-01'
+    })
+  })
+})
+
+describe('findAndSetWaybackTrips', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  it('should do nothing when no wayback is found', async () => {
+    jest.spyOn(mockClient, 'queryAll').mockResolvedValueOnce(null)
+    const trips = await findAndSetWaybackRecurringTimeseries(
+      mockClient,
+      mockTimeserie(),
+      mockSimilarTimeseries()
+    )
+    expect(trips).toEqual([])
+  })
+
+  it('should find and set purpose to wayback trips for initial trip', async () => {
+    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({
+      data: [
+        mockTimeserie({
+          startPlace: 'Mount Doom, Mordor',
+          endPlace: 'Bag End, The Shire'
+        })
+      ]
+    })
+    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({ data: [] })
+    const trips = await findAndSetWaybackTimeserie(
+      mockClient,
+      mockTimeserie({
+        startPlace: 'Bag End, The Shire',
+        endPlace: 'Mount Doom, Mordor',
+        manualPurpose: 'WORK'
+      })
+    )
+    expect(trips.length).toEqual(1)
+    expect(trips[0]).toMatchObject({
+      aggregation: {
+        startPlaceDisplayName: 'Mount Doom, Mordor',
+        endPlaceDisplayName: 'Bag End, The Shire'
+      },
+      series: [
+        {
+          properties: {
+            automatic_purpose: 'WORK'
+          }
+        }
+      ]
+    })
+  })
+  it('should find and set purpose to wayback trips for similar trips', async () => {
+    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({
+      data: [
+        mockTimeserie({
+          id: 3,
+          startPlace: 'Grey Havens, Lindon',
+          endPlace: 'Valinor'
+        })
+      ]
+    })
+    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({
+      data: [
+        mockTimeserie({
+          id: 4,
+          startPlace: 'Grey Havens, Lindon',
+          endPlace: 'Valinor'
+        })
+      ]
+    })
+    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({ data: [] })
+    const trips = await findAndSetWaybackRecurringTimeseries(
+      mockClient,
+      mockTimeserie({
+        startPlace: 'Valinor',
+        endPlace: 'Grey Havens, Lindon',
+        manualPurpose: 'PICK_DROP'
+      }),
+      mockSimilarTimeseries({
+        startPlace: 'Valinor',
+        endPlace: 'Grey Havens, Lindon'
+      })
+    )
+    expect(trips.length).toEqual(2)
+    expect(trips[0]).toMatchObject({
+      aggregation: {
+        startPlaceDisplayName: 'Grey Havens, Lindon',
+        endPlaceDisplayName: 'Valinor'
+      },
+      series: [
+        {
+          properties: {
+            automatic_purpose: 'PICK_DROP'
+          }
+        }
+      ]
+    })
+  })
+})

--- a/src/lib/services.js
+++ b/src/lib/services.js
@@ -1,9 +1,10 @@
 import { JOBS_DOCTYPE } from 'src/doctypes'
 import { APP_SLUG } from 'src/constants'
 
-export const restartService = async (client, serviceName) => {
+export const startService = async (client, serviceName, { fields } = {}) => {
   await client.collection(JOBS_DOCTYPE).create('service', {
     name: serviceName,
-    slug: APP_SLUG
+    slug: APP_SLUG,
+    fields
   })
 }

--- a/src/lib/timeseries.js
+++ b/src/lib/timeseries.js
@@ -350,6 +350,9 @@ export const setAutomaticPurpose = (
   purpose,
   { isRecurringTrip = true } = {}
 ) => {
+  if (!timeserie?.series?.[0]) {
+    throw new Error('Timeserie is malformed')
+  }
   const newTimeserie = { ...timeserie }
   set(newTimeserie, 'series[0].properties.automatic_purpose', purpose)
   set(newTimeserie, 'aggregation.recurring', isRecurringTrip)

--- a/src/lib/timeseries.spec.js
+++ b/src/lib/timeseries.spec.js
@@ -751,6 +751,12 @@ describe('set purpose', () => {
       series: [{ properties: { automatic_purpose: 'HOBBY' } }]
     })
   })
+
+  it('should throw when timeserie is malformed', () => {
+    const ts = { series: null }
+    expect(() => setAutomaticPurpose(ts, 'HOBBY')).toThrow()
+  })
+
   it('should properly set the given occasional automatic purpose', () => {
     const ts = { series: [{ properties: {} }] }
     expect(

--- a/src/lib/timeseries.spec.js
+++ b/src/lib/timeseries.spec.js
@@ -32,7 +32,9 @@ import {
   getFormattedTotalCO2,
   computeTotalCO2ByMode,
   computeAndFormatTotalCO2ByMode,
-  getFormattedTotalCalories
+  getFormattedTotalCalories,
+  setAggregationPurpose,
+  setAutomaticPurpose
 } from 'src/lib/timeseries'
 
 describe('transformSerieToTrip', () => {
@@ -704,5 +706,58 @@ describe('getFormattedTotalCalories', () => {
       aggregation: { totalCalories: 22.7456 }
     })
     expect(wCalories).toBe('23 kcal')
+  })
+})
+
+describe('set purpose', () => {
+  it('should set the new aggregation purpose with an automatic mode', () => {
+    const ts = {
+      series: [
+        {
+          properties: {
+            automatic_purpose: 'HOBBY'
+          }
+        }
+      ]
+    }
+    expect(setAggregationPurpose(ts)).toMatchObject({
+      aggregation: { purpose: 'HOBBY' }
+    })
+  })
+  it('should set the new aggregation purpose with a manual mode', () => {
+    const ts = {
+      series: [
+        {
+          properties: {
+            manual_purpose: 'SPORT',
+            automatic_purpose: 'HOBBY'
+          }
+        }
+      ]
+    }
+    expect(setAggregationPurpose(ts)).toMatchObject({
+      aggregation: { purpose: 'SPORT' }
+    })
+  })
+  it('should do nothing when there is no purpose', () => {
+    const ts = { series: [{ properties: {} }] }
+    expect(setAggregationPurpose(ts)).toMatchObject(ts)
+  })
+
+  it('should properly set the given recurring automatic purpose', () => {
+    const ts = { series: [{ properties: {} }] }
+    expect(setAutomaticPurpose(ts, 'HOBBY')).toMatchObject({
+      aggregation: { purpose: 'HOBBY', recurring: true },
+      series: [{ properties: { automatic_purpose: 'HOBBY' } }]
+    })
+  })
+  it('should properly set the given occasional automatic purpose', () => {
+    const ts = { series: [{ properties: {} }] }
+    expect(
+      setAutomaticPurpose(ts, 'HOBBY', { isRecurringTrip: false })
+    ).toMatchObject({
+      aggregation: { purpose: 'HOBBY', recurring: false },
+      series: [{ properties: { automatic_purpose: 'HOBBY' } }]
+    })
   })
 })

--- a/src/lib/trips.js
+++ b/src/lib/trips.js
@@ -5,8 +5,12 @@ import { UNKNOWN_MODE } from 'src/constants'
 import { modes } from 'src/components/helpers'
 import { averageSpeedKmH } from 'src/lib/helpers'
 
-export const getPurpose = trip => {
+export const getManualPurpose = trip => {
   return get(trip, 'properties.manual_purpose')
+}
+
+export const getAutomaticPurpose = trip => {
+  return trip?.properties?.automatic_purpose
 }
 
 export const getStartPlaceDisplayName = trip => {

--- a/src/lib/trips.spec.js
+++ b/src/lib/trips.spec.js
@@ -5,7 +5,11 @@ import {
   modeProps
 } from 'test/mockTrip'
 
-import { getSectionsFromTrip, getPurpose, getFeatureMode } from 'src/lib/trips'
+import {
+  getSectionsFromTrip,
+  getManualPurpose,
+  getFeatureMode
+} from 'src/lib/trips'
 
 const mockedFeatures = () => [
   mockFeature('featureId01'),
@@ -23,12 +27,12 @@ const mockedFeatures = () => [
   ])
 ]
 
-describe('getPurpose', () => {
+describe('getManualPurpose', () => {
   it('should return purpose value', () => {
     const trips = mockSerie('serieId01', mockedFeatures(), {
       manual_purpose: 'PICK_DROP'
     })
-    const purpose = getPurpose(trips)
+    const purpose = getManualPurpose(trips)
 
     expect(purpose).toBe('PICK_DROP')
   })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -50,6 +50,11 @@
     "selectPurpose": "Modify the travel purpose"
   },
   "purpose": "Reason for travel",
+  "recurring": {
+    "title": "Recurrence",
+    "recurringTrip": "Recurring trip",
+    "ocasionnalTrip": "Occasional trip"
+  },
   "analysis": {
     "mode": "CO2 emissions",
     "purpose": "CO2 emissions",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -50,6 +50,11 @@
     "selectPurpose": "Modifier le motif du déplacement"
   },
   "purpose": "Motif du déplacement",
+  "recurring": {
+    "title": "Récurrence",
+    "recurringTrip": "Déplacement habituel",
+    "ocasionnalTrip": "Déplacement occasionnel"
+  },
   "analysis": {
     "mode": "Émissions de CO2",
     "purpose": "Émissions de CO2",

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -138,42 +138,38 @@ export const buildOldestTimeseriesQueryByAccountId = accountId => ({
     .limitBy(1)
 })
 
-export const builTimeserieQueryByAccountIdAndStartPlaceAndEndPlace = ({
-  accountId,
-  startPlaceDisplayName,
-  endPlaceDisplayName,
-  startDate = { $gt: null },
-  limit = 1000
-}) => {
-  const selector = {
-    'cozyMetadata.sourceAccount': accountId,
-    'aggregation.startPlaceDisplayName': startPlaceDisplayName,
-    'aggregation.endPlaceDisplayName': endPlaceDisplayName,
-    startDate
+export const builTimeserieQueryByAccountIdAndStartPlaceAndEndPlaceAndStartDate =
+  ({
+    accountId,
+    startPlaceDisplayName,
+    endPlaceDisplayName,
+    startDate = { $gt: null },
+    limit = 1000
+  }) => {
+    const selector = {
+      'cozyMetadata.sourceAccount': accountId,
+      'aggregation.startPlaceDisplayName': startPlaceDisplayName,
+      'aggregation.endPlaceDisplayName': endPlaceDisplayName,
+      startDate
+    }
+    return {
+      definition: Q(GEOJSON_DOCTYPE)
+        .where(selector)
+        .indexFields([
+          'cozyMetadata.sourceAccount',
+          'aggregation.startPlaceDisplayName',
+          'aggregation.endPlaceDisplayName',
+          'startDate'
+        ])
+        .sortBy([
+          { 'cozyMetadata.sourceAccount': 'asc' },
+          { 'aggregation.startPlaceDisplayName': 'asc' },
+          { 'aggregation.endPlaceDisplayName': 'asc' },
+          { startDate: 'asc' }
+        ])
+        .limitBy(limit)
+    }
   }
-  return {
-    definition: Q(GEOJSON_DOCTYPE)
-      .where(selector)
-      .indexFields([
-        'cozyMetadata.sourceAccount',
-        'aggregation.startPlaceDisplayName',
-        'aggregation.endPlaceDisplayName',
-        'startDate'
-      ])
-      .partialIndex({
-        manual_purpose: {
-          $exists: false
-        }
-      })
-      .sortBy([
-        { 'cozyMetadata.sourceAccount': 'asc' },
-        { 'aggregation.startPlaceDisplayName': 'asc' },
-        { 'aggregation.endPlaceDisplayName': 'asc' },
-        { startDate: 'asc' }
-      ])
-      .limitBy(limit)
-  }
-}
 
 export const buildOneYearOldTimeseriesWithAggregationByAccountId =
   accountId => {

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -142,18 +142,14 @@ export const builTimeserieQueryByAccountIdAndStartPlaceAndEndPlace = ({
   accountId,
   startPlaceDisplayName,
   endPlaceDisplayName,
-  startDate = null,
-  searchForward = true,
+  startDate = { $gt: null },
   limit = 1000
 }) => {
-  const rangeOperatorDate = searchForward ? '$gt' : '$lt'
   const selector = {
     'cozyMetadata.sourceAccount': accountId,
     'aggregation.startPlaceDisplayName': startPlaceDisplayName,
     'aggregation.endPlaceDisplayName': endPlaceDisplayName,
-    startDate: {
-      [rangeOperatorDate]: startDate
-    }
+    startDate
   }
   return {
     definition: Q(GEOJSON_DOCTYPE)

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -10,7 +10,7 @@ import {
   createGenerateClassName
 } from '@material-ui/core/styles'
 
-import { CozyProvider } from 'cozy-client'
+import { CozyProvider, RealTimeQueries } from 'cozy-client'
 import { I18n } from 'cozy-ui/transpiled/react/I18n'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
@@ -20,6 +20,7 @@ import setupApp from 'src/targets/browser/setupApp'
 import { register as registerServiceWorker } from 'src/targets/browser/serviceWorkerRegistration'
 import App from 'src/components/App'
 import AccountProvider from 'src/components/Providers/AccountProvider'
+import { GEOJSON_DOCTYPE } from 'src/doctypes'
 
 /*
 With MUI V4, it is possible to generate deterministic class names.
@@ -38,6 +39,7 @@ const init = function () {
     <WebviewIntentProvider>
       <StylesProvider generateClassName={generateClassName}>
         <CozyProvider client={client}>
+          <RealTimeQueries doctype={GEOJSON_DOCTYPE} />
           <AccountProvider>
             <I18n lang={lang} polyglot={polyglot}>
               <MuiCozyTheme>

--- a/src/targets/browser/setupApp.jsx
+++ b/src/targets/browser/setupApp.jsx
@@ -5,6 +5,7 @@ import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
 import { getClient } from 'src/utils/client'
 import { getValues, initBar } from 'src/utils/bar'
 import flag from 'cozy-flags'
+import { RealtimePlugin } from 'cozy-realtime'
 
 /**
  * Memoize this function in its own file so that it is correctly memoized
@@ -15,6 +16,7 @@ const setupApp = memoize(() => {
   const polyglot = initTranslation(lang, lang => require(`locales/${lang}`))
   const client = getClient()
   client.registerPlugin(flag.plugin)
+  client.registerPlugin(RealtimePlugin)
 
   initBar({ client, root, lang, appName })
 

--- a/src/targets/services/dacc.js
+++ b/src/targets/services/dacc.js
@@ -3,7 +3,7 @@ import log from 'cozy-logger'
 import schema from 'src/doctypes'
 
 import { runDACCService } from 'src/lib/dacc'
-import { restartService } from 'src/lib/services'
+import { startService } from 'src/lib/services'
 import { DACC_SERVICE_NAME } from 'src/constants'
 
 import fetch from 'node-fetch'
@@ -16,7 +16,7 @@ const dacc = async () => {
   const shouldRestart = await runDACCService(client)
   if (shouldRestart) {
     log('info', 'There are more DACC measures to send: restart the service')
-    await restartService(client, DACC_SERVICE_NAME)
+    await startService(client, DACC_SERVICE_NAME)
   }
 }
 

--- a/src/targets/services/recurringPurposes.js
+++ b/src/targets/services/recurringPurposes.js
@@ -17,13 +17,13 @@ const recurringPurposes = async () => {
   const client = CozyClient.fromEnv(process.env, { schema })
 
   const fields = JSON.parse(process.env.COZY_FIELDS || '{}')
-  const { docId } = fields
-
-  if (!docId) {
-    log('error', 'No docId provided to the service')
+  const { docId, oldPurpose } = fields
+  if (!docId || !oldPurpose) {
+    log('error', 'No docId or purpose provided to the service')
     return
   }
-  await runRecurringPurposes(client, docId)
+
+  await runRecurringPurposes(client, { docId, oldPurpose })
 }
 
 recurringPurposes().catch(e => {

--- a/src/targets/services/recurringPurposes.js
+++ b/src/targets/services/recurringPurposes.js
@@ -2,7 +2,7 @@ import CozyClient from 'cozy-client'
 import log from 'cozy-logger'
 import schema from 'src/doctypes'
 
-import { runReccuringPurposes } from 'src/lib/recurringPurposes'
+import { runRecurringPurposes } from 'src/lib/recurringPurposes'
 
 import fetch from 'node-fetch'
 global.fetch = fetch
@@ -23,7 +23,7 @@ const recurringPurposes = async () => {
     log('error', 'No docId provided to the service')
     return
   }
-  await runReccuringPurposes(client, docId)
+  await runRecurringPurposes(client, docId)
 }
 
 recurringPurposes().catch(e => {

--- a/src/targets/services/recurringPurposes.js
+++ b/src/targets/services/recurringPurposes.js
@@ -1,0 +1,32 @@
+import CozyClient from 'cozy-client'
+import log from 'cozy-logger'
+import schema from 'src/doctypes'
+
+import { runReccuringPurposes } from 'src/lib/recurringPurposes'
+
+import fetch from 'node-fetch'
+global.fetch = fetch
+
+/**
+ * This service detects recurring trips and set automatic purpose.
+ * It is triggered when the user edits a manual purpose.
+ *
+ */
+const recurringPurposes = async () => {
+  log('info', 'Start recurringPurposes service')
+  const client = CozyClient.fromEnv(process.env, { schema })
+
+  const fields = JSON.parse(process.env.COZY_FIELDS || '{}')
+  const { docId } = fields
+
+  if (!docId) {
+    log('error', 'No docId provided to the service')
+    return
+  }
+  await runReccuringPurposes(client, docId)
+}
+
+recurringPurposes().catch(e => {
+  log('critical', e)
+  process.exit(1)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1606,7 +1606,7 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cozy/minilog@1.0.0":
+"@cozy/minilog@1.0.0", "@cozy/minilog@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@cozy/minilog/-/minilog-1.0.0.tgz#1acc1aad849261e931e255a5f181b638315f7b84"
   integrity sha512-IkDHF9CLh0kQeSEVsou59ar/VehvenpbEUjLfwhckJyOUqZnKAWmXy8qrBgMT5Loxr8Xjs2wmMnj0D67wP00eQ==
@@ -4955,6 +4955,13 @@ cozy-device-helper@^2.1.0:
   dependencies:
     lodash "^4.17.19"
 
+cozy-device-helper@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-2.2.1.tgz#d5822afd818919fa871527e6f78b0265fc1e009b"
+  integrity sha512-1zVQag2OI+6sEGEC70w77urnk4GpWa/ncvCYuyrOOgib4bH6v2YbBrymOD9T3MH0yVF/LVMnXnugSHQfhNLVhA==
+  dependencies:
+    lodash "^4.17.19"
+
 cozy-doctypes@1.39.0:
   version "1.39.0"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.39.0.tgz#edbd8b7575d858ce5305c0e7c6d14cf6c44b6d83"
@@ -5093,6 +5100,14 @@ cozy-realtime@3.2.1:
   integrity sha512-Ff1vQ8vxam5aH9GmL6+YgEApV40aku7Z84yTdfcEUaOYo4OJ+n40P0EUsQoqgpA2suGONdUfvJ+FnS0aha+9nw==
   dependencies:
     minilog "3.1.0"
+
+cozy-realtime@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-4.2.1.tgz#b42fe82057bd1aae4f227d7987f207eacb169984"
+  integrity sha512-YuyT8DfzInyzt5dW4Acb+nxU0lIMQ4aGveZyx2pTjpYVpRf8xYDz0zPkcxVugfEgSstZBfFtcXKS1+9i4QcjMw==
+  dependencies:
+    "@cozy/minilog" "^1.0.0"
+    cozy-device-helper "^2.2.1"
 
 cozy-release@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
This service is used to detect similar/recurring trips compared to a
trip with a manual purpose.
The detected recurring trips are then updated with this manual purpose
and are magically displayed in realtime to the user.

Note the recurring trips detection is very naïve for now: we simply
detect trips with the same (or reverse) start/end displayed place.
This is a first step and eventually will be improved later.
