### PR TITLE
Selected date changes to last month when selecting a  mode/purpose in analysis

### DIFF
--- a/src/components/AppProviders.jsx
+++ b/src/components/AppProviders.jsx
@@ -10,8 +10,9 @@ import { I18n } from 'cozy-ui/transpiled/react/I18n'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
-import AccountProvider from 'src/components/Providers/AccountProvider'
 import { GEOJSON_DOCTYPE } from 'src/doctypes'
+import AccountProvider from 'src/components/Providers/AccountProvider'
+import SelectDatesProvider from 'src/components/Providers/SelectDatesProvider'
 
 /*
 With MUI V4, it is possible to generate deterministic class names.
@@ -31,11 +32,13 @@ const AppProviders = ({ client, lang, polyglot, children }) => {
         <CozyProvider client={client}>
           <RealTimeQueries doctype={GEOJSON_DOCTYPE} />
           <AccountProvider>
-            <I18n lang={lang} polyglot={polyglot}>
-              <MuiCozyTheme>
-                <BreakpointsProvider>{children}</BreakpointsProvider>
-              </MuiCozyTheme>
-            </I18n>
+            <SelectDatesProvider>
+              <I18n lang={lang} polyglot={polyglot}>
+                <MuiCozyTheme>
+                  <BreakpointsProvider>{children}</BreakpointsProvider>
+                </MuiCozyTheme>
+              </I18n>
+            </SelectDatesProvider>
           </AccountProvider>
         </CozyProvider>
       </StylesProvider>

--- a/src/components/AppProviders.jsx
+++ b/src/components/AppProviders.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import {
+  StylesProvider,
+  createGenerateClassName
+} from 'cozy-ui/transpiled/react/styles'
+
+import { CozyProvider, RealTimeQueries } from 'cozy-client'
+import { WebviewIntentProvider } from 'cozy-intent'
+import { I18n } from 'cozy-ui/transpiled/react/I18n'
+import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
+import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import AccountProvider from 'src/components/Providers/AccountProvider'
+import { GEOJSON_DOCTYPE } from 'src/doctypes'
+
+/*
+With MUI V4, it is possible to generate deterministic class names.
+In the case of multiple react roots, it is necessary to disable this
+feature. Since we have the cozy-bar root, we need to disable the
+feature.
+https://material-ui.com/styles/api/#stylesprovider
+*/
+const generateClassName = createGenerateClassName({
+  disableGlobal: true
+})
+
+const AppProviders = ({ client, lang, polyglot, children }) => {
+  return (
+    <WebviewIntentProvider>
+      <StylesProvider generateClassName={generateClassName}>
+        <CozyProvider client={client}>
+          <RealTimeQueries doctype={GEOJSON_DOCTYPE} />
+          <AccountProvider>
+            <I18n lang={lang} polyglot={polyglot}>
+              <MuiCozyTheme>
+                <BreakpointsProvider>{children}</BreakpointsProvider>
+              </MuiCozyTheme>
+            </I18n>
+          </AccountProvider>
+        </CozyProvider>
+      </StylesProvider>
+    </WebviewIntentProvider>
+  )
+}
+
+export default AppProviders

