### PR TITLE
Add navigation to and from the onboarding page

### DIFF
--- a/src/components/Goals/BikeGoal/BikeGoalAlertManager.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAlertManager.jsx
@@ -1,9 +1,12 @@
 import React from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import useSettings from 'src/hooks/useSettings'
 import BikeGoalAlert from 'src/components/Goals/BikeGoal/BikeGoalAlert'
 
 const BikeGoalAlertManager = () => {
+  const location = useLocation()
+  const navigate = useNavigate()
   const {
     isLoading,
     value: showGoals = true,
@@ -14,7 +17,9 @@ const BikeGoalAlertManager = () => {
     setShowGoals(false)
   }
   const onParticipate = () => {
-    // TODO
+    navigate('/bikegoal/onboarding', {
+      state: { background: location }
+    })
   }
 
   if (!isLoading && !showGoals) return null

--- a/src/components/Views/BikeGoalOnboarding.jsx
+++ b/src/components/Views/BikeGoalOnboarding.jsx
@@ -1,16 +1,38 @@
 import React from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
-import { useNavigate } from 'react-router-dom'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 
 const BikeGoalOnboarding = () => {
+  const { t } = useI18n()
+  const location = useLocation()
   const navigate = useNavigate()
+
+  const handleBack = () => {
+    navigate(location.state.background)
+  }
+
+  const handleForward = () => {
+    navigate('/bikegoal')
+  }
+
   return (
     <Dialog
       open
-      title="Bike Goal Onboarding"
-      content="⚠️ under construction ⚠️"
-      onClose={() => navigate('/settings')}
+      disableGutters
+      title={t('bikeGoal.onboarding.title')}
+      content={
+        <>
+          <div>⚠️ under construction ⚠️</div>
+          <Button
+            onClick={handleForward}
+            label={t('bikeGoal.onboarding.actions.finish')}
+          />
+        </>
+      }
+      onClose={handleBack}
     />
   )
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -198,6 +198,12 @@
       "showAlerter": "Show bike goals alerter",
       "hideOnboarding": "Hide bike goal onboarding",
       "showAlerterSuccess": "Show the bike goal success alert"
+    },
+    "onboarding": {
+      "title": "\"Sustainable mobility\" package",
+      "actions": {
+        "finish": "Finish"
+      }
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -198,6 +198,12 @@
       "showAlerter": "Afficher l'alerter de l'objectif vélo",
       "hideOnboarding": "Masquer l'embarquement d'objectif vélo",
       "showAlerterSuccess": "Afficher l'alerte de succès de l'objectif vélo"
+    },
+    "onboarding": {
+      "title": "Forfait \"mobilités durables\"",
+      "actions": {
+        "finish": "Terminer"
+      }
     }
   }
 }


### PR DESCRIPTION
This makes it so:
- clicking on the "Participate" button in the alerter opens the onboarding
- clicking on the back button in the onboarding goes back to the background location (either the settings or the trips)
- clicking on a temporary "Finish" button in the onboarding opens the current year for the bike goal

This also updates the title of the onboarding dialog.
```
### ✨ Features

* Add navigation to and from the onboarding page
```
