### PR TITLE
fix: Add endDate in retrieved fields for trips query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 🐛 Bug Fixes
 
 * Vertically center the trip map on mobile when opening it
+* Fix app crashes due to missing field in query
 
 ## 🔧 Tech
 

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -95,7 +95,12 @@ export const buildTimeseriesQueryByDateAndAccountId = (
         $exists: true
       }
     })
-    .select(['aggregation', 'cozyMetadata.sourceAccount', 'startDate'])
+    .select([
+      'aggregation',
+      'cozyMetadata.sourceAccount',
+      'startDate',
+      'endDate'
+    ])
     .indexFields(['cozyMetadata.sourceAccount', 'startDate'])
     .limitBy(limit)
 


### PR DESCRIPTION
This attribute is necessary to compute trip duration, which was
causing random crash of the app, probably because of concurrent queries
timing.