### PR TITLE
Upgrade to react 18

### DIFF
--- a/app.config.babel-loader-leaflet.js
+++ b/app.config.babel-loader-leaflet.js
@@ -1,0 +1,20 @@
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: [
+          {
+            test: /(node_modules|cozy-(bar|client-js))/,
+            exclude: [
+              /node_modules\/leaflet/,
+              /node_modules\/@react-leaflet/,
+              /node_modules\/react-leaflet/
+            ]
+          }
+        ],
+        loader: require.resolve('cozy-scripts/node_modules/babel-loader')
+      }
+    ]
+  }
+}

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,6 @@
+const config = [
+  require('cozy-scripts/config/webpack.bundle.default.js'),
+  require('./app.config.babel-loader-leaflet')
+]
+
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react": "17.0.2",
     "react-chartjs-2": "4.0.1",
     "react-dom": "17.0.2",
-    "react-leaflet": "2.8.0",
+    "react-leaflet": "4.1.0",
     "react-router-dom": "6.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cozy-scripts": "^6.3.3",
     "eslint-config-cozy-app": "^4.1.1",
     "mockdate": "^3.0.5",
-    "react-test-renderer": "^17.0.2"
+    "react-test-renderer": "18.2.0"
   },
   "dependencies": {
     "@material-ui/core": "4",
@@ -65,9 +65,9 @@
     "humanize-duration": "3.27.1",
     "leaflet": "1.9.1",
     "lodash": "^4.17.21",
-    "react": "17.0.2",
+    "react": "18.2.0",
     "react-chartjs-2": "4.0.1",
-    "react-dom": "17.0.2",
+    "react-dom": "18.2.0",
     "react-leaflet": "4.1.0",
     "react-router-dom": "6.3.0"
   }

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   },
   "homepage": "https://github.com/cozy/coachCO2#README",
   "devDependencies": {
-    "@testing-library/jest-dom": "5.16.2",
-    "@testing-library/react": "11.2.7",
-    "@testing-library/react-hooks": "^7.0.2",
+    "@testing-library/jest-dom": "5.16.5",
+    "@testing-library/react": "13.4.0",
+    "@testing-library/react-hooks": "8.0.1",
     "babel-preset-cozy-app": "^2.0.2",
     "bundlemon": "1.3.1",
     "cozy-ach": "^1.39.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cozy-intent": "^1.17.1",
     "cozy-logger": "^1.9.0",
     "cozy-realtime": "^4.2.1",
-    "cozy-ui": "^74.2.0",
+    "cozy-ui": "^75.4.1",
     "date-fns": "^2.28.0",
     "humanize-duration": "3.27.1",
     "leaflet": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "cozy-ui": "^74.2.0",
     "date-fns": "^2.28.0",
     "humanize-duration": "3.27.1",
-    "leaflet": "^1.7.1",
+    "leaflet": "1.9.1",
     "lodash": "^4.17.21",
     "react": "17.0.2",
     "react-chartjs-2": "4.0.1",

--- a/src/components/Trip/TripMap.jsx
+++ b/src/components/Trip/TripMap.jsx
@@ -1,94 +1,23 @@
-// use http://leaflet-extras.github.io/leaflet-providers/preview/ to choose a tileLayer
-
-import React, { useEffect, useRef, useMemo, useState } from 'react'
-import { Map, TileLayer, GeoJSON } from 'react-leaflet'
-import { useTheme } from 'cozy-ui/transpiled/react/styles'
-import L from 'leaflet'
+import React, { useEffect, useRef, useState } from 'react'
+import { Map } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
 
-import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
-
-import { useTrip } from 'src/components/Providers/TripProvider'
-import { bottomSheetSettings } from 'src/components/Trip/TripDialogMobileContent'
-import { getGeoJSONData } from 'src/lib/timeseries'
-
-import './tripmap.styl'
+import TripMapContent from './TripMapContent'
 
 const mapCenter = [51.505, -0.09]
-const mapPadding = 16
-
-const makeGeoJsonOptions = theme => ({
-  style: feature => {
-    return {
-      weight: feature.properties.feature_type === 'section' ? 5 : 2,
-      color: theme.palette.primary.main
-    }
-  },
-  pointToLayer: (feature, latlng) => {
-    return L.marker(latlng, {
-      icon: L.divIcon({
-        html: `<div></div>`,
-        iconSize: [12, 12],
-        className: `cozy-leaflet-markers ${
-          feature.properties.feature_type === 'end_place'
-            ? 'cozy-leaflet-markers-end'
-            : 'cozy-leaflet-markers-start'
-        }`
-      })
-    })
-  }
-})
 
 const TripMap = () => {
-  const { isMobile } = useBreakpoints()
-  const { timeserie } = useTrip()
-  const theme = useTheme()
   const mapRef = useRef()
-  const geojsonRef = useRef()
   const [mapL, setMapL] = useState(null)
-
-  const { pointToLayer, style } = useMemo(
-    () => makeGeoJsonOptions(theme),
-    [theme]
-  )
-  const mapPanRatio = useMemo(
-    () => (isMobile ? bottomSheetSettings.mediumHeightRatio : 0),
-    [isMobile]
-  )
 
   // needed to force a rerender, to be able to get Map children ref
   useEffect(() => {
     setMapL(mapRef.current.leafletElement)
   }, [])
 
-  useEffect(() => {
-    if (geojsonRef.current) {
-      const geojsonL = geojsonRef.current.leafletElement
-      const bounds = geojsonL.getBounds()
-      const paddingTopLeft = [mapPadding, mapPadding]
-      const paddingBottomRight = [
-        mapPadding,
-        mapPadding + mapL.getSize().y * mapPanRatio
-      ]
-      mapL.fitBounds(bounds, {
-        paddingTopLeft,
-        paddingBottomRight
-      })
-    }
-  }, [mapL, mapPanRatio])
-
   return (
     <Map className="u-h-100" ref={mapRef} center={mapCenter} zoom={13}>
-      <TileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-      />
-      <GeoJSON
-        ref={geojsonRef}
-        data={getGeoJSONData(timeserie)}
-        pointToLayer={pointToLayer}
-        style={style}
-      />
+      <TripMapContent mapL={mapL} />
     </Map>
   )
 }

--- a/src/components/Trip/TripMap.jsx
+++ b/src/components/Trip/TripMap.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react'
-import { Map } from 'react-leaflet'
+import React from 'react'
+import { MapContainer } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
 
 import TripMapContent from './TripMapContent'
@@ -7,18 +7,10 @@ import TripMapContent from './TripMapContent'
 const mapCenter = [51.505, -0.09]
 
 const TripMap = () => {
-  const mapRef = useRef()
-  const [mapL, setMapL] = useState(null)
-
-  // needed to force a rerender, to be able to get Map children ref
-  useEffect(() => {
-    setMapL(mapRef.current.leafletElement)
-  }, [])
-
   return (
-    <Map className="u-h-100" ref={mapRef} center={mapCenter} zoom={13}>
-      <TripMapContent mapL={mapL} />
-    </Map>
+    <MapContainer className="u-h-100" center={mapCenter} zoom={13}>
+      <TripMapContent />
+    </MapContainer>
   )
 }
 

--- a/src/components/Trip/TripMapContent.jsx
+++ b/src/components/Trip/TripMapContent.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useMemo } from 'react'
-import { TileLayer, GeoJSON } from 'react-leaflet'
+import { TileLayer, GeoJSON, useMap } from 'react-leaflet'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 
@@ -36,11 +36,12 @@ const makeGeoJsonOptions = theme => ({
   }
 })
 
