### PR TITLE
fix: Unusable index on some instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@material-ui/core": "4",
     "@material-ui/lab": "^4.0.0-alpha.60",
     "chart.js": "3.7.1",
-    "cozy-client": "^33.0.0",
+    "cozy-client": "^33.2.0",
     "cozy-device-helper": "^2.1.0",
     "cozy-flags": "^2.8.7",
     "cozy-intent": "^1.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4971,16 +4971,16 @@ cozy-client@^27.26.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^33.0.0:
-  version "33.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-33.0.0.tgz#0711096ce281c9ebfe017a95475ceacf7879dd2e"
-  integrity sha512-RXzjoii+3/ri99EJTJF+ogEvYKW7qQ2VPcmMS5q1UCBOqziXGnDxND/DbHPX6wZaOynSBfJ/iyBIqhlmEi469w==
+cozy-client@^33.2.0:
+  version "33.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-33.2.0.tgz#276835cce8b230c56631b3cfa98611ea900079d8"
+  integrity sha512-z+oA0Ri+m4vsAE1Gznab+vSP8j/uEa0zv9+qzB5ORIJvQ0QNHuLBWDoy+0FT4Rz4z+qLqDXxYyVVDBuwps4atQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^33.0.0"
+    cozy-stack-client "^33.2.0"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -5276,10 +5276,10 @@ cozy-stack-client@^27.26.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^33.0.0:
-  version "33.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-33.0.0.tgz#cd65a0aa82e773653b6e03392508f30792fea2b2"
-  integrity sha512-SqEhtJXuSDsCeC2goHibozX3c2HzoV/vfnp2J10XORMFcvzfx7pfYuwH5XQrRMtAzhERqqn7UNPjPzb/Yo6ljw==
+cozy-stack-client@^33.2.0:
+  version "33.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-33.2.0.tgz#97b80514d68da2b6392f74d280f9867165b7d606"
+  integrity sha512-50vTnZvjCEYGx5nN+2rLhf63JZICNq9bXKY0QUFmfuMBfOTdD4EGw+EVA0YGxQYaz3E3FLrmMuIw5TtLzCDgcA==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
@@ -10449,9 +10449,9 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
### 🐛 Bug Fixes

* Fix `unusable index`. For few instances, a 'Unusable index' error is thrown, because of a problematic index migration, that should be automatically fixed by cozy-client since the [31.1.1](https://github.com/cozy/cozy-client/releases/tag/v33.1.1)