--- a/src/components/AppRouter.jsx
+++ b/src/components/AppRouter.jsx
@@ -27,7 +27,10 @@ const AppRouter = () => {
 
         <Route path="settings" element={<Settings />} />
 
-        <Route path="analysis/modes" element={<ModeAnalysis />} />
+        <Route
+          path="analysis/modes"
+          element={<OutletWrapper Component={ModeAnalysis} />}
+        />
         <Route
           path="analysis/modes/:mode"
           element={<OutletWrapper Component={ModeAnalysis} />}
@@ -35,7 +38,10 @@ const AppRouter = () => {
           <Route path=":timeserieId" element={<Trip />} />
         </Route>
 
-        <Route path="analysis/purposes" element={<PurposeAnalysis />} />
+        <Route
+          path="analysis/purposes"
+          element={<OutletWrapper Component={PurposeAnalysis} />}
+        />
         <Route
           path="analysis/purposes/:purpose"
           element={<OutletWrapper Component={PurposeAnalysis} />}

--- a/src/components/Views/ModeAnalysis.jsx
+++ b/src/components/Views/ModeAnalysis.jsx
@@ -4,7 +4,6 @@ import { useParams, useNavigate } from 'react-router-dom'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-import SelectDatesProvider from 'src/components/Providers/SelectDatesProvider'
 import Titlebar from 'src/components/Titlebar'
 import ModesList from 'src/components/Analysis/Modes/ModesList'
 import TabsNav from 'src/components/Analysis/TabsNav'
@@ -21,12 +20,12 @@ const ModeAnalysis = () => {
   const onBack = mode ? () => navigate('/analysis/modes') : undefined
 
   return (
-    <SelectDatesProvider>
+    <>
       <Titlebar label={modeTitle} onBack={onBack} />
       {isMobile && <TabsNav />}
       <SelectDatesWrapper />
       <ModesList />
-    </SelectDatesProvider>
+    </>
   )
 }
 

--- a/src/components/Views/PurposeAnalysis.jsx
+++ b/src/components/Views/PurposeAnalysis.jsx
@@ -6,7 +6,6 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import Titlebar from 'src/components/Titlebar'
 import TabsNav from 'src/components/Analysis/TabsNav'
-import SelectDatesProvider from 'src/components/Providers/SelectDatesProvider'
 import PurposesList from 'src/components/Analysis/Purposes/PurposesList'
 import SelectDatesWrapper from 'src/components/SelectDatesWrapper'
 
@@ -23,12 +22,12 @@ const PurposeAnalysis = () => {
   const onBack = purpose ? () => navigate('/analysis/purposes') : undefined
 
   return (
-    <SelectDatesProvider>
+    <>
       <Titlebar label={purposeTitle} onBack={onBack} />
       {isMobile && <TabsNav />}
       <SelectDatesWrapper />
       <PurposesList />
-    </SelectDatesProvider>
+    </>
   )
 }
 

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -5,53 +5,19 @@ import 'src/styles/index.styl'
 
 import React from 'react'
 import { render } from 'react-dom'
-import {
-  StylesProvider,
-  createGenerateClassName
-} from 'cozy-ui/transpiled/react/styles'
-
-import { CozyProvider, RealTimeQueries } from 'cozy-client'
-import { I18n } from 'cozy-ui/transpiled/react/I18n'
-import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
-import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
-import { WebviewIntentProvider } from 'cozy-intent'
 
 import setupApp from 'src/targets/browser/setupApp'
 import { register as registerServiceWorker } from 'src/targets/browser/serviceWorkerRegistration'
+import AppProviders from 'src/components/AppProviders'
 import App from 'src/components/App'
-import AccountProvider from 'src/components/Providers/AccountProvider'
-import { GEOJSON_DOCTYPE } from 'src/doctypes'
-
-/*
-With MUI V4, it is possible to generate deterministic class names.
-In the case of multiple react roots, it is necessary to disable this
-feature. Since we have the cozy-bar root, we need to disable the
-feature.
-https://material-ui.com/styles/api/#stylesprovider
-*/
-const generateClassName = createGenerateClassName({
-  disableGlobal: true
-})
 
 const init = function () {
   const { root, client, lang, polyglot } = setupApp()
+
   render(
-    <WebviewIntentProvider>
-      <StylesProvider generateClassName={generateClassName}>
-        <CozyProvider client={client}>
-          <RealTimeQueries doctype={GEOJSON_DOCTYPE} />
-          <AccountProvider>
-            <I18n lang={lang} polyglot={polyglot}>
-              <MuiCozyTheme>
-                <BreakpointsProvider>
-                  <App />
-                </BreakpointsProvider>
-              </MuiCozyTheme>
-            </I18n>
-          </AccountProvider>
-        </CozyProvider>
-      </StylesProvider>
-    </WebviewIntentProvider>,
+    <AppProviders client={client} lang={lang} polyglot={polyglot}>
+      <App />
+    </AppProviders>,
     root
   )
 }


### PR DESCRIPTION
Ceci est une régression dû à l'implémentation des nouvelles routes. Sur la page d'analyse, si on change la date dans le sélecteur, et qu'on navigue ensuite sur la liste des modes/purposes, la date se réinitialisait au dernier mois.

C'était dû au rerender du provider de date (qui set la date à `null` par défaut) à cause visiblement du fait qu'il faut utiliser 
`Outlet` dans la route parente.