### PR TITLE
Add a switch to open the onboarding or disable the bike goal

### DIFF
--- a/src/components/CO2EmissionDaccAlertSwitcher.jsx
+++ b/src/components/CO2EmissionDaccAlertSwitcher.jsx
@@ -23,10 +23,11 @@ const CO2EmissionDaccAlertSwitcher = props => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
-  const { isLoading, value, save } = useSettings('hideDaccAlerter')
+
+  const { isLoading, value, save } = useSettings('CO2Emission.showAlert')
 
   const handleChange = ev => {
-    save(ev.target.checked)
+    save(!ev.target.checked)
   }
 
   return (
@@ -39,7 +40,7 @@ const CO2EmissionDaccAlertSwitcher = props => {
           </Typography>
         }
         labelPlacement={isMobile ? 'start' : 'end'}
-        checked={value}
+        checked={!value}
         disabled={isLoading}
         onChange={handleChange}
         control={<Switch color="primary" />}

--- a/src/components/CO2EmissionDaccAlertSwitcher.jsx
+++ b/src/components/CO2EmissionDaccAlertSwitcher.jsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(() => ({
   }
 }))
 
-const CO2EmissionDaccAlertSwitcher = props => {
+const CO2EmissionDaccAlertSwitcher = ({ className }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
@@ -31,7 +31,7 @@ const CO2EmissionDaccAlertSwitcher = props => {
   }
 
   return (
-    <div {...props}>
+    <div className={className}>
       <FormControlLabel
         classes={classes}
         label={

--- a/src/components/CO2EmissionDaccAlertSwitcher.jsx
+++ b/src/components/CO2EmissionDaccAlertSwitcher.jsx
@@ -24,7 +24,7 @@ const CO2EmissionDaccAlertSwitcher = props => {
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
 
-  const { isLoading, value, save } = useSettings('CO2Emission.showAlert')
+  const { isLoading, value = true, save } = useSettings('CO2Emission.showAlert')
 
   const handleChange = ev => {
     save(ev.target.checked)

--- a/src/components/CO2EmissionDaccAlertSwitcher.jsx
+++ b/src/components/CO2EmissionDaccAlertSwitcher.jsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(() => ({
   }
 }))
 
-const DaccAlerterSwitcher = props => {
+const CO2EmissionDaccAlertSwitcher = props => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
@@ -48,4 +48,4 @@ const DaccAlerterSwitcher = props => {
   )
 }
 
-export default DaccAlerterSwitcher
+export default CO2EmissionDaccAlertSwitcher

--- a/src/components/CO2EmissionDaccAlertSwitcher.jsx
+++ b/src/components/CO2EmissionDaccAlertSwitcher.jsx
@@ -27,7 +27,7 @@ const CO2EmissionDaccAlertSwitcher = props => {
   const { isLoading, value, save } = useSettings('CO2Emission.showAlert')
 
   const handleChange = ev => {
-    save(!ev.target.checked)
+    save(ev.target.checked)
   }
 
   return (
@@ -36,11 +36,11 @@ const CO2EmissionDaccAlertSwitcher = props => {
         classes={classes}
         label={
           <Typography style={{ color: 'var(--infoColor)' }}>
-            {t('dacc.settings.hideAlerter')}
+            {t('dacc.settings.showAlerter')}
           </Typography>
         }
         labelPlacement={isMobile ? 'start' : 'end'}
-        checked={!value}
+        checked={value}
         disabled={isLoading}
         onChange={handleChange}
         control={<Switch color="primary" />}

--- a/src/components/CO2EmissionDaccSwitcher.jsx
+++ b/src/components/CO2EmissionDaccSwitcher.jsx
@@ -24,7 +24,11 @@ const CO2EmissionDaccSwitcher = props => {
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
 
-  const { isLoading, value, save } = useSettings('CO2Emission.sendToDACC')
+  const {
+    isLoading,
+    value = false,
+    save
+  } = useSettings('CO2Emission.sendToDACC')
 
   const handleChange = ev => {
     save(ev.target.checked)

--- a/src/components/CO2EmissionDaccSwitcher.jsx
+++ b/src/components/CO2EmissionDaccSwitcher.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import Label from 'cozy-ui/transpiled/react/Label'
 import Switch from 'cozy-ui/transpiled/react/MuiCozyTheme/Switch'
 import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
 import { makeStyles } from 'cozy-ui/transpiled/react/styles'
@@ -36,7 +35,6 @@ const CO2EmissionDaccSwitcher = ({ className }) => {
 
   return (
     <div className={className}>
-      <Label>{t('dacc.settings.label')}</Label>
       <FormControlLabel
         classes={classes}
         label={t('dacc.settings.anonymous_participation')}

--- a/src/components/CO2EmissionDaccSwitcher.jsx
+++ b/src/components/CO2EmissionDaccSwitcher.jsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(() => ({
   }
 }))
 
-const CO2EmissionDaccSwitcher = props => {
+const CO2EmissionDaccSwitcher = ({ className }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
@@ -35,7 +35,7 @@ const CO2EmissionDaccSwitcher = props => {
   }
 
   return (
-    <div {...props}>
+    <div className={className}>
       <Label>{t('dacc.settings.label')}</Label>
       <FormControlLabel
         classes={classes}

--- a/src/components/CO2EmissionDaccSwitcher.jsx
+++ b/src/components/CO2EmissionDaccSwitcher.jsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(() => ({
   }
 }))
 
-const DaccSwitcher = props => {
+const CO2EmissionDaccSwitcher = props => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
@@ -45,4 +45,4 @@ const DaccSwitcher = props => {
   )
 }
 
-export default DaccSwitcher
+export default CO2EmissionDaccSwitcher

--- a/src/components/CO2EmissionDaccSwitcher.jsx
+++ b/src/components/CO2EmissionDaccSwitcher.jsx
@@ -23,7 +23,8 @@ const CO2EmissionDaccSwitcher = props => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
-  const { isLoading, value, save } = useSettings('allowSendDataToDacc')
+
+  const { isLoading, value, save } = useSettings('CO2Emission.sendToDACC')
 
   const handleChange = ev => {
     save(ev.target.checked)

--- a/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
+++ b/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
@@ -18,9 +18,8 @@ const CO2EmissionsChart = () => {
   const theme = useTheme()
   const { isMobile } = useBreakpoints()
   const { account } = useAccountContext()
-  const { isSettingsLoading, value: allowSendDataToDacc } = useSettings(
-    'allowSendDataToDacc'
-  )
+  const { isLoading: isSettingsLoading, value: allowSendDataToDacc } =
+    useSettings('allowSendDataToDacc')
 
   const oneYearOldTimeseriesQuery =
     buildOneYearOldTimeseriesWithAggregationByAccountId(account?._id)

--- a/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
+++ b/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
@@ -19,7 +19,7 @@ const CO2EmissionsChart = () => {
   const { isMobile } = useBreakpoints()
   const { account } = useAccountContext()
 
-  const { isLoading: isSettingsLoading, value: allowSendDataToDacc } =
+  const { isLoading: isSettingsLoading, value: allowSendDataToDacc = false } =
     useSettings('CO2Emission.sendToDACC')
 
   const oneYearOldTimeseriesQuery =

--- a/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
+++ b/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
@@ -18,8 +18,9 @@ const CO2EmissionsChart = () => {
   const theme = useTheme()
   const { isMobile } = useBreakpoints()
   const { account } = useAccountContext()
+
   const { isLoading: isSettingsLoading, value: allowSendDataToDacc } =
-    useSettings('allowSendDataToDacc')
+    useSettings('CO2Emission.sendToDACC')
 
   const oneYearOldTimeseriesQuery =
     buildOneYearOldTimeseriesWithAggregationByAccountId(account?._id)

--- a/src/components/DaccManager/DaccManager.jsx
+++ b/src/components/DaccManager/DaccManager.jsx
@@ -26,13 +26,18 @@ const DaccManager = () => {
     return null
   }
 
-  const { hideDaccAlerter, allowSendDataToDacc } = settings[0] || {}
+  const CO2Emission = settings[0]?.CO2Emission || {}
+
+  const { showAlert, sendToDacc } = CO2Emission
 
   const handleOnDiscard = () => {
     client.save({
       ...settings[0],
       _type: SETTINGS_DOCTYPE,
-      hideDaccAlerter: true
+      CO2Emission: {
+        ...CO2Emission,
+        showAlert: false
+      }
     })
   }
 
@@ -40,14 +45,17 @@ const DaccManager = () => {
     client.save({
       ...settings[0],
       _type: SETTINGS_DOCTYPE,
-      hideDaccAlerter: true,
-      allowSendDataToDacc: true
+      CO2Emission: {
+        ...CO2Emission,
+        showAlert: false,
+        sendToDACC: true
+      }
     })
   }
 
   return (
     <>
-      {!hideDaccAlerter && !allowSendDataToDacc && (
+      {showAlert && !sendToDacc && (
         <DaccBanner
           onDiscard={handleOnDiscard}
           onAccept={() => setShowCompareDialog(true)}

--- a/src/components/DaccManager/DaccManager.jsx
+++ b/src/components/DaccManager/DaccManager.jsx
@@ -28,7 +28,7 @@ const DaccManager = () => {
 
   const CO2Emission = settings[0]?.CO2Emission || {}
 
-  const { showAlert, sendToDacc } = CO2Emission
+  const { showAlert = true, sendToDacc = false } = CO2Emission
 
   const handleOnDiscard = () => {
     client.save({

--- a/src/components/DaccManager/DaccManager.spec.js
+++ b/src/components/DaccManager/DaccManager.spec.js
@@ -11,7 +11,11 @@ jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 const setup = ({
   queryMock = {
     fetchStatus: 'loaded',
-    data: [{ hideDaccAlerter: false, allowSendDataToDacc: undefined }]
+    data: [
+      {
+        CO2Emission: { showAlert: true, sendToDacc: undefined }
+      }
+    ]
   }
 } = {}) => {
   useQuery.mockReturnValue(queryMock)
@@ -45,11 +49,15 @@ describe('DaccManager', () => {
   })
 
   describe('it should not show the banner', () => {
-    it('when hideDaccAlerter is true', () => {
+    it('when showAlert is true', () => {
       const { queryByText } = setup({
         queryMock: {
           fetchStatus: 'loaded',
-          data: [{ hideDaccAlerter: true, allowSendDataToDacc: undefined }]
+          data: [
+            {
+              CO2Emission: { showAlert: false, sendToDacc: undefined }
+            }
+          ]
         }
       })
 
@@ -60,11 +68,15 @@ describe('DaccManager', () => {
       ).toBeNull()
     })
 
-    it('when allowSendDataToDacc is true', () => {
+    it('when sendToDacc is true', () => {
       const { queryByText } = setup({
         queryMock: {
           fetchStatus: 'loaded',
-          data: [{ hideDaccAlerter: false, allowSendDataToDacc: true }]
+          data: [
+            {
+              CO2Emission: { showAlert: true, sendToDacc: true }
+            }
+          ]
         }
       })
 
@@ -75,11 +87,15 @@ describe('DaccManager', () => {
       ).toBeNull()
     })
 
-    it('when hideDaccAlerter and allowSendDataToDacc are both true', () => {
+    it('when showAlert and sendToDacc are both true', () => {
       const { queryByText } = setup({
         queryMock: {
           fetchStatus: 'loaded',
-          data: [{ hideDaccAlerter: true, allowSendDataToDacc: true }]
+          data: [
+            {
+              CO2Emission: { showAlert: false, sendToDacc: true }
+            }
+          ]
         }
       })
 

--- a/src/components/Goals/BikeGoal/BikeGoalAlertManager.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAlertManager.jsx
@@ -10,7 +10,7 @@ const BikeGoalAlertManager = () => {
   const { t } = useI18n()
   const {
     isLoading,
-    value: showGoals,
+    value: showGoals = true,
     save: setShowGoals
   } = useSettings('bikeGoal.showAlert')
 

--- a/src/components/Goals/BikeGoal/BikeGoalAlertManager.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAlertManager.jsx
@@ -10,18 +10,18 @@ const BikeGoalAlertManager = () => {
   const { t } = useI18n()
   const {
     isLoading,
-    value: hideGoals,
-    save: setHideGoals
-  } = useSettings('hideObjectivesAlerter')
+    value: showGoals,
+    save: setShowGoals
+  } = useSettings('bikeGoal.showAlert')
 
   const onDiscard = () => {
-    setHideGoals(true)
+    setShowGoals(false)
   }
   const onParticipate = () => {
     // TODO
   }
 
-  if (!isLoading && hideGoals) return null
+  if (!isLoading && !showGoals) return null
 
   return (
     <>

--- a/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.jsx
@@ -27,7 +27,7 @@ const BikeGoalAlertSwitcher = () => {
   const { isLoading, value, save } = useSettings('bikeGoal.showAlert')
 
   const handleChange = ev => {
-    save(!ev.target.checked)
+    save(ev.target.checked)
   }
 
   return (
@@ -36,11 +36,11 @@ const BikeGoalAlertSwitcher = () => {
         classes={classes}
         label={
           <Typography style={{ color: 'var(--infoColor)' }}>
-            {t('bikeGoal.settings.hideAlerter')}
+            {t('bikeGoal.settings.showAlerter')}
           </Typography>
         }
         labelPlacement={isMobile ? 'start' : 'end'}
-        checked={!value}
+        checked={value}
         disabled={isLoading}
         onChange={handleChange}
         control={<Switch color="primary" />}

--- a/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.jsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(() => ({
   }
 }))
 
-const BikeGoalAlertSwitcher = () => {
+const BikeGoalAlertSwitcher = ({ className }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
@@ -31,7 +31,7 @@ const BikeGoalAlertSwitcher = () => {
   }
 
   return (
-    <div>
+    <div className={className}>
       <FormControlLabel
         classes={classes}
         label={

--- a/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.jsx
@@ -24,7 +24,7 @@ const BikeGoalAlertSwitcher = () => {
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
 
-  const { isLoading, value, save } = useSettings('bikeGoal.showAlert')
+  const { isLoading, value = true, save } = useSettings('bikeGoal.showAlert')
 
   const handleChange = ev => {
     save(ev.target.checked)

--- a/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.jsx
@@ -23,10 +23,11 @@ const BikeGoalAlertSwitcher = () => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const classes = useStyles()
-  const { isLoading, value, save } = useSettings('hideObjectivesAlerter')
+
+  const { isLoading, value, save } = useSettings('bikeGoal.showAlert')
 
   const handleChange = ev => {
-    save(ev.target.checked)
+    save(!ev.target.checked)
   }
 
   return (
@@ -39,7 +40,7 @@ const BikeGoalAlertSwitcher = () => {
           </Typography>
         }
         labelPlacement={isMobile ? 'start' : 'end'}
-        checked={value}
+        checked={!value}
         disabled={isLoading}
         onChange={handleChange}
         control={<Switch color="primary" />}

--- a/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.spec.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.spec.jsx
@@ -1,24 +1,40 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 
+import { useQuery } from 'cozy-client'
+
 import AppLike from 'test/AppLike'
 import { SETTINGS_DOCTYPE } from 'src/doctypes'
 import BikeGoalAlertSwitcher from 'src/components/Goals/BikeGoal/BikeGoalAlertSwitcher'
 
-jest.mock('cozy-client', () => ({
-  ...jest.requireActual('cozy-client'),
-  useQuery: jest.fn(() => ({ data: {} }))
-}))
+jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
+
+const setup = ({
+  queryMock = {
+    fetchStatus: 'loaded',
+    data: []
+  },
+  mockSave = jest.fn()
+} = {}) => {
+  useQuery.mockReturnValue(queryMock)
+
+  return render(
+    <AppLike client={{ save: mockSave }}>
+      <BikeGoalAlertSwitcher />
+    </AppLike>
+  )
+}
 
 describe('BikeGoalAlertSwitcher', () => {
-  it('should call client.save when switch is clicked', () => {
+  it('should call client.save when switch is clicked with no initial value', () => {
     const mockSave = jest.fn()
-    const { getByRole } = render(
-      <AppLike client={{ save: mockSave }}>
-        <BikeGoalAlertSwitcher />
-      </AppLike>
-    )
+    const { getByRole } = setup({
+      mockSave
+    })
+
     const switchBtn = getByRole('checkbox')
+
+    expect(switchBtn.checked).toBe(true)
 
     fireEvent.click(switchBtn)
     expect(mockSave).toBeCalledTimes(1)
@@ -28,13 +44,62 @@ describe('BikeGoalAlertSwitcher', () => {
         showAlert: false
       }
     })
+  })
+
+  it('should call client.save when switch is clicked with a falsy initial value', () => {
+    const queryMock = {
+      fetchStatus: 'loaded',
+      data: [
+        {
+          bikeGoal: { showAlert: false }
+        }
+      ]
+    }
+    const mockSave = jest.fn()
+    const { getByRole } = setup({
+      queryMock,
+      mockSave
+    })
+
+    const switchBtn = getByRole('checkbox')
+
+    expect(switchBtn.checked).toBe(false)
 
     fireEvent.click(switchBtn)
-    expect(mockSave).toBeCalledTimes(2)
+    expect(mockSave).toBeCalledTimes(1)
     expect(mockSave).toBeCalledWith({
       _type: SETTINGS_DOCTYPE,
       bikeGoal: {
         showAlert: true
+      }
+    })
+  })
+
+  it('should call client.save when switch is clicked with a truthy initial value', () => {
+    const queryMock = {
+      fetchStatus: 'loaded',
+      data: [
+        {
+          bikeGoal: { showAlert: true }
+        }
+      ]
+    }
+    const mockSave = jest.fn()
+    const { getByRole } = setup({
+      queryMock,
+      mockSave
+    })
+
+    const switchBtn = getByRole('checkbox')
+
+    expect(switchBtn.checked).toBe(true)
+
+    fireEvent.click(switchBtn)
+    expect(mockSave).toBeCalledTimes(1)
+    expect(mockSave).toBeCalledWith({
+      _type: SETTINGS_DOCTYPE,
+      bikeGoal: {
+        showAlert: false
       }
     })
   })

--- a/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.spec.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.spec.jsx
@@ -24,14 +24,18 @@ describe('BikeGoalAlertSwitcher', () => {
     expect(mockSave).toBeCalledTimes(1)
     expect(mockSave).toBeCalledWith({
       _type: SETTINGS_DOCTYPE,
-      hideObjectivesAlerter: true
+      bikeGoal: {
+        showAlert: false
+      }
     })
 
     fireEvent.click(switchBtn)
     expect(mockSave).toBeCalledTimes(2)
     expect(mockSave).toBeCalledWith({
       _type: SETTINGS_DOCTYPE,
-      hideObjectivesAlerter: false
+      bikeGoal: {
+        showAlert: true
+      }
     })
   })
 })

--- a/src/components/Goals/BikeGoal/BikeGoalOnboardedSwitcher.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalOnboardedSwitcher.jsx
@@ -1,0 +1,67 @@
+import React from 'react'
+
+import Switch from 'cozy-ui/transpiled/react/MuiCozyTheme/Switch'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import useSettings from 'src/hooks/useSettings'
+
+const useStyles = makeStyles(() => ({
+  root: {
+    marginLeft: 0
+  },
+  labelPlacementStart: {
+    display: 'flex',
+    justifyContent: 'space-between'
+  }
+}))
+
+const BikeGoalOnboardedSwitcher = ({ className }) => {
+  const { t } = useI18n()
+  const { isMobile } = useBreakpoints()
+  const classes = useStyles()
+
+  const {
+    isLoading: isOnboardedLoading,
+    value: isOnboarded = false,
+    save: saveOnboarded
+  } = useSettings('bikeGoal.onboarded')
+  const {
+    isLoading: isActivatedLoading,
+    value: isActivated = false,
+    save: saveActivated
+  } = useSettings('bikeGoal.activated')
+
+  const isChecked = isOnboarded || isActivated
+  const isLoading = isOnboardedLoading || isActivatedLoading
+
+  const handleChange = async ev => {
+    if (isActivated) {
+      await saveActivated(ev.target.checked)
+    }
+    await saveOnboarded(ev.target.checked)
+  }
+
+  return (
+    <div className={className}>
+      <FormControlLabel
+        classes={classes}
+        label={
+          <Typography style={{ color: 'var(--infoColor)' }}>
+            {t('bikeGoal.settings.hideOnboarding')}
+          </Typography>
+        }
+        labelPlacement={isMobile ? 'start' : 'end'}
+        checked={isChecked}
+        disabled={isLoading}
+        onChange={handleChange}
+        control={<Switch color="primary" />}
+      />
+    </div>
+  )
+}
+
+export default BikeGoalOnboardedSwitcher

--- a/src/components/Goals/BikeGoal/BikeGoalSwitcher.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalSwitcher.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+import Switch from 'cozy-ui/transpiled/react/MuiCozyTheme/Switch'
+import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import useSettings from 'src/hooks/useSettings'
+
+const useStyles = makeStyles(() => ({
+  root: {
+    marginLeft: 0
+  },
+  labelPlacementStart: {
+    display: 'flex',
+    justifyContent: 'space-between'
+  }
+}))
+
+const BikeGoalSwitcher = ({ className }) => {
+  const { t } = useI18n()
+  const { isMobile } = useBreakpoints()
+  const classes = useStyles()
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  const { isLoading: isOnboardedLoading, value: isOnboarded = false } =
+    useSettings('bikeGoal.onboarded')
+  const {
+    isLoading: isActivatedLoading,
+    value: isActivated = false,
+    save: saveActivated
+  } = useSettings('bikeGoal.activated')
+
+  const isChecked = isOnboarded && isActivated
+  const isLoading = isOnboardedLoading || isActivatedLoading
+
+  const handleChange = async ev => {
+    if (isOnboarded) {
+      await saveActivated(ev.target.checked)
+    } else {
+      navigate('/bikegoal/onboarding', {
+        state: { background: location }
+      })
+    }
+  }
+
+  return (
+    <div className={className}>
+      <FormControlLabel
+        classes={classes}
+        label={t('bikeGoal.settings.participation')}
+        labelPlacement={isMobile ? 'start' : 'end'}
+        checked={isChecked}
+        disabled={isLoading}
+        onChange={handleChange}
+        control={<Switch color="primary" />}
+      />
+    </div>
+  )
+}
+
+export default BikeGoalSwitcher

--- a/src/components/Views/Settings.jsx
+++ b/src/components/Views/Settings.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
 import flag from 'cozy-flags'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Label from 'cozy-ui/transpiled/react/Label'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import {
@@ -16,6 +18,7 @@ import AppVersionNumber from 'src/components/AppVersionNumber'
 import BikeGoalAlertSwitcher from 'src/components/Goals/BikeGoal/BikeGoalAlertSwitcher'
 
 export const Settings = () => {
+  const { t } = useI18n()
   const { account } = useAccountContext()
 
   if (!account) {
@@ -29,6 +32,7 @@ export const Settings = () => {
       <Titlebar />
       <div className="u-mh-1 u-mb-1">
         <AccountSelector className="u-mt-1" />
+        <Label>{t('settings.services')}</Label>
         <div className="u-mt-1">
           <CO2EmissionDaccSwitcher className="u-mt-half-s" />
           {flag('coachco2.admin-mode') && (

--- a/src/components/Views/Settings.jsx
+++ b/src/components/Views/Settings.jsx
@@ -10,8 +10,8 @@ import {
 import Titlebar from 'src/components/Titlebar'
 import CsvExporter from 'src/components/ExportCSV/CsvExporter'
 import AccountSelector from 'src/components/AccountSelector'
-import DaccSwitcher from 'src/components/DaccSwitcher'
-import DaccAlerterSwitcher from 'src/components/DaccAlerterSwitcher'
+import CO2EmissionDaccSwitcher from 'src/components/CO2EmissionDaccSwitcher'
+import CO2EmissionDaccAlertSwitcher from 'src/components/CO2EmissionDaccAlertSwitcher'
 import AppVersionNumber from 'src/components/AppVersionNumber'
 import BikeGoalAlertSwitcher from 'src/components/Goals/BikeGoal/BikeGoalAlertSwitcher'
 
@@ -30,10 +30,10 @@ export const Settings = () => {
       <div className="u-mh-1 u-mv-1-half">
         <AccountSelector />
         <div>
-          <DaccSwitcher className="u-mt-1-half" />
+          <CO2EmissionDaccSwitcher className="u-mt-1-half" />
           {flag('coachco2.admin-mode') && (
             <>
-              <DaccAlerterSwitcher className="u-mt-half-s" />
+              <CO2EmissionDaccAlertSwitcher className="u-mt-half-s" />
               <BikeGoalAlertSwitcher className="u-mt-half-s" />
             </>
           )}

--- a/src/components/Views/Settings.jsx
+++ b/src/components/Views/Settings.jsx
@@ -27,19 +27,19 @@ export const Settings = () => {
   return (
     <>
       <Titlebar />
-      <div className="u-mh-1 u-mv-1-half">
-        <AccountSelector />
-        <div>
-          <CO2EmissionDaccSwitcher className="u-mt-1-half" />
+      <div className="u-mh-1 u-mb-1">
+        <AccountSelector className="u-mt-1" />
+        <div className="u-mt-1">
+          <CO2EmissionDaccSwitcher className="u-mt-half-s" />
           {flag('coachco2.admin-mode') && (
             <>
-              <CO2EmissionDaccAlertSwitcher className="u-mt-half-s" />
-              <BikeGoalAlertSwitcher className="u-mt-half-s" />
+              <CO2EmissionDaccAlertSwitcher className="u-mt-1-half-s" />
+              <BikeGoalAlertSwitcher className="u-mt-1-half-s" />
             </>
           )}
         </div>
         <CsvExporter
-          className="u-mt-1-half"
+          className="u-mt-1"
           accountName={getAccountLabel(account)}
         />
         {flag('coachco2.admin-mode') && <AppVersionNumber />}

--- a/src/components/Views/Settings.jsx
+++ b/src/components/Views/Settings.jsx
@@ -15,6 +15,7 @@ import AccountSelector from 'src/components/AccountSelector'
 import CO2EmissionDaccSwitcher from 'src/components/CO2EmissionDaccSwitcher'
 import CO2EmissionDaccAlertSwitcher from 'src/components/CO2EmissionDaccAlertSwitcher'
 import AppVersionNumber from 'src/components/AppVersionNumber'
+import BikeGoalSwitcher from 'src/components/Goals/BikeGoal/BikeGoalSwitcher'
 import BikeGoalAlertSwitcher from 'src/components/Goals/BikeGoal/BikeGoalAlertSwitcher'
 
 export const Settings = () => {
@@ -34,7 +35,11 @@ export const Settings = () => {
         <AccountSelector className="u-mt-1" />
         <Label>{t('settings.services')}</Label>
         <div className="u-mt-1">
+          <Label>{t('settings.services')}</Label>
           <CO2EmissionDaccSwitcher className="u-mt-half-s" />
+          {flag('coachco2.bikegoal.enabled') && (
+            <BikeGoalSwitcher className="u-mt-1-half-s" />
+          )}
           {flag('coachco2.admin-mode') && (
             <>
               <CO2EmissionDaccAlertSwitcher className="u-mt-1-half-s" />

--- a/src/components/Views/Settings.jsx
+++ b/src/components/Views/Settings.jsx
@@ -17,6 +17,7 @@ import CO2EmissionDaccAlertSwitcher from 'src/components/CO2EmissionDaccAlertSwi
 import AppVersionNumber from 'src/components/AppVersionNumber'
 import BikeGoalSwitcher from 'src/components/Goals/BikeGoal/BikeGoalSwitcher'
 import BikeGoalAlertSwitcher from 'src/components/Goals/BikeGoal/BikeGoalAlertSwitcher'
+import BikeGoalOnboardedSwitcher from 'src/components/Goals/BikeGoal/BikeGoalOnboardedSwitcher'
 
 export const Settings = () => {
   const { t } = useI18n()
@@ -44,6 +45,7 @@ export const Settings = () => {
             <>
               <CO2EmissionDaccAlertSwitcher className="u-mt-1-half-s" />
               <BikeGoalAlertSwitcher className="u-mt-1-half-s" />
+              <BikeGoalOnboardedSwitcher className="u-mt-1-half-s" />
             </>
           )}
         </div>

--- a/src/hooks/useSettings.jsx
+++ b/src/hooks/useSettings.jsx
@@ -16,10 +16,10 @@ const useSettings = setting => {
   const isLoading = isQueryLoading(settingsQueryLeft)
 
   const value = isLoading
-    ? null
+    ? undefined
     : settings && settings[0]
     ? get(settings[0], setting)
-    : null
+    : undefined
 
   const save = async value => {
     const newSettings = {

--- a/src/hooks/useSettings.jsx
+++ b/src/hooks/useSettings.jsx
@@ -1,3 +1,5 @@
+import get from 'lodash/get'
+import set from 'lodash/set'
 import { isQueryLoading, useClient, useQuery } from 'cozy-client'
 
 import { SETTINGS_DOCTYPE } from 'src/doctypes'
@@ -16,15 +18,16 @@ const useSettings = setting => {
   const value = isLoading
     ? null
     : settings && settings[0]
-    ? settings[0][setting]
+    ? get(settings[0], setting)
     : null
 
-  const save = value => {
-    client.save({
+  const save = async value => {
+    const newSettings = {
       ...settings[0],
-      _type: SETTINGS_DOCTYPE,
-      [setting]: value
-    })
+      _type: SETTINGS_DOCTYPE
+    }
+    set(newSettings, setting, value)
+    await client.save(newSettings)
   }
 
   return { isLoading, value, save }

--- a/src/hooks/useSettings.spec.jsx
+++ b/src/hooks/useSettings.spec.jsx
@@ -58,7 +58,7 @@ describe('useSettings', () => {
   })
 
   describe('value', () => {
-    it('should return null if data from query is an empty array', () => {
+    it('should return undefined if data from query is an empty array', () => {
       useQuery.mockReturnValue({
         fetchStatus: 'loaded',
         data: []
@@ -70,7 +70,7 @@ describe('useSettings', () => {
         }
       } = setup('foo')
 
-      expect(value).toBe(null)
+      expect(value).toBe(undefined)
     })
 
     it('should return the value according to the key passed', () => {

--- a/src/lib/dacc.js
+++ b/src/lib/dacc.js
@@ -199,7 +199,7 @@ export const sendMeasuresForAccount = async (client, account) => {
  */
 export const runDACCService = async client => {
   const settings = await client.queryAll(buildSettingsQuery().definition)
-  if (!settings || !settings[0].allowSendDataToDacc) {
+  if (!settings?.[0]?.CO2Emission?.sendToDacc) {
     log('info', 'The user did not give consent to send data to DACC')
     return false
   }

--- a/src/lib/dacc.spec.js
+++ b/src/lib/dacc.spec.js
@@ -287,7 +287,7 @@ describe('runDACCService', () => {
 
     jest
       .spyOn(mockClient, 'queryAll')
-      .mockResolvedValueOnce([{ allowSendDataToDacc: false }])
+      .mockResolvedValueOnce([{ CO2Emission: { sendToDacc: false } }])
     shouldRestart = await dacc.runDACCService(mockClient)
     expect(sendMeasureToDACC).toHaveBeenCalledTimes(0)
     expect(shouldRestart).toBe(false)
@@ -296,7 +296,7 @@ describe('runDACCService', () => {
   it('should return false when there is no more measure to send', async () => {
     jest
       .spyOn(mockClient, 'queryAll')
-      .mockResolvedValueOnce([{ allowSendDataToDacc: true }])
+      .mockResolvedValueOnce([{ CO2Emission: { sendToDacc: true } }])
     jest
       .spyOn(mockClient, 'queryAll')
       .mockResolvedValueOnce([
@@ -314,7 +314,7 @@ describe('runDACCService', () => {
   it('should return true when there are no more measure to send', async () => {
     jest
       .spyOn(mockClient, 'queryAll')
-      .mockResolvedValueOnce([{ allowSendDataToDacc: true }])
+      .mockResolvedValueOnce([{ CO2Emission: { sendToDacc: true } }])
     jest
       .spyOn(mockClient, 'queryAll')
       .mockResolvedValueOnce([

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -168,7 +168,8 @@
     },
     "settings": {
       "participation": "Participate to the goal “Bike to work”",
-      "showAlerter": "Show bike goals alerter"
+      "showAlerter": "Show bike goals alerter",
+      "hideOnboarding": "Hide bike goal onboarding"
     }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -14,6 +14,9 @@
     "select": "Select a device",
     "label": "Data source"
   },
+  "settings": {
+    "services": "Services"
+  },
   "trips": {
     "trips": "Trips",
     "from": "Trips from",
@@ -114,7 +117,6 @@
   },
   "dacc": {
     "settings": {
-      "label": "Data transmission",
       "anonymous_participation": "Participate anonymously in the calculation of average CO2 emissions",
       "showAlerter": "Show DACC alerter"
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -167,6 +167,7 @@
       }
     },
     "settings": {
+      "participation": "Participate to the goal “Bike to work”",
       "showAlerter": "Show bike goals alerter"
     }
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -116,7 +116,7 @@
     "settings": {
       "label": "Data transmission",
       "anonymous_participation": "Participate anonymously in the calculation of average CO2 emissions",
-      "hideAlerter": "Hide DACC alerter"
+      "showAlerter": "Show DACC alerter"
     },
     "tripsCard": {
       "label": "Compare your emissions to the average of other users of the application?",
@@ -165,7 +165,7 @@
       }
     },
     "settings": {
-      "hideAlerter": "Hide bike goals alerter"
+      "showAlerter": "Show bike goals alerter"
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -167,6 +167,7 @@
       }
     },
     "settings": {
+      "participation": "Participer à l'objectif “Aller au travail à vélo”",
       "showAlerter": "Afficher l'alerter de l'objectif vélo"
     }
   }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -14,6 +14,9 @@
     "select": "Sélectionnez un appareil",
     "label": "Source des données"
   },
+  "settings": {
+    "services": "Services"
+  },
   "trips": {
     "trips": "Déplacements",
     "from": "Déplacements de",
@@ -114,7 +117,6 @@
   },
   "dacc": {
     "settings": {
-      "label": "Transmission des données",
       "anonymous_participation": "Participer anonymement au calcul des émissions moyennes de CO2",
       "showAlerter": "Afficher l'alerter DACC"
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -116,7 +116,7 @@
     "settings": {
       "label": "Transmission des données",
       "anonymous_participation": "Participer anonymement au calcul des émissions moyennes de CO2",
-      "hideAlerter": "Masquer l'alerter DACC"
+      "showAlerter": "Afficher l'alerter DACC"
     },
     "tripsCard": {
       "label": "Comparez vos émissions à la moyenne des autres utilisateurs de l’application ?",
@@ -165,7 +165,7 @@
       }
     },
     "settings": {
-      "hideAlerter": "Masquer l'alerter de l'objectif vélo"
+      "showAlerter": "Afficher l'alerter de l'objectif vélo"
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -168,7 +168,8 @@
     },
     "settings": {
       "participation": "Participer à l'objectif “Aller au travail à vélo”",
-      "showAlerter": "Afficher l'alerter de l'objectif vélo"
+      "showAlerter": "Afficher l'alerter de l'objectif vélo",
+      "hideOnboarding": "Masquer l'embarquement d'objectif vélo"
     }
   }
 }


### PR DESCRIPTION
This PR mainly focuses on two things: changing the shape of the app settings in the database, which is a breaking change (no migration path is planned), and add one switch to open the onboarding if not completed yet, or to deactivate the bike goal feature afterwards.
The switch is kept behind the flag `coachco2.bikegoal.enabled` while the breaking change applies to every user of this branch.
Another switch is also added in admin mode to help to reset the upcoming onboarding.

```
### ✨ Features

* Move CO2 Emission settings to a dedicated object
* Add a switch to open the onboarding or disable the bike goal
```