### PR TITLE
feat: Add distance metric for trips similarity detection

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -175,3 +175,5 @@ export const DACC_SERVICE_NAME = 'dacc'
 export const MAX_DACC_MEASURES_SENT = 12
 
 export const RECURRING_PURPOSES_SERVICE_NAME = 'recurringPurposes'
+// Maximum distance ratio gap between trips to be considered as similar
+export const TRIPS_DISTANCE_SIMILARITY_RATIO = 0.1

--- a/src/lib/recurringPurposes.spec.js
+++ b/src/lib/recurringPurposes.spec.js
@@ -20,6 +20,7 @@ const mockTimeserie = ({
   endDate,
   startPlace,
   endPlace,
+  totalDistance = 1000,
   recurring,
   manualPurpose,
   noPurpose = false
@@ -32,7 +33,8 @@ const mockTimeserie = ({
       startPlaceDisplayName: startPlace || 'Bag End, The Shire',
       endPlaceDisplayName: endPlace || 'Rivendell, Eastern Eriador',
       purpose: noPurpose ? null : manualPurpose || 'HOBBY',
-      recurring
+      recurring,
+      totalDistance
     },
     cozyMetadata: {
       sourceAccount: 'account-id'

--- a/src/queries/queries.spec.js
+++ b/src/queries/queries.spec.js
@@ -2,7 +2,8 @@ import MockDate from 'mockdate'
 
 import {
   buildTimeseriesQueryByDateAndAccountId,
-  buildOneYearOldTimeseriesWithAggregationByAccountId
+  buildOneYearOldTimeseriesWithAggregationByAccountId,
+  builTimeserieQueryByAccountIdAndStartPlaceAndEndPlaceAndStartDateAndDistance
 } from './queries'
 
 describe('buildTimeseriesQueryByDateAndAccountId', () => {
@@ -94,6 +95,27 @@ describe('buildOneYearOldTimeseriesWithAggregationByAccountId', () => {
       },
       options: {
         as: 'io.cozy.timeseries.geojson/sourceAccount/accountId/withAggregation/fromDate/2019-0'
+      }
+    })
+  })
+})
+
+describe('builTimeserieQueryByAccountIdAndStartPlaceAndEndPlaceAndStartDateAndDistance', () => {
+  it('should correctly set distance bounds', () => {
+    const query =
+      builTimeserieQueryByAccountIdAndStartPlaceAndEndPlaceAndStartDateAndDistance(
+        {
+          distance: 500
+        }
+      )
+    expect(query).toMatchObject({
+      definition: {
+        selector: {
+          'aggregation.totalDistance': {
+            $gte: 450,
+            $lte: 550
+          }
+        }
       }
     })
   })


### PR DESCRIPTION
When looking for similar trips to find recurring trips, we were only
looking on the start/end place name.
We now add a distance metric that consists of searching only for trips
with a total distance close enough to the reference trip.