### PR TITLE
feat: Start recurring service after trips creation

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -77,7 +77,7 @@
       "type": "node",
       "file": "services/timeseriesWithoutAggregateMigration/coachco2.js",
       "trigger": "@event io.cozy.timeseries.geojson:CREATED,UPDATED",
-      "debounce": "5m"
+      "debounce": "1m"
     },
     "dacc": {
       "type": "node",
@@ -86,7 +86,9 @@
     },
     "recurringPurposes": {
       "type": "node",
-      "file": "services/recurringPurposes/coachco2.js"
+      "file": "services/recurringPurposes/coachco2.js",
+      "trigger": "@event io.cozy.timeseries.geojson:CREATED",
+      "debounce": "2m"
     }
   }
 }

--- a/src/hooks/useExportTripsToCSV.jsx
+++ b/src/hooks/useExportTripsToCSV.jsx
@@ -7,7 +7,7 @@ import {
   getAccountLabel,
   useAccountContext
 } from 'src/components/Providers/AccountProvider'
-import { buildTimeseriesQueryByAccountId } from 'src/queries/queries'
+import { buildTimeseriesQueryByAccountIdAndDate } from 'src/queries/queries'
 import { uploadFile } from 'src/lib/exportTripsToCSV'
 
 const useExportTripsToCSV = () => {
@@ -22,7 +22,7 @@ const useExportTripsToCSV = () => {
     isLoading: true
   })
 
