### PR TITLE
feat: Ask user for recurring trip 

### DIFF
--- a/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
+++ b/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
@@ -1,16 +1,21 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
 import { useClient } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import NestedSelectModal from 'cozy-ui/transpiled/react/NestedSelect/Modal'
 
 import { purposes } from 'src/components/helpers'
-import { createGeojsonWithModifiedPurpose } from 'src/components/EditDialogs/PurposeEditDialog/helpers'
 import { PurposeAvatar } from 'src/components/Avatar'
 import { useTrip } from 'src/components/Providers/TripProvider'
 import { OTHER_PURPOSE, RECURRING_PURPOSES_SERVICE_NAME } from 'src/constants'
-import { getGeoJSONData, getTimeseriePurpose } from 'src/lib/timeseries'
+import {
+  getTimeseriePurpose,
+  setAutomaticPurpose,
+  setManualPurpose
+} from 'src/lib/timeseries'
 import { startService } from 'src/lib/services'
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { Button } from 'cozy-ui/transpiled/react/Button'
 
 const makeOptions = t => {
   const options = purposes.map(purpose => ({
@@ -18,35 +23,67 @@ const makeOptions = t => {
     title: t(`trips.purposes.${purpose}`),
     icon: <PurposeAvatar attribute={purpose} />
   }))
-
   return { children: options }
 }
 
 const PurposeEditDialog = ({ onClose }) => {
+  const [showRecurringDialog, setShowRecurringDialog] = useState(false)
+  const [selectedPurpose, setSelectedPurpose] = useState(null)
   const { t } = useI18n()
   const client = useClient()
   const { timeserie } = useTrip()
 
   const handleSelect = useCallback(
     async item => {
+      setSelectedPurpose(item.id)
       const oldPurpose = getTimeseriePurpose(timeserie)
-      const newTimeserie = createGeojsonWithModifiedPurpose({
-        timeserie,
-        tripId: getGeoJSONData(timeserie).id,
-        purpose: item.id
-      })
-      await client.save(newTimeserie)
-      // Start service to set the purpose to similar trips
-      startService(client, RECURRING_PURPOSES_SERVICE_NAME, {
-        fields: {
-          docId: newTimeserie._id,
-          oldPurpose
-        }
-      })
+      if (oldPurpose !== OTHER_PURPOSE) {
+        setShowRecurringDialog(true)
+        return
+      }
+      handleRecurringTrip({ purpose: item.id, oldPurpose })
+
       onClose()
     },
     [client, timeserie, onClose]
   )
+
+  const saveTripWithPurpose = async ({ purpose, isRecurringTrip } = {}) => {
+    let newTimeserie = { ...timeserie }
+    if (isRecurringTrip) {
+      newTimeserie = setAutomaticPurpose(newTimeserie, purpose, {
+        isRecurringTrip
+      })
+    }
+    newTimeserie = setManualPurpose(newTimeserie, purpose, {
+      isRecurringTrip
+    })
+    await client.save(newTimeserie)
+  }
+
+  const handleOccasionalTrip = async () => {
+    await saveTripWithPurpose({
+      purpose: selectedPurpose,
+      isRecurringTrip: false
+    })
+    onClose()
+  }
+
+  const handleRecurringTrip = async ({ purpose, oldPurpose } = {}) => {
+    await saveTripWithPurpose({
+      purpose: purpose || selectedPurpose,
+      isRecurringTrip: true
+    })
+
+    // Start service to set the purpose to similar trips
+    startService(client, RECURRING_PURPOSES_SERVICE_NAME, {
+      fields: {
+        docId: timeserie._id,
+        oldPurpose: oldPurpose || getTimeseriePurpose(timeserie)
+      }
+    })
+    onClose()
+  }
 
   const isSelected = useMemo(
     () => item => {
@@ -58,6 +95,30 @@ const PurposeEditDialog = ({ onClose }) => {
     [timeserie]
   )
 
+  if (showRecurringDialog) {
+    return (
+      <ConfirmDialog
+        open={showRecurringDialog}
+        onClose={onClose}
+        title={t('recurring.confirmDialog.title')}
+        content={t('recurring.confirmDialog.content')}
+        actions={
+          <>
+            <Button
+              theme="secondary"
+              label={t('recurring.confirmDialog.decline')}
+              onClick={handleOccasionalTrip}
+            />
+            <Button
+              theme="primary"
+              label={t('recurring.confirmDialog.confirm')}
+              onClick={handleRecurringTrip}
+            />
+          </>
+        }
+      />
+    )
+  }
   return (
     <NestedSelectModal
       title={t('tripEdit.selectPurpose')}

--- a/src/components/Trip/TripDialogDesktop.jsx
+++ b/src/components/Trip/TripDialogDesktop.jsx
@@ -24,7 +24,7 @@ const styles = {
 
 const TripDialogDesktop = ({ timeserieId, setShowTripDialog }) => {
   const timeserieQuery = buildTimeserieQueryById(timeserieId)
-  const { data: timeseries, ...timeseriesQueryResult } = useQuery(
+  const { data: timeserie, ...timeseriesQueryResult } = useQuery(
     timeserieQuery.definition,
     timeserieQuery.options
   )
@@ -37,11 +37,11 @@ const TripDialogDesktop = ({ timeserieId, setShowTripDialog }) => {
   )
 
   return (
-    <TripProvider timeserie={isLoading ? '' : timeseries[0]}>
+    <TripProvider timeserie={isLoading ? '' : timeserie}>
       <Dialog
         open={true}
         onClose={hideModal}
-        title={isLoading ? '' : getEndPlaceDisplayName(timeseries[0])}
+        title={isLoading ? '' : getEndPlaceDisplayName(timeserie)}
         size="large"
         content={
           isLoading ? (

--- a/src/components/Views/Trip.jsx
+++ b/src/components/Views/Trip.jsx
@@ -27,7 +27,7 @@ const Trip = () => {
   }
 
   return (
-    <TripProvider timeserie={data[0]}>
+    <TripProvider timeserie={data}>
       <TripDialogMobile />
     </TripProvider>
   )

--- a/src/lib/recurringPurposes.js
+++ b/src/lib/recurringPurposes.js
@@ -130,20 +130,20 @@ export const findAndSetWaybackRecurringTimeseries = async (
   { oldPurpose, waybackInitialTimeseries }
 ) => {
   const waybacks = {}
-  // Populate with initial waybacks to avoid conflicts
-  for (const wayback of waybackInitialTimeseries) {
-    waybacks[wayback._id] = wayback
-  }
-
+  const waybackInitialIds = waybackInitialTimeseries.map(ts => ts._id)
   for (const trip of recurringTimeseries) {
     // Find way-back trips
     const closestWaybackTrips = await findClosestWaybackTrips(client, trip, {
       oldPurpose
     })
     for (const waybackTrip of closestWaybackTrips) {
-      if (!waybacks[waybackTrip._id])
+      if (
+        !waybacks[waybackTrip._id] &&
+        !waybackInitialIds.includes(waybackTrip._id)
+      ) {
         // Avoid duplicates
         waybacks[waybackTrip._id] = waybackTrip
+      }
     }
   }
   return setRecurringPurposes(initialTimeserie, Object.values(waybacks))
@@ -219,7 +219,6 @@ export const runRecurringPurposes = async (client, { docId, oldPurpose }) => {
     similarTimeseries,
     { oldPurpose, waybackInitialTimeseries }
   )
-
   // Save trips with new purpose
   const timeseriesToUpdate = [
     updatedTS,

--- a/src/lib/timeseries.js
+++ b/src/lib/timeseries.js
@@ -285,11 +285,11 @@ export const sortTimeseriesByCO2GroupedByPurpose = aggregatedTimeseries => {
 }
 
 export const getStartDate = timeserie => {
-  return new Date(timeserie.startDate)
+  return timeserie.startDate ? new Date(timeserie.startDate) : null
 }
 
 export const getEndDate = timeserie => {
-  return new Date(timeserie.endDate)
+  return timeserie.endDate ? new Date(timeserie.endDate) : null
 }
 
 export const getStartPlaceDisplayName = timeserie => {

--- a/src/lib/timeseries.spec.js
+++ b/src/lib/timeseries.spec.js
@@ -34,7 +34,8 @@ import {
   computeAndFormatTotalCO2ByMode,
   getFormattedTotalCalories,
   setAggregationPurpose,
-  setAutomaticPurpose
+  setAutomaticPurpose,
+  setManualPurpose
 } from 'src/lib/timeseries'
 
 describe('transformSerieToTrip', () => {
@@ -712,6 +713,9 @@ describe('getFormattedTotalCalories', () => {
 describe('set purpose', () => {
   it('should set the new aggregation purpose with an automatic mode', () => {
     const ts = {
+      aggregation: {
+        recurring: true
+      },
       series: [
         {
           properties: {
@@ -757,13 +761,23 @@ describe('set purpose', () => {
     expect(() => setAutomaticPurpose(ts, 'HOBBY')).toThrow()
   })
 
-  it('should properly set the given occasional automatic purpose', () => {
+  it('should properly set the given manual purpose with no recurrence', () => {
     const ts = { series: [{ properties: {} }] }
+    expect(setManualPurpose(ts, 'HOBBY')).toMatchObject({
+      aggregation: { purpose: 'HOBBY' },
+      series: [{ properties: { manual_purpose: 'HOBBY' } }]
+    })
+  })
+
+  it('should properly set the given manual purpose with recurrence', () => {
+    const ts = { series: [{ properties: { automatic_purpose: 'SPORT' } }] }
     expect(
-      setAutomaticPurpose(ts, 'HOBBY', { isRecurringTrip: false })
+      setManualPurpose(ts, 'HOBBY', { isRecurringTrip: true })
     ).toMatchObject({
-      aggregation: { purpose: 'HOBBY', recurring: false },
-      series: [{ properties: { automatic_purpose: 'HOBBY' } }]
+      aggregation: { purpose: 'SPORT', recurring: true },
+      series: [
+        { properties: { manual_purpose: 'HOBBY', automatic_purpose: 'SPORT' } }
+      ]
     })
   })
 })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -53,7 +53,13 @@
   "recurring": {
     "title": "Recurrence",
     "recurringTrip": "Recurring trip",
-    "ocasionnalTrip": "Occasional trip"
+    "ocasionnalTrip": "Occasional trip",
+    "confirmDialog": {
+      "title": "Is it a regular trip?",
+      "content": "If yes, this trip will be set as recurring and its purpose will be used for similar trips.",
+      "confirm": "Yes",
+      "decline": "No"
+    }
   },
   "analysis": {
     "mode": "CO2 emissions",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -53,7 +53,13 @@
   "recurring": {
     "title": "Récurrence",
     "recurringTrip": "Déplacement habituel",
-    "ocasionnalTrip": "Déplacement occasionnel"
+    "ocasionnalTrip": "Déplacement occasionnel",
+    "confirmDialog": {
+      "title": "Faîtes-vous régulièrement ce déplacement ?",
+      "content": "Si oui, son motif sera considéré comme récurrent et son motif sera appliqué aux déplacements équivalents.",
+      "confirm": "Oui",
+      "decline": "Non"
+    }
   },
   "analysis": {
     "mode": "Émissions de CO2",

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -194,7 +194,12 @@ export const buildOneYearOldTimeseriesWithAggregationByAccountId =
             $exists: true
           }
         })
-        .select(['startDate', 'aggregation', 'cozyMetadata.sourceAccount'])
+        .select([
+          'startDate',
+          'endDate',
+          'aggregation',
+          'cozyMetadata.sourceAccount'
+        ])
         .indexFields(['cozyMetadata.sourceAccount', 'startDate'])
         .sortBy([{ 'cozyMetadata.sourceAccount': 'asc' }, { startDate: 'asc' }])
         .limitBy(1000),

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -64,7 +64,8 @@ export const buildTimeserieQueryById = timeserieId => ({
   definition: Q(GEOJSON_DOCTYPE).getById(timeserieId),
   options: {
     as: `${GEOJSON_DOCTYPE}/${timeserieId}`,
-    fetchPolicy: CozyClient.fetchPolicies.olderThan(older30s)
+    fetchPolicy: CozyClient.fetchPolicies.olderThan(older30s),
+    singleDocData: true
   }
 })
 


### PR DESCRIPTION
When the user wants to edit the purpose of a trip, a modal is now used
to know if the trip is recurring or not. If this is the case, the
recurring service is started. 

We take advantage of this to exclude explicit non-recurring trips from the automatic purpose detection.