### PR TITLE
chore: Add css-modules config from cozy-script

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,5 +1,6 @@
 const config = [
   require('cozy-scripts/config/webpack.bundle.default.js'),
+  require('cozy-scripts/config/webpack.config.css-modules'),
   require('./app.config.babel-loader-leaflet')
 ]
 


### PR DESCRIPTION
With this configuration we can use `.styl` files.

```
### 🔧 Tech

* Add css-modules config from cozy-script
```