-  const timeseriesQuery = buildTimeseriesQueryByAccountId({
+  const timeseriesQuery = buildTimeseriesQueryByAccountIdAndDate({
     accountId: account?._id,
     limitBy: 1000
   })

--- a/src/lib/recurringPurposes.js
+++ b/src/lib/recurringPurposes.js
@@ -4,25 +4,80 @@ import log from 'cozy-logger'
 import { getManualPurpose, getAutomaticPurpose } from 'src/lib/trips'
 import { setAutomaticPurpose } from 'src/lib/timeseries'
 import {
+  buildNewestRecurringTimeseriesQuery,
+  buildSettingsQuery,
+  buildTimeseriesQueryByAccountIdAndDate,
   builTimeserieQueryByAccountIdAndStartPlaceAndEndPlaceAndStartDate,
   queryTimeserieByDocId
 } from 'src/queries/queries'
 import { OTHER_PURPOSE } from 'src/constants'
+import { set } from 'lodash'
 
-export const filterByPurposeAndRecurrence = (timeseries, purpose) => {
+/**
+ * Filter timeseries to keep those with recurring purposes
+ *
+ * @param {Array<object>} timeseries - The timeseries to filter
+ * @returns {Array<object>} The filtered timeseries
+ */
+export const keepTripsWithRecurringPurposes = timeseries => {
+  return timeseries.filter(ts => {
+    if (ts?.aggregation?.recurring === false) {
+      return false
+    }
+    return (
+      ts?.aggregation?.purpose && ts?.aggregation?.purpose !== OTHER_PURPOSE
+    )
+  })
+}
+
+/**
+ * Filter timeseries to keep those with the same given purpose,
+ * with those additional rules:
+ *
+ * - Trips with explicit 'recurring: false' should be excluded
+ * - When the purpose is OTHER_PURPOSE, we include trips with missing purpose
+ *
+ * @param {Array<object>} timeseries - The timeseries to filter
+ * @param {string} purpose - The searched purpose
+ * @returns {Array<object>} The filtered timeseries
+ */
+export const keepTripsWithSameRecurringPurpose = (timeseries, purpose) => {
   return timeseries
     ? timeseries.filter(ts => {
+        if (ts?.aggregation?.recurring === false) {
+          return false
+        }
         if (purpose === OTHER_PURPOSE) {
           return (
             !ts?.aggregation?.purpose || ts?.aggregation?.purpose === purpose
           )
         }
-        return (
-          ts?.aggregation?.purpose === purpose &&
-          ts.aggregation?.recurring !== false
-        )
+        return ts?.aggregation?.purpose === purpose
       })
     : []
+}
+
+const queryTimeseriesByPlaceAndDate = async (
+  client,
+  {
+    accountId,
+    startPlaceDisplayName,
+    endPlaceDisplayName,
+    _id,
+    oldPurpose = null
+  }
+) => {
+  const queryDef =
+    builTimeserieQueryByAccountIdAndStartPlaceAndEndPlaceAndStartDate({
+      accountId,
+      startPlaceDisplayName,
+      endPlaceDisplayName
+    }).definition
+  const results = await client.queryAll(queryDef)
+  const timeseries = results.filter(ts => ts._id !== _id)
+  return !oldPurpose
+    ? keepTripsWithRecurringPurposes(timeseries)
+    : keepTripsWithSameRecurringPurpose(timeseries, oldPurpose)
 }
 
 // Similar trips = same start/end dipslay name
@@ -34,26 +89,28 @@ const findSimilarTimeseries = async (
   const accountId = timeserie?.cozyMetadata?.sourceAccount
   const startPlaceDisplayName = timeserie?.aggregation?.startPlaceDisplayName
   const endPlaceDisplayName = timeserie?.aggregation?.endPlaceDisplayName
-  if (
-    !accountId ||
-    !startPlaceDisplayName ||
-    !endPlaceDisplayName ||
-    !oldPurpose
-  ) {
+  if (!accountId || !startPlaceDisplayName || !endPlaceDisplayName) {
     throw new Error('Missing attributes to run query')
   }
-  const queryDef =
-    builTimeserieQueryByAccountIdAndStartPlaceAndEndPlaceAndStartDate({
-      accountId,
-      startPlaceDisplayName,
-      endPlaceDisplayName,
-      purpose: oldPurpose
-    }).definition
-  const timeseries = await client.queryAll(queryDef)
-  return filterByPurposeAndRecurrence(
-    timeseries.filter(ts => ts._id !== timeserie._id),
-    oldPurpose
-  )
+  return queryTimeseriesByPlaceAndDate(client, {
+    accountId,
+    startPlaceDisplayName,
+    endPlaceDisplayName,
+    oldPurpose,
+    _id: timeserie._id
+  })
+}
+
+const findWaybackTimeseries = async (client, timeserie) => {
+  const accountId = timeserie?.cozyMetadata?.sourceAccount
+  const startPlaceDisplayName = timeserie.aggregation.endPlaceDisplayName
+  const endPlaceDisplayName = timeserie.aggregation.startPlaceDisplayName
+  return queryTimeseriesByPlaceAndDate(client, {
+    accountId,
+    startPlaceDisplayName,
+    endPlaceDisplayName,
+    _id: timeserie._id
+  })
 }
 
 export const findClosestWaybackTrips = async (
@@ -78,7 +135,10 @@ export const findClosestWaybackTrips = async (
       limit: 1
     }).definition
   const resForward = await client.query(queryDefForward)
-  const nextWayback = filterByPurposeAndRecurrence(resForward?.data, oldPurpose)
+  const nextWayback = keepTripsWithSameRecurringPurpose(
+    resForward?.data,
+    oldPurpose
+  )
   if (nextWayback.length > 0) {
     waybackTrips.push(nextWayback[0])
   }
@@ -93,7 +153,7 @@ export const findClosestWaybackTrips = async (
       limit: 1
     }).definition
   const resBackward = await client.query(queryDefBackward)
-  const previousWayback = filterByPurposeAndRecurrence(
+  const previousWayback = keepTripsWithSameRecurringPurpose(
     resBackward?.data,
     oldPurpose
   )
@@ -175,8 +235,39 @@ export const setRecurringPurposes = (timeserie, similarTimeseries) => {
   return timeseriesToUpdate
 }
 
-export const runRecurringPurposes = async (client, { docId, oldPurpose }) => {
-  const timeserie = await queryTimeserieByDocId(client, docId)
+const getTimeserieWithPurpose = timeseries => {
+  return timeseries.find(ts => {
+    const purpose = ts?.aggregation?.purpose
+    return purpose && purpose !== OTHER_PURPOSE
+  })
+}
+
+const isLoopTrip = timeserie => {
+  return (
+    timeserie?.aggregation?.startPlaceDisplayName ===
+    timeserie?.aggregation?.endPlaceDisplayName
+  )
+}
+
+export const findPurposeFromSimilarTimeserieAndWaybacks = async (
+  client,
+  timeserie
+) => {
+  const similarTimeseries = await findSimilarTimeseries(client, timeserie)
+  let tsWithPurpose = getTimeserieWithPurpose(similarTimeseries)
+  if (!tsWithPurpose) {
+    // if no similar trips with purpose found, try with waybacks trips
+    const waybackTimeseries = await findWaybackTimeseries(client, timeserie)
+    tsWithPurpose = getTimeserieWithPurpose(waybackTimeseries)
+  }
+  return tsWithPurpose?.aggregation?.purpose || null
+}
+
+const findRecurringTripsFromTimeserie = async (
+  client,
+  timeserie,
+  { oldPurpose }
+) => {
   if (!timeserie) {
     log('error', 'No timeserie found')
     return []
@@ -192,7 +283,6 @@ export const runRecurringPurposes = async (client, { docId, oldPurpose }) => {
     log('warn', 'Timeserie without aggregation')
     return []
   }
-
   // Find similar trips and set their purpose
   const similarTimeseries = await findSimilarTimeseries(client, timeserie, {
     oldPurpose
@@ -202,40 +292,128 @@ export const runRecurringPurposes = async (client, { docId, oldPurpose }) => {
     similarTimeseries
   )
   log('info', `Found ${similarTimeseries.length} similar timeseries`)
-
-  // Find wayback trips (with reverse start/end place) and set their purpose
-  const waybackInitialTimeseries = await findAndSetWaybackTimeserie(
-    client,
-    timeserie,
-    { oldPurpose, similarTimeseries }
-  )
-
   const updatedTS = setManuallyUpdatedTrip(timeserie)
-  const recurringWaybackTimeseries = await findAndSetWaybackRecurringTimeseries(
-    client,
-    updatedTS,
-    similarTimeseries,
-    { oldPurpose, waybackInitialTimeseries }
-  )
-  log(
-    'info',
-    `Found ${
-      waybackInitialTimeseries.length + recurringWaybackTimeseries.length
-    } wayback timeseries`
-  )
 
-  // Save trips with new purpose
-  const timeseriesToUpdate = [
-    updatedTS,
-    ...similarTimeseriesToUpdate,
-    ...waybackInitialTimeseries,
-    ...recurringWaybackTimeseries
-  ]
+  let timeseriesToUpdate = []
+  if (!isLoopTrip(timeserie)) {
+    // Find wayback trips (with reverse start/end place) and set their purpose
+    const waybackInitialTimeseries = await findAndSetWaybackTimeserie(
+      client,
+      timeserie,
+      { oldPurpose }
+    )
+
+    const recurringWaybackTimeseries =
+      await findAndSetWaybackRecurringTimeseries(
+        client,
+        updatedTS,
+        similarTimeseries,
+        { oldPurpose, waybackInitialTimeseries }
+      )
+    log(
+      'info',
+      `Found ${
+        waybackInitialTimeseries.length + recurringWaybackTimeseries.length
+      } wayback timeseries`
+    )
+    timeseriesToUpdate = [
+      updatedTS,
+      ...similarTimeseriesToUpdate,
+      ...waybackInitialTimeseries,
+      ...recurringWaybackTimeseries
+    ]
+  } else {
+    // Do not search for wayback for loop trips
+    timeseriesToUpdate = [updatedTS, ...similarTimeseriesToUpdate]
+  }
+
+  return timeseriesToUpdate
+}
+
+const saveTrips = async (client, timeseriesToUpdate) => {
   if (timeseriesToUpdate.length > 0) {
     log('info', `${timeseriesToUpdate.length} trips to update`)
-    await client.saveAll(timeseriesToUpdate)
-  } else {
-    log('info', `No trip to update`)
+    return client.saveAll(timeseriesToUpdate)
   }
-  return timeseriesToUpdate
+  log('info', `No trip to update`)
+  return []
+}
+
+/**
+ * Look for existing recurring purpose on similar trips for newly
+ * created trips.
+ *
+ * @param {object} client - The cozy-client instance
+ * @returns {Promise<Array>} The updated trips
+ */
+export const runRecurringPurposesForNewTrips = async client => {
+  const settings = await client.query(buildSettingsQuery().definition)
+  const accountId = settings.data?.[0]?.account?._id
+  if (!accountId) {
+    log('error', 'No account found')
+    return []
+  }
+  const newestRecurringTimeserie = await client.query(
+    buildNewestRecurringTimeseriesQuery({ accountId }).definition
+  )
+  if (!newestRecurringTimeserie.data?.[0]) {
+    // No recurring trip: nothing to do
+    log('info', 'No recurring trip found.')
+    return []
+  }
+  const oldestDateToQuery = newestRecurringTimeserie.data?.[0].startDate
+  log('info', `Looking for trips from ${oldestDateToQuery}`)
+
+  const timeseries = await client.queryAll(
+    buildTimeseriesQueryByAccountIdAndDate({
+      accountId,
+      date: oldestDateToQuery
+    }).definition
+  )
+  let nTripsWithAutoPurpose = 0
+  const timeseriesToUpdate = []
+
+  for (const timeserie of timeseries) {
+    const newPurpose = await findPurposeFromSimilarTimeserieAndWaybacks(
+      client,
+      timeserie
+    )
+    let newTS
+    if (newPurpose) {
+      // Set automatic purpose if a a purpose is found in older similar timeserie
+      newTS = setAutomaticPurpose(timeserie, newPurpose)
+      nTripsWithAutoPurpose++
+    } else {
+      // Set recurring for trips without purpose, as they might be used for future purposes
+      newTS = set(timeserie, 'aggregation.recurring', true)
+    }
+    timeseriesToUpdate.push(newTS)
+  }
+  log('info', `Set ${nTripsWithAutoPurpose} trips with automatic purpose`)
+  return saveTrips(client, timeseriesToUpdate)
+}
+
+/**
+ * Look for similar trips to set the same purpose than the
+ * given trip, after the user set a manual purpose
+ *
+ * @param {object} client - The cozy-client instance
+ * @param {object} params
+ * @param {string} params.docId - The trip docId
+ * @param {string} params.oldPurpose - The trip purpose before the manual change
+ * @returns {Promise<Array>} The updated trips
+ */
+export const runRecurringPurposesForManualTrip = async (
+  client,
+  { docId, oldPurpose }
+) => {
+  // A new purpose has been manually set: look for existing trips to update
+  const timeserie = await queryTimeserieByDocId(client, docId)
+
+  const timeseriesToUpdate = await findRecurringTripsFromTimeserie(
+    client,
+    timeserie,
+    { oldPurpose }
+  )
+  return saveTrips(client, timeseriesToUpdate)
 }

--- a/src/targets/services/recurringPurposes.js
+++ b/src/targets/services/recurringPurposes.js
@@ -2,7 +2,10 @@ import CozyClient from 'cozy-client'
 import log from 'cozy-logger'
 import schema from 'src/doctypes'
 
-import { runRecurringPurposes } from 'src/lib/recurringPurposes'
+import {
+  runRecurringPurposesForManualTrip,
+  runRecurringPurposesForNewTrips
+} from 'src/lib/recurringPurposes'
 
 import fetch from 'node-fetch'
 global.fetch = fetch
@@ -18,12 +21,13 @@ const recurringPurposes = async () => {
 
   const fields = JSON.parse(process.env.COZY_FIELDS || '{}')
   const { docId, oldPurpose } = fields
-  if (!docId || !oldPurpose) {
-    log('error', 'No docId or purpose provided to the service')
-    return
+  if (docId && oldPurpose) {
+    log('info', 'Search for recurring trips after manual edit')
+    await runRecurringPurposesForManualTrip(client, { docId, oldPurpose })
+  } else {
+    log('info', 'Search for new recurring trips')
+    await runRecurringPurposesForNewTrips(client)
   }
-
-  await runRecurringPurposes(client, { docId, oldPurpose })
 }
 
 recurringPurposes().catch(e => {


### PR DESCRIPTION
When a connector imports trips, the service should be started, so newly
created trips might have an automatic purpose.

Note the behaviour is not the same depending on if the service is run
from the app or the trigger. In case of the app, we are looking for
similar existing trips to set them the new manual purpose. In case of a
trigger, we are searching for any trips without purpose and find similar
trips with manual purpose.