### PR TITLE
Router rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## ✨ Features
 
+* New router to open trip on modal on a specific route on desktop
+
 ## 🐛 Bug Fixes
 
 ## 🔧 Tech

--- a/src/components/Analysis/Modes/LoadedModesList.jsx
+++ b/src/components/Analysis/Modes/LoadedModesList.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useParams, useLocation } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import cx from 'classnames'
 
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
@@ -18,7 +18,6 @@ import AnalysisListItem from 'src/components/Analysis/AnalysisListItem'
 import TripsList from 'src/components/TripsList'
 
 const LoadedModesList = ({ timeseries }) => {
-  const { pathname } = useLocation()
   const { mode } = useParams()
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
@@ -81,7 +80,7 @@ const LoadedModesList = ({ timeseries }) => {
 
   return (
     <div className="u-mt-2">
-      <TripsList timeseries={tripsListTimeseries} from={pathname} />
+      <TripsList timeseries={tripsListTimeseries} />
     </div>
   )
 }

--- a/src/components/Analysis/Modes/LoadedModesList.spec.js
+++ b/src/components/Analysis/Modes/LoadedModesList.spec.js
@@ -18,8 +18,7 @@ jest.mock('src/components/TripsList', () => () => (
   <div data-testid="TripsList" />
 ))
 jest.mock('react-router-dom', () => ({
-  useParams: jest.fn().mockReturnValue(() => ({ purpose: '', mode: '' })),
-  useLocation: jest.fn().mockReturnValue(() => ({ pathname: '' }))
+  useParams: jest.fn().mockReturnValue(() => ({ purpose: '', mode: '' }))
 }))
 jest.mock('src/components/Analysis/helpers')
 jest.mock('src/lib/timeseries')

--- a/src/components/Analysis/Purposes/LoadedPurposesList.jsx
+++ b/src/components/Analysis/Purposes/LoadedPurposesList.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useParams, useLocation } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import cx from 'classnames'
 
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
@@ -18,7 +18,6 @@ import AnalysisListItem from 'src/components/Analysis/AnalysisListItem'
 import TripsList from 'src/components/TripsList'
 
 const LoadedPurposesList = ({ timeseries }) => {
-  const { pathname } = useLocation()
   const { purpose } = useParams()
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
@@ -81,7 +80,7 @@ const LoadedPurposesList = ({ timeseries }) => {
 
   return (
     <div className="u-mt-2">
-      <TripsList timeseries={tripsListTimeseries} from={pathname} />
+      <TripsList timeseries={tripsListTimeseries} />
     </div>
   )
 }

--- a/src/components/Analysis/Purposes/LoadedPurposesList.spec.js
+++ b/src/components/Analysis/Purposes/LoadedPurposesList.spec.js
@@ -18,8 +18,7 @@ jest.mock('src/components/TripsList', () => () => (
   <div data-testid="TripsList" />
 ))
 jest.mock('react-router-dom', () => ({
-  useParams: jest.fn().mockReturnValue(() => ({ purpose: '', mode: '' })),
-  useLocation: jest.fn().mockReturnValue(() => ({ pathname: '' }))
+  useParams: jest.fn().mockReturnValue(() => ({ purpose: '', mode: '' }))
 }))
 jest.mock('src/components/Analysis/helpers')
 jest.mock('src/lib/timeseries')

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -6,7 +6,7 @@ import Sprite from 'cozy-ui/transpiled/react/Icon/Sprite'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-import AppRouteur from 'src/components/AppRouteur'
+import AppRouter from 'src/components/AppRouter'
 import Sidebar from 'src/components/Sidebar'
 
 const App = () => {
@@ -18,7 +18,7 @@ const App = () => {
         <Sidebar />
         <Main>
           <Content>
-            <AppRouteur />
+            <AppRouter />
           </Content>
         </Main>
         <Alerter t={t} />

--- a/src/components/AppRouter.jsx
+++ b/src/components/AppRouter.jsx
@@ -14,7 +14,7 @@ const OutletWrapper = ({ Component }) => (
   </>
 )
 
-const AppRouteur = () => {
+const AppRouter = () => {
   const location = useLocation()
   const background = location?.state?.background
 
@@ -64,4 +64,4 @@ const AppRouteur = () => {
   )
 }
 
-export default AppRouteur
+export default AppRouter

--- a/src/components/AppRouteur.jsx
+++ b/src/components/AppRouteur.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Routes, Route, Navigate } from 'react-router-dom'
+import { Routes, Route, Navigate, useLocation, Outlet } from 'react-router-dom'
 
 import Trips from 'src/components/Views/Trips'
 import Trip from 'src/components/Views/Trip'
@@ -7,29 +7,60 @@ import ModeAnalysis from 'src/components/Views/ModeAnalysis'
 import PurposeAnalysis from 'src/components/Views/PurposeAnalysis'
 import Settings from 'src/components/Views/Settings'
 
+const OutletWrapper = ({ Component }) => (
+  <>
+    <Component />
+    <Outlet />
+  </>
+)
+
 const AppRouteur = () => {
+  const location = useLocation()
+  const background = location?.state?.background
+
   return (
-    <Routes>
-      <Route path="trip/:timeserieId" element={<Trip />} />
-      <Route path="trips" element={<Trips />} />
-      <Route path="settings" element={<Settings />} />
-      <Route path="analysis/modes/:mode/trip/:timeserieId" element={<Trip />} />
-      <Route path="analysis/modes" element={<ModeAnalysis />}>
-        <Route path=":mode" element={<ModeAnalysis />} />
-      </Route>
-      <Route
-        path="analysis/purposes/:purpose/trip/:timeserieId"
-        element={<Trip />}
-      />
-      <Route path="analysis/purposes" element={<PurposeAnalysis />}>
-        <Route path=":purpose" element={<PurposeAnalysis />} />
-      </Route>
-      <Route
-        path="analysis"
-        element={<Navigate replace to="/analysis/modes" />}
-      />
-      <Route path="*" element={<Navigate replace to="/trips" />} />
-    </Routes>
+    <>
+      <Routes location={background || location}>
+        <Route path="trips" element={<OutletWrapper Component={Trips} />}>
+          <Route path=":timeserieId" element={<Trip />} />
+        </Route>
+
+        <Route path="settings" element={<Settings />} />
+
+        <Route path="analysis/modes" element={<ModeAnalysis />} />
+        <Route
+          path="analysis/modes/:mode"
+          element={<OutletWrapper Component={ModeAnalysis} />}
+        >
+          <Route path=":timeserieId" element={<Trip />} />
+        </Route>
+
+        <Route path="analysis/purposes" element={<PurposeAnalysis />} />
+        <Route
+          path="analysis/purposes/:purpose"
+          element={<OutletWrapper Component={PurposeAnalysis} />}
+        >
+          <Route path=":timeserieId" element={<Trip />} />
+        </Route>
+
+        <Route
+          path="analysis"
+          element={<Navigate replace to="/analysis/modes" />}
+        />
+        <Route path="*" element={<Navigate replace to="/trips" />} />
+      </Routes>
+
+      {background && (
+        <Routes>
+          <Route path="trips/:timeserieId" element={<Trip />} />
+          <Route path="analysis/modes/:mode/:timeserieId" element={<Trip />} />
+          <Route
+            path="analysis/purposes/:purpose/:timeserieId"
+            element={<Trip />}
+          />
+        </Routes>
+      )}
+    </>
   )
 }
 

--- a/src/components/Trip/TripDialogDesktop.jsx
+++ b/src/components/Trip/TripDialogDesktop.jsx
@@ -2,23 +2,10 @@ import React from 'react'
 import { useNavigate, useLocation, useParams } from 'react-router-dom'
 
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
-import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 
-import { useTrip } from 'src/components/Providers/TripProvider'
 import { getEndPlaceDisplayName } from 'src/lib/timeseries'
-import TripMap from 'src/components/Trip/TripMap'
-import BottomSheetHeaderContent from 'src/components/Trip/BottomSheet/BottomSheetHeaderContent'
-import BottomSheetContent from 'src/components/Trip/BottomSheet/BottomSheetContent'
-
-const styles = {
-  map: {
-    height: '400px',
-    margin: '-24px -32px 0'
-  },
-  divider: {
-    margin: '10px -32px 25px'
-  }
-}
+import { useTrip } from 'src/components/Providers/TripProvider'
+import TripDialogDesktopContent from 'src/components/Trip/TripDialogDesktopContent'
 
 const TripDialogDesktop = () => {
   const { timeserieId } = useParams()
@@ -31,18 +18,7 @@ const TripDialogDesktop = () => {
       open
       size="large"
       title={getEndPlaceDisplayName(timeserie)}
-      content={
-        <>
-          <div style={styles.map}>
-            <TripMap />
-          </div>
-          <div className="u-mt-1 u-h-3 u-flex u-flex-items-center u-pb-half">
-            <BottomSheetHeaderContent />
-          </div>
-          <Divider style={styles.divider} />
-          <BottomSheetContent />
-        </>
-      }
+      content={<TripDialogDesktopContent />}
       onClose={() => navigate(pathname.split(`/${timeserieId}`)[0])}
     />
   )

--- a/src/components/Trip/TripDialogDesktop.jsx
+++ b/src/components/Trip/TripDialogDesktop.jsx
@@ -1,16 +1,14 @@
-import React, { useCallback } from 'react'
+import React from 'react'
+import { useNavigate, useLocation, useParams } from 'react-router-dom'
 
-import { isQueryLoading, useQuery } from 'cozy-client'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
-import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
-import { buildTimeserieQueryById } from 'src/queries/queries'
+import { useTrip } from 'src/components/Providers/TripProvider'
 import { getEndPlaceDisplayName } from 'src/lib/timeseries'
 import TripMap from 'src/components/Trip/TripMap'
 import BottomSheetHeaderContent from 'src/components/Trip/BottomSheet/BottomSheetHeaderContent'
 import BottomSheetContent from 'src/components/Trip/BottomSheet/BottomSheetContent'
-import TripProvider from 'src/components/Providers/TripProvider'
 
 const styles = {
   map: {
@@ -22,48 +20,31 @@ const styles = {
   }
 }
 
-const TripDialogDesktop = ({ timeserieId, setShowTripDialog }) => {
-  const timeserieQuery = buildTimeserieQueryById(timeserieId)
-  const { data: timeserie, ...timeseriesQueryResult } = useQuery(
-    timeserieQuery.definition,
-    timeserieQuery.options
-  )
-
-  const isLoading = isQueryLoading(timeseriesQueryResult)
-
-  const hideModal = useCallback(
-    () => setShowTripDialog(false),
-    [setShowTripDialog]
-  )
+const TripDialogDesktop = () => {
+  const { timeserieId } = useParams()
+  const { timeserie } = useTrip()
+  const { pathname } = useLocation()
+  const navigate = useNavigate()
 
   return (
-    <TripProvider timeserie={isLoading ? '' : timeserie}>
-      <Dialog
-        open={true}
-        onClose={hideModal}
-        title={isLoading ? '' : getEndPlaceDisplayName(timeserie)}
-        size="large"
-        content={
-          isLoading ? (
-            <Spinner
-              size="xxlarge"
-              className="u-flex u-flex-justify-center u-mt-1"
-            />
-          ) : (
-            <>
-              <div style={styles.map}>
-                <TripMap />
-              </div>
-              <div className="u-mt-1 u-h-3 u-flex u-flex-items-center u-pb-half">
-                <BottomSheetHeaderContent />
-              </div>
-              <Divider style={styles.divider} />
-              <BottomSheetContent />
-            </>
-          )
-        }
-      />
-    </TripProvider>
+    <Dialog
+      open
+      size="large"
+      title={getEndPlaceDisplayName(timeserie)}
+      content={
+        <>
+          <div style={styles.map}>
+            <TripMap />
+          </div>
+          <div className="u-mt-1 u-h-3 u-flex u-flex-items-center u-pb-half">
+            <BottomSheetHeaderContent />
+          </div>
+          <Divider style={styles.divider} />
+          <BottomSheetContent />
+        </>
+      }
+      onClose={() => navigate(pathname.split(`/${timeserieId}`)[0])}
+    />
   )
 }
 

--- a/src/components/Trip/TripDialogDesktopContent.jsx
+++ b/src/components/Trip/TripDialogDesktopContent.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+
+import TripMap from 'src/components/Trip/TripMap'
+import BottomSheetHeaderContent from 'src/components/Trip/BottomSheet/BottomSheetHeaderContent'
+import BottomSheetContent from 'src/components/Trip/BottomSheet/BottomSheetContent'
+
+const styles = {
+  map: {
+    height: '400px',
+    margin: '-24px -32px 0'
+  },
+  divider: {
+    margin: '10px -32px 25px'
+  }
+}
+
+const TripDialogDesktopContent = () => {
+  return (
+    <>
+      <div style={styles.map}>
+        <TripMap />
+      </div>
+      <div className="u-mt-1 u-h-3 u-flex u-flex-items-center u-pb-half">
+        <BottomSheetHeaderContent />
+      </div>
+      <Divider style={styles.divider} />
+      <BottomSheetContent />
+    </>
+  )
+}
+
+export default TripDialogDesktopContent

--- a/src/components/Trip/TripDialogMobile.jsx
+++ b/src/components/Trip/TripDialogMobile.jsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavigate, useLocation, useParams } from 'react-router-dom'
 
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 
@@ -8,9 +8,11 @@ import { useTrip } from 'src/components/Providers/TripProvider'
 import TripDialogMobileContent from 'src/components/Trip/TripDialogMobileContent'
 
 const TripDialogMobile = () => {
+  const { timeserieId } = useParams()
   const { timeserie } = useTrip()
   const { pathname } = useLocation()
   const navigate = useNavigate()
+
   const titleRef = useRef(null)
 
   return (
@@ -18,10 +20,10 @@ const TripDialogMobile = () => {
       open
       transitionDuration={0}
       disableGutters
-      onBack={() => navigate(pathname.split('/trip')[0] || '/trips')}
       title={getEndPlaceDisplayName(timeserie)}
       titleRef={titleRef}
       content={<TripDialogMobileContent titleRef={titleRef} />}
+      onBack={() => navigate(pathname.split(`/${timeserieId}`)[0])}
     />
   )
 }

--- a/src/components/TripItem.jsx
+++ b/src/components/TripItem.jsx
@@ -1,6 +1,6 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
 
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
@@ -11,7 +11,6 @@ import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import Typography from 'cozy-ui/transpiled/react/Typography'
-import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import { PurposeAvatar } from 'src/components/Avatar'
 import {
@@ -25,7 +24,6 @@ import {
   computeAndFormatTotalCO2ByMode
 } from 'src/lib/timeseries'
 import { pickModeIcon } from 'src/components/helpers'
-import TripDialogDesktop from 'src/components/Trip/TripDialogDesktop'
 
 const styles = {
   co2: {
@@ -48,12 +46,11 @@ const TripItemSecondary = ({ tripModeIcons, duration, distance }) => {
   )
 }
 
-export const TripItem = ({ timeserie, hasDateHeader, from }) => {
+export const TripItem = ({ timeserie, hasDateHeader }) => {
   const { f } = useI18n()
+  const location = useLocation()
   const navigate = useNavigate()
   const { mode } = useParams()
-  const { isMobile } = useBreakpoints()
-  const [showTripDialog, setShowTripDialog] = useState(false)
 
   const purpose = getTimeseriePurpose(timeserie)
   const duration = getFormattedDuration(timeserie)
@@ -73,10 +70,9 @@ export const TripItem = ({ timeserie, hasDateHeader, from }) => {
   )
 
   const handleClick = () => {
-    if (isMobile) {
-      navigate(`${from ?? ''}/trip/${timeserie._id}`)
-    }
-    setShowTripDialog(true)
+    navigate(`${location.pathname}/${timeserie._id}`, {
+      state: { background: location }
+    })
   }
 
   return (
@@ -106,12 +102,6 @@ export const TripItem = ({ timeserie, hasDateHeader, from }) => {
         <Icon icon={RightIcon} color="var(--secondaryTextColor)" />
       </ListItem>
       <Divider />
-      {showTripDialog && (
-        <TripDialogDesktop
-          timeserieId={timeserie._id}
-          setShowTripDialog={setShowTripDialog}
-        />
-      )}
     </>
   )
 }

--- a/src/components/TripsList.jsx
+++ b/src/components/TripsList.jsx
@@ -11,7 +11,7 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 import TripItem from 'src/components/TripItem'
 import { getStartDate } from 'src/lib/timeseries'
 
-export const TripsList = ({ timeseries, from }) => {
+export const TripsList = ({ timeseries }) => {
   const { isMobile } = useBreakpoints()
   const { t } = useI18n()
 
@@ -42,7 +42,6 @@ export const TripsList = ({ timeseries, from }) => {
             key={`${timeserie.id}${index}`}
             timeserie={timeserie}
             hasDateHeader={hasDateHeader(timeserie, index)}
-            from={from}
           />
         ))}
       </List>
@@ -51,8 +50,7 @@ export const TripsList = ({ timeseries, from }) => {
 }
 
 TripsList.propTypes = {
-  timeseries: PropTypes.arrayOf(PropTypes.object).isRequired,
-  from: PropTypes.string
+  timeseries: PropTypes.arrayOf(PropTypes.object).isRequired
 }
 
 export default TripsList

--- a/src/components/Views/Trip.jsx
+++ b/src/components/Views/Trip.jsx
@@ -5,10 +5,13 @@ import { isQueryLoading, useQuery } from 'cozy-client'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import TripDialogMobile from 'src/components/Trip/TripDialogMobile'
+import TripDialogDesktop from 'src/components/Trip/TripDialogDesktop'
 import { buildTimeserieQueryById } from 'src/queries/queries'
 import TripProvider from 'src/components/Providers/TripProvider'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 const Trip = () => {
+  const { isMobile } = useBreakpoints()
   const { pathname } = useLocation()
   const timeserieId = useMemo(() => pathname.split('/').pop(), [pathname])
 
@@ -28,7 +31,7 @@ const Trip = () => {
 
   return (
     <TripProvider timeserie={data}>
-      <TripDialogMobile />
+      {isMobile ? <TripDialogMobile /> : <TripDialogDesktop />}
     </TripProvider>
   )
 }


### PR DESCRIPTION
L'idée ici est de pouvoir afficher une modale avec une certaine route, par-dessus l'application "sans perdre de vue" la route sur laquelle on était avant d'ouvrir la modale. Ainsi on peut revenir sur la route initiale sans faire de rechargement de composant, et donc par exemple garder sa position si jamais on a scrollé dans le contenu. Cela permet aussi, puisqu'on a des routes spécifiques par modale, d'ouvrir l'application directement sur une route avec modale ouverte, ou faire un hard refresh sans perdre l'ouverture de la modale.

Pour se faire une modification du router a été nécessaire :
- utilisation d'un `background` qu'on passe à la place du `location` sur `Routes` principal : `<Routes location={background || location}>`
- utilisation d'un deuxième `Routes` afin de gérer l'ajout des modales "par dessus" l'app
- utilisation d'un wrapper d'`Outlet` https://reactrouter.com/en/v6.3.0/api#outlet pour afficher la route enfant d'un parent qui va accueillir une modale
- suite à `Outlet`, rework des routes pour avoir des routes simples `parent > enfant`

D'ailleurs on s'est rendu compte qu'il n'est pas possible d'imbriquer 2 routes param à la suite :

```diff
- <Route path="myUrl">
-   <Route path=":param1">
-     <Route path=":param2" />
-   </Route>
- </Route>
+ <Route path="myUrl" />
+ <Route path="myUrl/:param1">
+   <Route path=":param2" />
+ </Route>
```

Suite à la modification du router, il a fallu revoir un peu les routes et les navigate dans l'app. L'astuce a été d'utiliser des routes absolues en récupérant `location.pathname` (voir modif sur `TripItem`)

Pour le background, on utilise le state du router. Avec un router configuré comme ici, c'est compatible avec le hard refresh et une entrée directe dans l'app sur l'url d'une modale.