### PR TITLE
Make the permission dialog reusable

### DIFF
--- a/src/components/DaccBanner/CO2EmissionDaccBanner.jsx
+++ b/src/components/DaccBanner/CO2EmissionDaccBanner.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import Banner from 'cozy-ui/transpiled/react/Banner'
 import Button from 'cozy-ui/transpiled/react/Buttons'
@@ -39,6 +40,11 @@ const CO2EmissionDaccBanner = ({ onDiscard, onAccept }) => {
       disableIconStyles
     />
   )
+}
+
+CO2EmissionDaccBanner.propTypes = {
+  onDiscard: PropTypes.func.isRequired,
+  onAccept: PropTypes.func.isRequired
 }
 
 export default CO2EmissionDaccBanner

--- a/src/components/DaccBanner/CO2EmissionDaccBanner.jsx
+++ b/src/components/DaccBanner/CO2EmissionDaccBanner.jsx
@@ -6,7 +6,7 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import LightbulbIcon from 'cozy-ui/transpiled/react/Icons/Lightbulb'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-const DaccBanner = ({ onDiscard, onAccept }) => {
+const CO2EmissionDaccBanner = ({ onDiscard, onAccept }) => {
   const { t } = useI18n()
 
   return (
@@ -41,4 +41,4 @@ const DaccBanner = ({ onDiscard, onAccept }) => {
   )
 }
 
-export default DaccBanner
+export default CO2EmissionDaccBanner

--- a/src/components/DaccManager/BikeGoalDaccManager.jsx
+++ b/src/components/DaccManager/BikeGoalDaccManager.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import DaccManager from 'src/components/DaccManager/DaccManager'
+
+const BikeGoalDaccManager = ({ onClose, onRefuse, onAccept }) => {
+  const { t } = useI18n()
+
+  return (
+    <DaccManager
+      onClose={onClose}
+      onRefuse={onRefuse}
+      onAccept={onAccept}
+      componentProps={{
+        DaccPermissionsDialog: {
+          sharedDataLabel: t(
+            'dacc.permissionsDialog.anonymized_bikegoal_progression'
+          )
+        }
+      }}
+    />
+  )
+}
+
+export default BikeGoalDaccManager

--- a/src/components/DaccManager/BikeGoalDaccManager.jsx
+++ b/src/components/DaccManager/BikeGoalDaccManager.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
@@ -21,6 +22,12 @@ const BikeGoalDaccManager = ({ onClose, onRefuse, onAccept }) => {
       }}
     />
   )
+}
+
+BikeGoalDaccManager.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onRefuse: PropTypes.func.isRequired,
+  onAccept: PropTypes.func.isRequired
 }
 
 export default BikeGoalDaccManager

--- a/src/components/DaccManager/CO2EmissionDaccCompareDialog.jsx
+++ b/src/components/DaccManager/CO2EmissionDaccCompareDialog.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Button from 'cozy-ui/transpiled/react/Buttons'
@@ -44,6 +45,12 @@ const CO2EmissionDaccCompareDialog = ({
       }
     />
   )
+}
+
+CO2EmissionDaccCompareDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  showDaccPermissionsDialog: PropTypes.func.isRequired
 }
 
 export default CO2EmissionDaccCompareDialog

--- a/src/components/DaccManager/CO2EmissionDaccCompareDialog.jsx
+++ b/src/components/DaccManager/CO2EmissionDaccCompareDialog.jsx
@@ -8,7 +8,11 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import DaccCompareSVG from 'src/assets/icons/dacc-compare.svg'
 
