### PR TITLE
Improve margins in the recurrence edit dialog title on mobile

### DIFF
--- a/src/components/EditDialogs/RecurrenceEditDialog/RecurrenceEditDialogTitle.jsx
+++ b/src/components/EditDialogs/RecurrenceEditDialog/RecurrenceEditDialogTitle.jsx
@@ -18,8 +18,12 @@ const RecurrenceEditDialogTitle = () => {
   if (isMobile) {
     return (
       <List>
-        <ListItem>
+        <ListItem
+          className="u-mb-half u-pl-1-half"
+          style={{ minHeight: '3rem' }}
+        >
           <ListItemText
+            className="u-pv-0"
             primary={t('recurring.title')}
             primaryTypographyProps={{ variant: 'h6' }}
           />


### PR DESCRIPTION
This makes the bottom sheet closer to the mock-up.