### PR TITLE
Adds some route and goBack improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.10.0
+
+## ✨ Features
+
+* Add two new routes to open trip from analysis + change back navigation button behavior
+
+## 🐛 Bug Fixes
+
+## 🔧 Tech
+
 # 0.9.0
 
 ## ✨ Features

--- a/src/components/Analysis/Modes/LoadedModesList.jsx
+++ b/src/components/Analysis/Modes/LoadedModesList.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useLocation } from 'react-router-dom'
 import cx from 'classnames'
 
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
@@ -18,6 +18,7 @@ import AnalysisListItem from 'src/components/Analysis/AnalysisListItem'
 import TripsList from 'src/components/TripsList'
 
 const LoadedModesList = ({ timeseries }) => {
+  const { pathname } = useLocation()
   const { mode } = useParams()
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
@@ -80,7 +81,7 @@ const LoadedModesList = ({ timeseries }) => {
 
   return (
     <div className="u-mt-2">
-      <TripsList timeseries={tripsListTimeseries} />
+      <TripsList timeseries={tripsListTimeseries} from={pathname} />
     </div>
   )
 }

--- a/src/components/Analysis/Modes/LoadedModesList.spec.js
+++ b/src/components/Analysis/Modes/LoadedModesList.spec.js
@@ -18,7 +18,8 @@ jest.mock('src/components/TripsList', () => () => (
   <div data-testid="TripsList" />
 ))
 jest.mock('react-router-dom', () => ({
-  useParams: jest.fn().mockReturnValue(() => ({ purpose: '', mode: '' }))
+  useParams: jest.fn().mockReturnValue(() => ({ purpose: '', mode: '' })),
+  useLocation: jest.fn().mockReturnValue(() => ({ pathname: '' }))
 }))
 jest.mock('src/components/Analysis/helpers')
 jest.mock('src/lib/timeseries')

--- a/src/components/Analysis/Purposes/LoadedPurposesList.jsx
+++ b/src/components/Analysis/Purposes/LoadedPurposesList.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useLocation } from 'react-router-dom'
 import cx from 'classnames'
 
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
@@ -18,6 +18,7 @@ import AnalysisListItem from 'src/components/Analysis/AnalysisListItem'
 import TripsList from 'src/components/TripsList'
 
 const LoadedPurposesList = ({ timeseries }) => {
+  const { pathname } = useLocation()
   const { purpose } = useParams()
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
@@ -80,7 +81,7 @@ const LoadedPurposesList = ({ timeseries }) => {
 
   return (
     <div className="u-mt-2">
-      <TripsList timeseries={tripsListTimeseries} />
+      <TripsList timeseries={tripsListTimeseries} from={pathname} />
     </div>
   )
 }

--- a/src/components/Analysis/Purposes/LoadedPurposesList.spec.js
+++ b/src/components/Analysis/Purposes/LoadedPurposesList.spec.js
@@ -18,7 +18,8 @@ jest.mock('src/components/TripsList', () => () => (
   <div data-testid="TripsList" />
 ))
 jest.mock('react-router-dom', () => ({
-  useParams: jest.fn().mockReturnValue(() => ({ purpose: '', mode: '' }))
+  useParams: jest.fn().mockReturnValue(() => ({ purpose: '', mode: '' })),
+  useLocation: jest.fn().mockReturnValue(() => ({ pathname: '' }))
 }))
 jest.mock('src/components/Analysis/helpers')
 jest.mock('src/lib/timeseries')

--- a/src/components/AppRouteur.jsx
+++ b/src/components/AppRouteur.jsx
@@ -13,9 +13,14 @@ const AppRouteur = () => {
       <Route path="trip/:timeserieId" element={<Trip />} />
       <Route path="trips" element={<Trips />} />
       <Route path="settings" element={<Settings />} />
+      <Route path="analysis/modes/:mode/trip/:timeserieId" element={<Trip />} />
       <Route path="analysis/modes" element={<ModeAnalysis />}>
         <Route path=":mode" element={<ModeAnalysis />} />
       </Route>
+      <Route
+        path="analysis/purposes/:purpose/trip/:timeserieId"
+        element={<Trip />}
+      />
       <Route path="analysis/purposes" element={<PurposeAnalysis />}>
         <Route path=":purpose" element={<PurposeAnalysis />} />
       </Route>

--- a/src/components/Trip/TripDialogMobile.jsx
+++ b/src/components/Trip/TripDialogMobile.jsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useRef } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React, { useRef } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
 
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 
@@ -9,17 +9,16 @@ import TripDialogMobileContent from 'src/components/Trip/TripDialogMobileContent
 
 const TripDialogMobile = () => {
   const { timeserie } = useTrip()
+  const { pathname } = useLocation()
   const navigate = useNavigate()
   const titleRef = useRef(null)
-
-  const historyBack = useCallback(() => navigate(-1), [navigate])
 
   return (
     <Dialog
       open
       transitionDuration={0}
       disableGutters
-      onBack={historyBack}
+      onBack={() => navigate(pathname.split('/trip')[0] || '/trips')}
       title={getEndPlaceDisplayName(timeserie)}
       titleRef={titleRef}
       content={<TripDialogMobileContent titleRef={titleRef} />}

--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import { useNavigate, useParams } from 'react-router-dom'
 
@@ -48,7 +48,7 @@ const TripItemSecondary = ({ tripModeIcons, duration, distance }) => {
   )
 }
 
-export const TripItem = ({ timeserie, hasDateHeader }) => {
+export const TripItem = ({ timeserie, hasDateHeader, from }) => {
   const { f } = useI18n()
   const navigate = useNavigate()
   const { mode } = useParams()
@@ -72,12 +72,12 @@ export const TripItem = ({ timeserie, hasDateHeader }) => {
     [modes]
   )
 
-  const handleClick = useCallback(() => {
+  const handleClick = () => {
     if (isMobile) {
-      return navigate(`/trip/${timeserie._id}`)
+      navigate(`${from ?? ''}/trip/${timeserie._id}`)
     }
     setShowTripDialog(true)
-  }, [navigate, isMobile, timeserie._id])
+  }
 
   return (
     <>

--- a/src/components/TripsList.jsx
+++ b/src/components/TripsList.jsx
@@ -11,7 +11,7 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 import TripItem from 'src/components/TripItem'
 import { getStartDate } from 'src/lib/timeseries'
 
-export const TripsList = ({ timeseries }) => {
+export const TripsList = ({ timeseries, from }) => {
   const { isMobile } = useBreakpoints()
   const { t } = useI18n()
 
@@ -42,6 +42,7 @@ export const TripsList = ({ timeseries }) => {
             key={`${timeserie.id}${index}`}
             timeserie={timeserie}
             hasDateHeader={hasDateHeader(timeserie, index)}
+            from={from}
           />
         ))}
       </List>
@@ -50,7 +51,8 @@ export const TripsList = ({ timeseries }) => {
 }
 
 TripsList.propTypes = {
-  timeseries: PropTypes.arrayOf(PropTypes.object).isRequired
+  timeseries: PropTypes.arrayOf(PropTypes.object).isRequired,
+  from: PropTypes.string
 }
 
 export default TripsList

--- a/src/components/Views/ModeAnalysis.jsx
+++ b/src/components/Views/ModeAnalysis.jsx
@@ -18,7 +18,7 @@ const ModeAnalysis = () => {
 
   const modeTitle = mode ? t(`trips.modes.${mode.toUpperCase()}`) : ''
 
-  const onBack = mode ? () => navigate(-1) : undefined
+  const onBack = mode ? () => navigate('/analysis/modes') : undefined
 
   return (
     <SelectDatesProvider>

--- a/src/components/Views/PurposeAnalysis.jsx
+++ b/src/components/Views/PurposeAnalysis.jsx
@@ -20,7 +20,7 @@ const PurposeAnalysis = () => {
     ? t(`trips.purposes.${purpose.toUpperCase()}`)
     : ''
 
-  const onBack = purpose ? () => navigate(-1) : undefined
+  const onBack = purpose ? () => navigate('/analysis/purposes') : undefined
 
   return (
     <SelectDatesProvider>


### PR DESCRIPTION
Change le comportement du back dans la toolbar/cozybar en haut. Au lieu de faire un simple back browser (ce qui pose souci par exemple lors d'un point d'entrée direct, ou dans l'AA) on utilise des routes spécifiques.

Pour afficher un trajet, on utilisait avant la même route qu'on vienne de la home ou des l'analyse. On utilise maintenant 2 routes différentes.

je n'ai pas de temps alloué au projet, c'est un correctif rapide, initialement c'est pour pouvoir afficher des modales avec des routes par dessus une autre route, sur desktop...