-const DaccDialogsManager = ({ open, onClose, showDaccPermissionsDialog }) => {
+const CO2EmissionDaccCompareDialog = ({
+  open,
+  onClose,
+  showDaccPermissionsDialog
+}) => {
   const { t } = useI18n()
 
   return (
@@ -42,4 +46,4 @@ const DaccDialogsManager = ({ open, onClose, showDaccPermissionsDialog }) => {
   )
 }
 
-export default DaccDialogsManager
+export default CO2EmissionDaccCompareDialog

--- a/src/components/DaccManager/CO2EmissionDaccManager.jsx
+++ b/src/components/DaccManager/CO2EmissionDaccManager.jsx
@@ -1,10 +1,8 @@
 import React, { useState } from 'react'
 
-import { isQueryLoading, useClient, useQuery } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-import { SETTINGS_DOCTYPE } from 'src/doctypes'
-import { buildSettingsQuery } from 'src/queries/queries'
+import useSettings from 'src/hooks/useSettings'
 import CO2EmissionDaccBanner from 'src/components/DaccBanner/CO2EmissionDaccBanner'
 import CO2EmissionDaccCompareDialog from 'src/components/DaccManager/CO2EmissionDaccCompareDialog'
 import DaccManager from 'src/components/DaccManager/DaccManager'
@@ -13,43 +11,30 @@ const CO2EmissionDaccManager = () => {
   const { t } = useI18n()
   const [showCompareDialog, setShowCompareDialog] = useState(false)
   const [showPermissionsDialog, setShowPermissionsDialog] = useState(false)
-  const client = useClient()
-  const settingsQuery = buildSettingsQuery()
-  const { data: settings, ...settingsQueryLeft } = useQuery(
-    settingsQuery.definition,
-    settingsQuery.options
-  )
-
-  const isLoading = isQueryLoading(settingsQueryLeft)
+  const {
+    isLoading,
+    value: CO2Emission = {},
+    save: setCO2Emission
+  } = useSettings('CO2Emission')
 
   if (isLoading) {
     return null
   }
 
-  const CO2Emission = settings[0]?.CO2Emission || {}
-
   const { showAlert = true, sendToDacc = false } = CO2Emission
 
   const handleOnDiscard = () => {
-    client.save({
-      ...settings[0],
-      _type: SETTINGS_DOCTYPE,
-      CO2Emission: {
-        ...CO2Emission,
-        showAlert: false
-      }
+    setCO2Emission({
+      ...CO2Emission,
+      showAlert: false
     })
   }
 
   const handleOnAccept = () => {
-    client.save({
-      ...settings[0],
-      _type: SETTINGS_DOCTYPE,
-      CO2Emission: {
-        ...CO2Emission,
-        showAlert: false,
-        sendToDACC: true
-      }
+    setCO2Emission({
+      ...CO2Emission,
+      showAlert: false,
+      sendToDACC: true
     })
   }
 

--- a/src/components/DaccManager/CO2EmissionDaccManager.jsx
+++ b/src/components/DaccManager/CO2EmissionDaccManager.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 
 import { isQueryLoading, useClient, useQuery } from 'cozy-client'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import { SETTINGS_DOCTYPE } from 'src/doctypes'
 import { buildSettingsQuery } from 'src/queries/queries'
@@ -9,6 +10,7 @@ import CO2EmissionDaccCompareDialog from 'src/components/DaccManager/CO2Emission
 import DaccManager from 'src/components/DaccManager/DaccManager'
 
 const CO2EmissionDaccManager = () => {
+  const { t } = useI18n()
   const [showCompareDialog, setShowCompareDialog] = useState(false)
   const [showPermissionsDialog, setShowPermissionsDialog] = useState(false)
   const client = useClient()
@@ -74,6 +76,11 @@ const CO2EmissionDaccManager = () => {
           onAccept={() => {
             handleOnAccept()
             setShowPermissionsDialog(false)
+          }}
+          componentProps={{
+            DaccPermissionsDialog: {
+              sharedDataLabel: t('dacc.permissionsDialog.anonymized_emissions')
+            }
           }}
         />
       )}

--- a/src/components/DaccManager/CO2EmissionDaccManager.jsx
+++ b/src/components/DaccManager/CO2EmissionDaccManager.jsx
@@ -6,13 +6,11 @@ import { SETTINGS_DOCTYPE } from 'src/doctypes'
 import { buildSettingsQuery } from 'src/queries/queries'
 import CO2EmissionDaccBanner from 'src/components/DaccBanner/CO2EmissionDaccBanner'
 import CO2EmissionDaccCompareDialog from 'src/components/DaccManager/CO2EmissionDaccCompareDialog'
-import DaccPermissionsDialog from 'src/components/DaccManager/DaccPermissionsDialog'
-import DaccReasonsDialog from 'src/components/DaccManager/DaccReasonsDialog'
+import DaccManager from 'src/components/DaccManager/DaccManager'
 
 const CO2EmissionDaccManager = () => {
   const [showCompareDialog, setShowCompareDialog] = useState(false)
   const [showPermissionsDialog, setShowPermissionsDialog] = useState(false)
-  const [showReasonsDialog, setShowReasonsDialog] = useState(false)
   const client = useClient()
   const settingsQuery = buildSettingsQuery()
   const { data: settings, ...settingsQueryLeft } = useQuery(
@@ -69,19 +67,15 @@ const CO2EmissionDaccManager = () => {
           setShowPermissionsDialog(true)
         }}
       />
-      <DaccPermissionsDialog
-        open={showPermissionsDialog}
-        onClose={() => setShowPermissionsDialog(false)}
-        onAccept={() => {
-          handleOnAccept()
-          setShowPermissionsDialog(false)
-        }}
-        showDaccReasonsDialog={() => setShowReasonsDialog(true)}
-      />
-      <DaccReasonsDialog
-        open={showReasonsDialog}
-        onClose={() => setShowReasonsDialog(false)}
-      />
+      {showPermissionsDialog && (
+        <DaccManager
+          onClose={() => setShowPermissionsDialog(false)}
+          onAccept={() => {
+            handleOnAccept()
+            setShowPermissionsDialog(false)
+          }}
+        />
+      )}
     </>
   )
 }

--- a/src/components/DaccManager/CO2EmissionDaccManager.jsx
+++ b/src/components/DaccManager/CO2EmissionDaccManager.jsx
@@ -73,4 +73,6 @@ const CO2EmissionDaccManager = () => {
   )
 }
 
+CO2EmissionDaccManager.propTypes = {}
+
 export default CO2EmissionDaccManager

--- a/src/components/DaccManager/CO2EmissionDaccManager.jsx
+++ b/src/components/DaccManager/CO2EmissionDaccManager.jsx
@@ -4,12 +4,12 @@ import { isQueryLoading, useClient, useQuery } from 'cozy-client'
 
 import { SETTINGS_DOCTYPE } from 'src/doctypes'
 import { buildSettingsQuery } from 'src/queries/queries'
-import DaccBanner from 'src/components/DaccBanner/DaccBanner'
-import DaccCompareDialog from 'src/components/DaccManager/DaccCompareDialog'
+import CO2EmissionDaccBanner from 'src/components/DaccBanner/CO2EmissionDaccBanner'
+import CO2EmissionDaccCompareDialog from 'src/components/DaccManager/CO2EmissionDaccCompareDialog'
 import DaccPermissionsDialog from 'src/components/DaccManager/DaccPermissionsDialog'
 import DaccReasonsDialog from 'src/components/DaccManager/DaccReasonsDialog'
 
-const DaccManager = () => {
+const CO2EmissionDaccManager = () => {
   const [showCompareDialog, setShowCompareDialog] = useState(false)
   const [showPermissionsDialog, setShowPermissionsDialog] = useState(false)
   const [showReasonsDialog, setShowReasonsDialog] = useState(false)
@@ -56,12 +56,12 @@ const DaccManager = () => {
   return (
     <>
       {showAlert && !sendToDacc && (
-        <DaccBanner
+        <CO2EmissionDaccBanner
           onDiscard={handleOnDiscard}
           onAccept={() => setShowCompareDialog(true)}
         />
       )}
-      <DaccCompareDialog
+      <CO2EmissionDaccCompareDialog
         open={showCompareDialog}
         onClose={() => setShowCompareDialog(false)}
         showDaccPermissionsDialog={() => {
@@ -86,4 +86,4 @@ const DaccManager = () => {
   )
 }
 
-export default DaccManager
+export default CO2EmissionDaccManager

--- a/src/components/DaccManager/CO2EmissionDaccManager.jsx
+++ b/src/components/DaccManager/CO2EmissionDaccManager.jsx
@@ -70,6 +70,7 @@ const CO2EmissionDaccManager = () => {
       {showPermissionsDialog && (
         <DaccManager
           onClose={() => setShowPermissionsDialog(false)}
+          onRefuse={() => setShowPermissionsDialog(false)}
           onAccept={() => {
             handleOnAccept()
             setShowPermissionsDialog(false)

--- a/src/components/DaccManager/CO2EmissionDaccManager.spec.js
+++ b/src/components/DaccManager/CO2EmissionDaccManager.spec.js
@@ -4,7 +4,7 @@ import { render, fireEvent } from '@testing-library/react'
 import { useQuery } from 'cozy-client'
 
 import AppLike from 'test/AppLike'
-import DaccManager from 'src/components/DaccManager/DaccManager'
+import CO2EmissionDaccManager from 'src/components/DaccManager/CO2EmissionDaccManager'
 
 jest.mock('cozy-client/dist/hooks/useQuery', () => jest.fn())
 
@@ -22,7 +22,7 @@ const setup = ({
 
   return render(
     <AppLike>
-      <DaccManager />
+      <CO2EmissionDaccManager />
     </AppLike>
   )
 }

--- a/src/components/DaccManager/DaccManager.jsx
+++ b/src/components/DaccManager/DaccManager.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 
 import DaccPermissionsDialog from 'src/components/DaccManager/DaccPermissionsDialog'
 import DaccReasonsDialog from 'src/components/DaccManager/DaccReasonsDialog'
@@ -21,6 +22,17 @@ const DaccManager = ({ onClose, onRefuse, onAccept, componentProps }) => {
       )}
     </>
   )
+}
+
+DaccManager.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onRefuse: PropTypes.func.isRequired,
+  onAccept: PropTypes.func.isRequired,
+  componentProps: PropTypes.shape({
+    DaccPermissionsDialog: PropTypes.shape({
+      sharedDataLabel: PropTypes.string.isRequired
+    }).isRequired
+  }).isRequired
 }
 
 export default DaccManager

--- a/src/components/DaccManager/DaccManager.jsx
+++ b/src/components/DaccManager/DaccManager.jsx
@@ -3,8 +3,9 @@ import React, { useState } from 'react'
 import DaccPermissionsDialog from 'src/components/DaccManager/DaccPermissionsDialog'
 import DaccReasonsDialog from 'src/components/DaccManager/DaccReasonsDialog'
 
-const DaccManager = ({ onClose, onRefuse, onAccept }) => {
+const DaccManager = ({ onClose, onRefuse, onAccept, componentProps }) => {
   const [showReasonsDialog, setShowReasonsDialog] = useState(false)
+
   return (
     <>
       <DaccPermissionsDialog
@@ -13,6 +14,7 @@ const DaccManager = ({ onClose, onRefuse, onAccept }) => {
         onRefuse={onRefuse}
         onAccept={onAccept}
         showDaccReasonsDialog={() => setShowReasonsDialog(true)}
+        {...componentProps.DaccPermissionsDialog}
       />
       {showReasonsDialog && (
         <DaccReasonsDialog open onClose={() => setShowReasonsDialog(false)} />

--- a/src/components/DaccManager/DaccManager.jsx
+++ b/src/components/DaccManager/DaccManager.jsx
@@ -3,13 +3,14 @@ import React, { useState } from 'react'
 import DaccPermissionsDialog from 'src/components/DaccManager/DaccPermissionsDialog'
 import DaccReasonsDialog from 'src/components/DaccManager/DaccReasonsDialog'
 
-const DaccManager = ({ onClose, onAccept }) => {
+const DaccManager = ({ onClose, onRefuse, onAccept }) => {
   const [showReasonsDialog, setShowReasonsDialog] = useState(false)
   return (
     <>
       <DaccPermissionsDialog
         open
         onClose={onClose}
+        onRefuse={onRefuse}
         onAccept={onAccept}
         showDaccReasonsDialog={() => setShowReasonsDialog(true)}
       />

--- a/src/components/DaccManager/DaccManager.jsx
+++ b/src/components/DaccManager/DaccManager.jsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react'
+
+import DaccPermissionsDialog from 'src/components/DaccManager/DaccPermissionsDialog'
+import DaccReasonsDialog from 'src/components/DaccManager/DaccReasonsDialog'
+
+const DaccManager = ({ onClose, onAccept }) => {
+  const [showReasonsDialog, setShowReasonsDialog] = useState(false)
+  return (
+    <>
+      <DaccPermissionsDialog
+        open
+        onClose={onClose}
+        onAccept={onAccept}
+        showDaccReasonsDialog={() => setShowReasonsDialog(true)}
+      />
+      {showReasonsDialog && (
+        <DaccReasonsDialog open onClose={() => setShowReasonsDialog(false)} />
+      )}
+    </>
+  )
+}
+
+export default DaccManager

--- a/src/components/DaccManager/DaccPermissionsDialog.jsx
+++ b/src/components/DaccManager/DaccPermissionsDialog.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Button from 'cozy-ui/transpiled/react/Buttons'
@@ -102,6 +103,15 @@ const DaccPermissionsDialog = ({
       />
     </CozyTheme>
   )
+}
+
+DaccPermissionsDialog.propTypes = {
+  sharedDataLabel: PropTypes.string.isRequired,
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onRefuse: PropTypes.func.isRequired,
+  onAccept: PropTypes.func.isRequired,
+  showDaccReasonsDialog: PropTypes.func.isRequired
 }
 
 export default DaccPermissionsDialog

--- a/src/components/DaccManager/DaccPermissionsDialog.jsx
+++ b/src/components/DaccManager/DaccPermissionsDialog.jsx
@@ -17,6 +17,7 @@ import AnonymousIcon from 'src/assets/icons/icon-anonymous.svg'
 import ExportIcon from 'src/assets/icons/icon-export.svg'
 
 const DaccPermissionsDialog = ({
+  sharedDataLabel,
   open,
   onClose,
   onRefuse,
@@ -61,7 +62,7 @@ const DaccPermissionsDialog = ({
                     <ListItemText
                       primary={
                         <Typography variant="body2">
-                          {t('dacc.permissionsDialog.anonymized_emissions')}
+                          {sharedDataLabel}
                         </Typography>
                       }
                     />

--- a/src/components/DaccManager/DaccPermissionsDialog.jsx
+++ b/src/components/DaccManager/DaccPermissionsDialog.jsx
@@ -19,6 +19,7 @@ import ExportIcon from 'src/assets/icons/icon-export.svg'
 const DaccPermissionsDialog = ({
   open,
   onClose,
+  onRefuse,
   onAccept,
   showDaccReasonsDialog
 }) => {
@@ -89,7 +90,7 @@ const DaccPermissionsDialog = ({
           <>
             <Button
               label={t('dacc.permissionsDialog.refuse')}
-              onClick={onClose}
+              onClick={onRefuse}
             />
             <Button
               label={t('dacc.permissionsDialog.accept')}

--- a/src/components/DaccManager/DaccReasonsDialog.jsx
+++ b/src/components/DaccManager/DaccReasonsDialog.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -14,6 +15,11 @@ const DaccReasonsDialog = ({ open, onClose }) => {
       content={t('dacc.reasonsDialog.content')}
     />
   )
+}
+
+DaccReasonsDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired
 }
 
 export default DaccReasonsDialog

--- a/src/components/Views/Trips.jsx
+++ b/src/components/Views/Trips.jsx
@@ -17,7 +17,7 @@ import {
 } from 'src/components/Providers/AccountProvider'
 import SpinnerOrEmptyContent from 'src/components/SpinnerOrEmptyContent'
 import CO2EmissionsChart from 'src/components/CO2EmissionsChart/CO2EmissionsChart'
-import DaccManager from 'src/components/DaccManager/DaccManager'
+import CO2EmissionDaccManager from 'src/components/DaccManager/CO2EmissionDaccManager'
 import BikeGoalManager from 'src/components/Goals/BikeGoal/BikeGoalManager'
 
 const style = {
@@ -80,7 +80,7 @@ export const Trips = () => {
       )}
       {flag('coachco2.bikegoal.enabled') && <BikeGoalManager />}
       <CO2EmissionsChart />
-      <DaccManager />
+      <CO2EmissionDaccManager />
       {isMobile && <Divider style={style.divider} />}
       <TripsList timeseries={timeseries} />
       {timeseriesQueryLeft.hasMore && (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -139,6 +139,7 @@
       "why_asking": "Why ask me for these permissions?",
       "export_outside": "Exporting out of Cozy",
       "anonymized_emissions": "My anonymized CO2 emissions",
+      "anonymized_bikegoal_progression": "My anonymized progression",
       "accept": "Always allow",
       "refuse": "Refuse"
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -139,6 +139,7 @@
       "why_asking": "Pourquoi me demander ces permissions ?",
       "export_outside": "Exporter hors du Cozy",
       "anonymized_emissions": "Mes émissions de CO2 anonymisées",
+      "anonymized_bikegoal_progression": "Ma progression de façon anonyme",
       "accept": "Toujours autoriser",
       "refuse": "Refuser"
     },


### PR DESCRIPTION
Mostly renaming and refactoring to extract the blue permission modal from the CO2 emission Dacc manager to reuse it for the bike goal feature. The only variable part is the type of data we ask to share.

The `BikeGoalDaccManager` component introduced here is not used anywhere yet but it will be in the stepper on the onboarding page. This component does not really carry any logic and just takes callbacks as props that will be called by the stepper, contrary to the similar component `CO2EmissionDaccManager`.

```
### 🔧 Tech

* Make the permission dialog reusable
```
