### PR TITLE
fix: Do not throw an error when timeserie is malformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## 🐛 Bug Fixes
 
+* The recurring purposes service do not throw an error when display names are missing
+
 ## 🔧 Tech
 
 # 0.9.0

--- a/src/lib/recurringPurposes.js
+++ b/src/lib/recurringPurposes.js
@@ -85,7 +85,7 @@ const queryTimeseriesByPlaceAndDate = async (
 }
 
 // Similar trips = same start/end dipslay name
-const findSimilarTimeseries = async (
+export const findSimilarTimeseries = async (
   client,
   timeserie,
   { oldPurpose = null } = {}
@@ -100,7 +100,11 @@ const findSimilarTimeseries = async (
     !endPlaceDisplayName ||
     !distance
   ) {
-    throw new Error('Missing attributes to run query')
+    log(
+      'error',
+      `Missing attributes to run similar trip query for trip ${timeserie._id}`
+    )
+    return []
   }
   return queryTimeseriesByPlaceAndDate(client, {
     accountId,
@@ -142,7 +146,11 @@ export const findClosestWaybackTrips = async (
     !endPlaceDisplayName ||
     !distance
   ) {
-    throw new Error('Missing attributes to run query')
+    log(
+      'error',
+      `Missing attributes to run wayback query for trip ${timeserie._id}`
+    )
+    return []
   }
   // Find closest wayback in the future
   const queryDefForward =

--- a/src/lib/recurringPurposes.spec.js
+++ b/src/lib/recurringPurposes.spec.js
@@ -9,7 +9,8 @@ import {
   keepTripsWithSameRecurringPurpose,
   findPurposeFromSimilarTimeserieAndWaybacks,
   keepTripsWithRecurringPurposes,
-  runRecurringPurposesForNewTrips
+  runRecurringPurposesForNewTrips,
+  findSimilarTimeseries
 } from './recurringPurposes'
 
 const mockClient = createMockClient({})
@@ -340,6 +341,13 @@ describe('findClosestWaybackTrips', () => {
       aggregation: { purpose: 'HOBBY' }
     })
   })
+  it('should return empty array if timeserie is malformed', async () => {
+    const timeserie = { aggregation: {} }
+    const waybacks = await findClosestWaybackTrips(mockClient, timeserie, {
+      oldPurpose: 'HOBBY'
+    })
+    expect(waybacks).toEqual([])
+  })
 })
 
 describe('findAndSetWaybackTrips', () => {
@@ -540,5 +548,29 @@ describe('findPurposeFromSimilarTimeserieAndWaybacks', () => {
       timeserie
     )
     expect(purpose).toEqual('WORK')
+  })
+})
+
+describe('findSimilarTimeseries', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should get similar timeseries', async () => {
+    jest
+      .spyOn(mockClient, 'queryAll')
+      .mockResolvedValueOnce(mockSimilarTimeseries({ manualPurpose: 'SPORT' }))
+    const timeserie = mockTimeserie({ manualPurpose: 'SPORT' })
+
+    const res = await findSimilarTimeseries(mockClient, timeserie)
+    expect(res.length).toEqual(2)
+  })
+
+  it('should return empty array if timeserie is malformed', async () => {
+    const timeserie = {
+      aggregation: {}
+    }
+    const res = await findSimilarTimeseries(mockClient, timeserie)
+    expect(res).toEqual([])
   })
 })


### PR DESCRIPTION
We discovered that the `aggregation.endPlaceDisplayName` might be
missing in some cases.
So, rather throwing an error when a required attribute is missing, we
log an error and continue the service execution.