-const TripMapContent = ({ mapL }) => {
+const TripMapContent = () => {
   const geojsonRef = useRef()
   const { isMobile } = useBreakpoints()
   const theme = useTheme()
   const { timeserie } = useTrip()
+  const map = useMap()
 
   const { pointToLayer, style } = useMemo(
     () => makeGeoJsonOptions(theme),
@@ -53,20 +54,17 @@ const TripMapContent = ({ mapL }) => {
   )
 
   useEffect(() => {
-    if (geojsonRef.current) {
-      const geojsonL = geojsonRef.current.leafletElement
-      const bounds = geojsonL.getBounds()
-      const paddingTopLeft = [mapPadding, mapPadding]
-      const paddingBottomRight = [
-        mapPadding,
-        mapPadding + mapL.getSize().y * mapPanRatio
-      ]
-      mapL.fitBounds(bounds, {
-        paddingTopLeft,
-        paddingBottomRight
-      })
-    }
-  }, [mapL, mapPanRatio])
+    const bounds = geojsonRef.current.getBounds()
+    const paddingTopLeft = [mapPadding, mapPadding]
+    const paddingBottomRight = [
+      mapPadding,
+      mapPadding + map.getSize().y * mapPanRatio
+    ]
+    map.fitBounds(bounds, {
+      paddingTopLeft,
+      paddingBottomRight
+    })
+  }, [map, mapPanRatio])
 
   return (
     <>

--- a/src/components/Trip/TripMapContent.jsx
+++ b/src/components/Trip/TripMapContent.jsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useRef, useMemo } from 'react'
+import { TileLayer, GeoJSON } from 'react-leaflet'
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+
+import { useTheme } from 'cozy-ui/transpiled/react/styles'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import { useTrip } from 'src/components/Providers/TripProvider'
+import { bottomSheetSettings } from 'src/components/Trip/TripDialogMobileContent'
+import { getGeoJSONData } from 'src/lib/timeseries'
+
+import './tripmap.styl'
+
+const mapPadding = 16
+
+const makeGeoJsonOptions = theme => ({
+  style: feature => {
+    return {
+      weight: feature.properties.feature_type === 'section' ? 5 : 2,
+      color: theme.palette.primary.main
+    }
+  },
+  pointToLayer: (feature, latlng) => {
+    return L.marker(latlng, {
+      icon: L.divIcon({
+        html: `<div></div>`,
+        iconSize: [12, 12],
+        className: `cozy-leaflet-markers ${
+          feature.properties.feature_type === 'end_place'
+            ? 'cozy-leaflet-markers-end'
+            : 'cozy-leaflet-markers-start'
+        }`
+      })
+    })
+  }
+})
+
+const TripMapContent = ({ mapL }) => {
+  const geojsonRef = useRef()
+  const { isMobile } = useBreakpoints()
+  const theme = useTheme()
+  const { timeserie } = useTrip()
+
+  const { pointToLayer, style } = useMemo(
+    () => makeGeoJsonOptions(theme),
+    [theme]
+  )
+
+  const mapPanRatio = useMemo(
+    () => (isMobile ? bottomSheetSettings.mediumHeightRatio : 0),
+    [isMobile]
+  )
+
+  useEffect(() => {
+    if (geojsonRef.current) {
+      const geojsonL = geojsonRef.current.leafletElement
+      const bounds = geojsonL.getBounds()
+      const paddingTopLeft = [mapPadding, mapPadding]
+      const paddingBottomRight = [
+        mapPadding,
+        mapPadding + mapL.getSize().y * mapPanRatio
+      ]
+      mapL.fitBounds(bounds, {
+        paddingTopLeft,
+        paddingBottomRight
+      })
+    }
+  }, [mapL, mapPanRatio])
+
+  return (
+    <>
+      <TileLayer
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      />
+      <GeoJSON
+        ref={geojsonRef}
+        data={getGeoJSONData(timeserie)}
+        pointToLayer={pointToLayer}
+        style={style}
+      />
+    </>
+  )
+}
+
+export default TripMapContent

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -12,13 +12,13 @@ import AppProviders from 'src/components/AppProviders'
 import App from 'src/components/App'
 
 const init = function () {
-  const { root, client, lang, polyglot } = setupApp()
+  const { container, client, lang, polyglot } = setupApp()
 
   render(
     <AppProviders client={client} lang={lang} polyglot={polyglot}>
       <App />
     </AppProviders>,
-    root
+    container
   )
 }
 

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -4,7 +4,7 @@ import 'cozy-ui/dist/cozy-ui.utils.min.css'
 import 'src/styles/index.styl'
 
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 
 import setupApp from 'src/targets/browser/setupApp'
 import { register as registerServiceWorker } from 'src/targets/browser/serviceWorkerRegistration'
@@ -13,12 +13,12 @@ import App from 'src/components/App'
 
 const init = function () {
   const { container, client, lang, polyglot } = setupApp()
+  const root = createRoot(container)
 
-  render(
+  root.render(
     <AppProviders client={client} lang={lang} polyglot={polyglot}>
       <App />
-    </AppProviders>,
-    container
+    </AppProviders>
   )
 }
 

--- a/src/targets/browser/setupApp.jsx
+++ b/src/targets/browser/setupApp.jsx
@@ -11,16 +11,16 @@ import { RealtimePlugin } from 'cozy-realtime'
  * Memoize this function in its own file so that it is correctly memoized
  */
 const setupApp = memoize(() => {
-  const root = document.querySelector('[role=application]')
-  const { lang, appName } = getValues(JSON.parse(root.dataset.cozy))
+  const container = document.querySelector('[role=application]')
+  const { lang, appName } = getValues(JSON.parse(container.dataset.cozy))
   const polyglot = initTranslation(lang, lang => require(`locales/${lang}`))
   const client = getClient()
   client.registerPlugin(flag.plugin)
   client.registerPlugin(RealtimePlugin)
 
-  initBar({ client, root, lang, appName })
+  initBar({ client, container, lang, appName })
 
-  return { root, client, lang, polyglot }
+  return { container, client, lang, polyglot }
 })
 
 export default setupApp

--- a/src/utils/bar.js
+++ b/src/utils/bar.js
@@ -32,8 +32,10 @@ export const getValues = ({ app, locale }) => {
  * Cozy bar initialization
  * @param {object} client - cozy client
  */
-export const initBar = ({ client, root, lang, appName }) => {
-  const { appNamePrefix, iconPath } = getValues(JSON.parse(root.dataset.cozy))
+export const initBar = ({ client, container, lang, appName }) => {
+  const { appNamePrefix, iconPath } = getValues(
+    JSON.parse(container.dataset.cozy)
+  )
 
   cozy.bar.init({
     appName,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adobe/css-tools@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.0.1.tgz#b38b444ad3aa5fedbb15f2f746dcd934226a12dd"
+  integrity sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==
+
 "@alloc/types@^1.2.1":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@alloc/types/-/types-1.3.0.tgz#904245b8d3260a4b7d8a801c12501968f64fac08"
@@ -1488,14 +1493,6 @@
     "@babel/helper-validator-option" "^7.16.7"
     "@babel/plugin-transform-typescript" "^7.17.12"
 
-"@babel/runtime-corejs3@^7.10.2":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.19.1.tgz#f0cbbe7edda7c4109cd253bb1dee99aba4594ad9"
-  integrity sha512-j2vJGnkopRzH+ykJ8h68wrHnEUmtK//E723jjixiAl/PPf6FhqY/vYRcMVlNydRKQjQsTsYEjpx+DZMIvnGk/g==
-  dependencies:
-    core-js-pure "^3.25.1"
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime-corejs3@^7.12.1":
   version "7.16.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.16.8.tgz#ea533d96eda6fdc76b1812248e9fbd0c11d4a1a7"
@@ -1529,13 +1526,6 @@
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
   integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.10.2":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
-  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2396,53 +2386,51 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@testing-library/dom@^7.28.1":
-  version "7.31.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"
-  integrity sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==
+"@testing-library/dom@^8.5.0":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.18.1.tgz#80f91be02bc171fe5a3a7003f88207be31ac2cf3"
+  integrity sha512-oEvsm2B/WtcHKE+IcEeeCqNU/ltFGaVyGbpcm4g/2ytuT49jrlH9x5qRKL/H3A6yfM4YAbSbC0ceT5+9CEXnLg==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
+    aria-query "^5.0.0"
     chalk "^4.1.0"
-    dom-accessibility-api "^0.5.6"
+    dom-accessibility-api "^0.5.9"
     lz-string "^1.4.4"
-    pretty-format "^26.6.2"
+    pretty-format "^27.0.2"
 
-"@testing-library/jest-dom@5.16.2":
-  version "5.16.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz#f329b36b44aa6149cd6ced9adf567f8b6aa1c959"
-  integrity sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==
+"@testing-library/jest-dom@5.16.5":
+  version "5.16.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz#3912846af19a29b2dbf32a6ae9c31ef52580074e"
+  integrity sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==
   dependencies:
+    "@adobe/css-tools" "^4.0.1"
     "@babel/runtime" "^7.9.2"
     "@types/testing-library__jest-dom" "^5.9.1"
     aria-query "^5.0.0"
     chalk "^3.0.0"
-    css "^3.0.0"
     css.escape "^1.5.1"
     dom-accessibility-api "^0.5.6"
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"
-  integrity sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==
+"@testing-library/react-hooks@8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@types/react" ">=16.9.0"
-    "@types/react-dom" ">=16.9.0"
-    "@types/react-test-renderer" ">=16.9.0"
     react-error-boundary "^3.1.0"
 
-"@testing-library/react@11.2.7":
-  version "11.2.7"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
-  integrity sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==
+"@testing-library/react@13.4.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.4.0.tgz#6a31e3bf5951615593ad984e96b9e5e2d9380966"
+  integrity sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^7.28.1"
+    "@testing-library/dom" "^8.5.0"
+    "@types/react-dom" "^18.0.0"
 
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
@@ -2608,7 +2596,7 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
   integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
 
-"@types/react-dom@>=16.9.0":
+"@types/react-dom@^18.0.0":
   version "18.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
   integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
@@ -2625,13 +2613,6 @@
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
-"@types/react-test-renderer@>=16.9.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"
-  integrity sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-transition-group@^4.2.0":
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
@@ -2643,15 +2624,6 @@
   version "17.0.38"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
   integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@>=16.9.0":
-  version "18.0.21"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.21.tgz#b8209e9626bb00a34c76f55482697edd2b43cc67"
-  integrity sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -3172,14 +3144,6 @@ argsarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/argsarray/-/argsarray-0.0.1.tgz#6e7207b4ecdb39b0af88303fa5ae22bda8df61cb"
   integrity sha1-bnIHtOzbObCviDA/pa4ivajfYcs=
-
-aria-query@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
-  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
-  dependencies:
-    "@babel/runtime" "^7.10.2"
-    "@babel/runtime-corejs3" "^7.10.2"
 
 aria-query@^5.0.0:
   version "5.0.0"
@@ -4764,11 +4728,6 @@ core-js-pure@^3.20.2:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.20.2.tgz#5d263565f0e34ceeeccdc4422fae3e84ca6b8c0f"
   integrity sha512-CmWHvSKn2vNL6p6StNp1EmMIfVY/pqn3JLAjfZQ8WZGPOlGoO92EkX9/Mk81i6GxvoPXjUqEQnpM3rJ5QxxIOg==
 
-core-js-pure@^3.25.1:
-  version "3.25.3"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.25.3.tgz#66ac5bfa5754b47fdfd14f3841c5ed21c46db608"
-  integrity sha512-T/7qvgv70MEvRkZ8p6BasLZmOVYKzOaWNBEHAU8FmveCJkl4nko2quqPQOmy6AJIp5MBanhz9no3A94NoRb0XA==
-
 core-js@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.0.tgz#a8dbfa978d29bfc263bfb66c556d0ca924c28957"
@@ -5607,15 +5566,6 @@ css@^2.0.0:
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
 
-css@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
-  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
-  dependencies:
-    inherits "^2.0.4"
-    source-map "^0.6.1"
-    source-map-resolve "^0.6.0"
-
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -5986,6 +5936,11 @@ dom-accessibility-api@^0.5.6:
   version "0.5.10"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz#caa6d08f60388d0bb4539dd75fe458a9a1d0014c"
   integrity sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -11860,7 +11815,7 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^27.0.0, pretty-format@^27.5.1:
+pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
   integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
@@ -13524,14 +13479,6 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
-
-source-map-resolve@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
-  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
-  dependencies:
-    atob "^2.1.2"
-    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,7 +1517,7 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
   integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
@@ -2276,6 +2276,11 @@
   version "2.11.2"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
   integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
+
+"@react-leaflet/core@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@react-leaflet/core/-/core-2.1.0.tgz#383acd31259d7c9ae8fb1b02d5e18fe613c2a13d"
+  integrity sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==
 
 "@react-spring/animated@9.0.0-rc.3":
   version "9.0.0-rc.3"
@@ -10469,9 +10474,9 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"
@@ -12239,15 +12244,12 @@ react-layout-effect@^1.0.1:
   resolved "https://registry.yarnpkg.com/react-layout-effect/-/react-layout-effect-1.0.5.tgz#0dc4e24452aee5de66c93c166f0ec512dfb1be80"
   integrity sha512-zdRXHuch+OBHU6bvjTelOGUCM+UDr/iCY+c0wXLEAc+G4/FlcJruD/hUOzlKH5XgO90Y/BUJPNhI/g9kl+VAsA==
 
-react-leaflet@2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/react-leaflet/-/react-leaflet-2.8.0.tgz#14bfc77b6ae8263d3a62e0ba7a39539c05973c6f"
-  integrity sha512-Y7oHtNrrlRH8muDttXf+jZ2Ga/X7jneSGi1GN8uEdeCfLProTqgG2Zoa5TfloS3ZnY20v7w+DIenMG59beFsQw==
+react-leaflet@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/react-leaflet/-/react-leaflet-4.1.0.tgz#b53bce23af3bd932c189d7a80bcc7102db85edee"
+  integrity sha512-i+V9pX5lywJ48O2+K3USeeTdYLIhxnLMweH+YLd/UPqVIj3uKzE3Q29bzt83PBtViyZmxDlulzC6uoR3JLiE9A==
   dependencies:
-    "@babel/runtime" "^7.12.1"
-    fast-deep-equal "^3.1.3"
-    hoist-non-react-statics "^3.3.2"
-    warning "^4.0.3"
+    "@react-leaflet/core" "^2.1.0"
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9712,10 +9712,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-leaflet@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.7.1.tgz#10d684916edfe1bf41d688a3b97127c0322a2a19"
-  integrity sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==
+leaflet@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.9.1.tgz#73c3c31233f5bc69ad3dd681e67860ba28c87291"
+  integrity sha512-5FcDAMTLAuOq0RisQQbTFatl8Sl4bM0gMrBfuHbl7CYbYJv45BfCS8oU3T644MLjleBq1Ncq541QEA1pqUGTFA==
 
 lerna-changelog@0.8.2:
   version "0.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,7 +1488,15 @@
     "@babel/helper-validator-option" "^7.16.7"
     "@babel/plugin-transform-typescript" "^7.17.12"
 
-"@babel/runtime-corejs3@^7.10.2", "@babel/runtime-corejs3@^7.12.1":
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.19.1.tgz#f0cbbe7edda7c4109cd253bb1dee99aba4594ad9"
+  integrity sha512-j2vJGnkopRzH+ykJ8h68wrHnEUmtK//E723jjixiAl/PPf6FhqY/vYRcMVlNydRKQjQsTsYEjpx+DZMIvnGk/g==
+  dependencies:
+    core-js-pure "^3.25.1"
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime-corejs3@^7.12.1":
   version "7.16.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.16.8.tgz#ea533d96eda6fdc76b1812248e9fbd0c11d4a1a7"
   integrity sha512-3fKhuICS1lMz0plI5ktOE/yEtBRMVxplzRkdn6mJQ197XiY0JnrzYV0+Mxozq3JZ8SBV9Ecurmw1XsGbwOf+Sg==
@@ -1517,10 +1525,17 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
   integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2594,9 +2609,9 @@
   integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
 
 "@types/react-dom@>=16.9.0":
-  version "17.0.13"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.13.tgz#a3323b974ee4280070982b3112351bb1952a7809"
-  integrity sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==
+  version "18.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
+  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
   dependencies:
     "@types/react" "*"
 
@@ -2611,9 +2626,9 @@
     redux "^4.0.0"
 
 "@types/react-test-renderer@>=16.9.0":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
-  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"
+  integrity sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==
   dependencies:
     "@types/react" "*"
 
@@ -2634,9 +2649,9 @@
     csstype "^3.0.2"
 
 "@types/react@>=16.9.0":
-  version "17.0.39"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
-  integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
+  version "18.0.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.21.tgz#b8209e9626bb00a34c76f55482697edd2b43cc67"
+  integrity sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -4748,6 +4763,11 @@ core-js-pure@^3.20.2:
   version "3.20.2"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.20.2.tgz#5d263565f0e34ceeeccdc4422fae3e84ca6b8c0f"
   integrity sha512-CmWHvSKn2vNL6p6StNp1EmMIfVY/pqn3JLAjfZQ8WZGPOlGoO92EkX9/Mk81i6GxvoPXjUqEQnpM3rJ5QxxIOg==
+
+core-js-pure@^3.25.1:
+  version "3.25.3"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.25.3.tgz#66ac5bfa5754b47fdfd14f3841c5ed21c46db608"
+  integrity sha512-T/7qvgv70MEvRkZ8p6BasLZmOVYKzOaWNBEHAU8FmveCJkl4nko2quqPQOmy6AJIp5MBanhz9no3A94NoRb0XA==
 
 core-js@3.0.0:
   version "3.0.0"
@@ -12166,14 +12186,13 @@ react-chartjs-2@4.1.0:
   resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-4.1.0.tgz#2a123df16d3a987c54eb4e810ed766d3c03adf8d"
   integrity sha512-AsUihxEp8Jm1oBhbEovE+w50m9PVNhz1sfwEIT4hZduRC0m14gHWHd0cUaxkFDb8HNkdMIGzsNlmVqKiOpU74g==
 
-react-dom@17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.23.0"
 
 react-error-boundary@^3.1.0:
   version "3.1.4"
@@ -12238,6 +12257,11 @@ react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-i
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 react-layout-effect@^1.0.1:
   version "1.0.5"
@@ -12375,7 +12399,7 @@ react-select@^4.3.0:
     react-input-autosize "^3.0.0"
     react-transition-group "^4.3.0"
 
-react-shallow-renderer@^16.13.1:
+react-shallow-renderer@^16.15.0:
   version "16.15.0"
   resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
   integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
@@ -12448,15 +12472,14 @@ react-swipeable-views@^0.13.3:
     react-swipeable-views-utils "^0.13.9"
     warning "^4.0.1"
 
-react-test-renderer@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
-  integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==
+react-test-renderer@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.2.0.tgz#1dd912bd908ff26da5b9fca4fd1c489b9523d37e"
+  integrity sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==
   dependencies:
-    object-assign "^4.1.1"
-    react-is "^17.0.2"
-    react-shallow-renderer "^16.13.1"
-    scheduler "^0.20.2"
+    react-is "^18.2.0"
+    react-shallow-renderer "^16.15.0"
+    scheduler "^0.23.0"
 
 react-themeable@^1.1.0:
   version "1.1.0"
@@ -12497,13 +12520,12 @@ react-use-measure@^2.0.0:
   dependencies:
     debounce "^1.2.1"
 
-react@17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -13107,13 +13129,12 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 schema-utils@^0.4.0:
   version "0.4.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5303,10 +5303,10 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@^74.2.0:
-  version "74.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-74.2.0.tgz#4f3275b10143f4faf89542455d4886d083efa5cc"
-  integrity sha512-FNp29OJm84OUaBzgc+IcLR+IiniBDHbcfO+C6vFSSJFiMytQYMOTfaNkxf2gOHONifG+ZyRZLX6AgAEj0/qTug==
+cozy-ui@^75.4.1:
+  version "75.4.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-75.4.1.tgz#7185d6994ed96e84ab6651eb982dc8b28990898e"
+  integrity sha512-WfpLTA6pHP1AeM6W1YPyWkWCVjWMr+B1gNOF6Y996OAyNU1rS1hv5kIXBUPqkgf9XD0ixvCuDGIz9eNRh8K8CQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -10449,9 +10449,9 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
Mise à jour de l'app en React 18.
La mise à jour de react-leaflet en v4+ était requise.
J'en ai profité pour mettre à jour les libs `@testing-library/*`

```
### ✨ Features
* Update react-leaflet from [2.8.0](https://github.com/PaulLeCam/react-leaflet/releases/tag/v2.8.0) to [4.1.0](https://github.com/PaulLeCam/react-leaflet/releases/tag/v4.1.0)
* Update leaflet from [1.7.1](https://github.com/Leaflet/Leaflet/releases/tag/v1.7.1) to [1.9.1](https://github.com/Leaflet/Leaflet/releases/tag/v1.9.1)

## 🔧 Tech
* Update react packages from [17.0.2](https://github.com/facebook/react/releases/tag/v17.0.2) to [18.2.0](https://github.com/facebook/react/releases/tag/v18.2.0)
* Update @testing-library/react from [11.2.7](https://github.com/testing-library/react-testing-library/releases/tag/v11.2.7) to [13.4.0](https://github.com/testing-library/react-testing-library/releases/tag/v13.4.0)
* Update @testing-library/jest-dom from [5.16.2](https://github.com/testing-library/jest-dom/releases/tag/v5.16.2) to [5.16.5](https://github.com/testing-library/jest-dom/releases/tag/v5.16.5)
* Update @testing-library/react-hooks from [7.0.2](https://github.com/testing-library/react-hooks-testing-library/releases/tag/v8.0.1) to [8.0.1](https://github.com/testing-library/react-hooks-testing-library/releases/tag/v8.0.1)
* Update cozy-ui packages from [74.2.0](https://github.com/cozy/cozy-ui/releases/tag/v74.2.0) to [75.4.1](https://github.com/cozy/cozy-ui/releases/tag/v75.4.1)
```

Dépendances check à propos des cycles de vie dépréciés (`componentWillMount`, `componentWillReceiveProps` & `componentWillUpdate`), à préfixer avec `UNSAFE_`
- [x] [cozy-ui](https://github.com/cozy/cozy-ui/pull/2259) || [commit](ac8434195b90910a341ab2f39dcf55d07ba6d400)
- [x] cozy-client
- [x] cozy-device-helper
- [x] cozy-flags
- [x] cozy-intent
- [x] cozy-logger
- [x] cozy-realtime