### PR TITLE
Enabled the bike goal feature and disable the onboarding once completed

### DIFF
--- a/src/components/Views/BikeGoalOnboarding.jsx
+++ b/src/components/Views/BikeGoalOnboarding.jsx
@@ -1,20 +1,36 @@
-import React from 'react'
+import React, { useReducer } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Button from 'cozy-ui/transpiled/react/Buttons'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+import useSettings from 'src/hooks/useSettings'
 
 const BikeGoalOnboarding = () => {
   const { t } = useI18n()
   const location = useLocation()
   const navigate = useNavigate()
+  const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
+  const {
+    isLoading,
+    value: bikeGoal = {},
+    save: setBikeGoal
+  } = useSettings('bikeGoal')
 
   const handleBack = () => {
     navigate(location.state.background)
   }
 
-  const handleForward = () => {
+  const handleForward = async () => {
+    toggleBusy()
+    await setBikeGoal({
+      ...bikeGoal,
+      onboarded: true,
+      activated: true,
+      showAlert: false
+    })
     navigate('/bikegoal')
   }
 
@@ -25,11 +41,22 @@ const BikeGoalOnboarding = () => {
       title={t('bikeGoal.onboarding.title')}
       content={
         <>
-          <div>⚠️ under construction ⚠️</div>
-          <Button
-            onClick={handleForward}
-            label={t('bikeGoal.onboarding.actions.finish')}
-          />
+          {isLoading && (
+            <Spinner
+              size="xxlarge"
+              className="u-flex u-flex-justify-center u-m-1"
+            />
+          )}
+          {!isLoading && (
+            <>
+              <div>⚠️ under construction ⚠️</div>
+              <Button
+                onClick={handleForward}
+                label={t('bikeGoal.onboarding.actions.finish')}
+                busy={isBusy}
+              />
+            </>
+          )}
         </>
       }
       onClose={handleBack}


### PR DESCRIPTION
This is on top of #220.

This hides the alerter and enables the bike goal feature when clicking on the temporary "Finish" button in the onboarding.
At this point of the stepper, most of the settings related to the feature should already be set, so there is no need to set them again (please note that the stepper is not yet implemented, so that's not the case currently).


```
### ✨ Features

* Enabled the bike goal feature and disable the onboarding once completed
```
