### PR TITLE
fix: Remove useless permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Vertically center the trip map on mobile when opening it
 * Fix app crashes due to missing field in query
+* Remove unused Contacts permission
 
 ## 🔧 Tech
 

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -56,11 +56,6 @@
       "type": "io.cozy.coachco2.settings",
       "verbs": ["GET", "POST", "PUT"]
     },
-    "contacts": {
-      "description": "Used to manage your Coach CO2 settings",
-      "type": "io.cozy.contacts",
-      "verbs": ["POST"]
-    },
     "jobs": {
       "description": "Used in services to start other services",
       "type": "io.cozy.jobs",


### PR DESCRIPTION
Mistakenly added by https://github.com/cozy/coachCO2/commit/a6baf1d0e7c5df11cf2e19d71c537d57944fd44d probably because of the BC listed in https://github.com/cozy/cozy-ui/blob/master/CHANGELOG.md#breaking-changes-6 (but not relevant here as the `ContactsListModal` is not used 