### PR TITLE
feat: Revert cozy-scripts to 6.3.0 for prevent duplicate css

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "cozy-ach": "^1.39.0",
     "cozy-bar": "7.16.0",
     "cozy-jobs-cli": "1.19.2",
-    "cozy-scripts": "^6.3.3",
+    "cozy-scripts": "6.3.0",
     "eslint-config-cozy-app": "^4.1.1",
     "mockdate": "^3.0.5",
     "react-test-renderer": "18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5144,10 +5144,10 @@ cozy-release@1.10.0:
   dependencies:
     exec-sh "0.3.2"
 
-cozy-scripts@^6.3.3:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-6.3.3.tgz#3924e5876f93dbadd343c834406ae29a47a98300"
-  integrity sha512-X8DrGAfxqscFi9PXW7DnGZW+s918YukF05NjrY0sDHhg9vXdWYvZ32j8y750HYaDx7l4FP3RSULa+cG9z640TA==
+cozy-scripts@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-6.3.0.tgz#7365f1af997ec18a907df0ce7f9c51f5c64e332e"
+  integrity sha512-ChHOGJS9XKRSw/t1deTfPbNAYk4GkJBgDS618z0n3MNcvDy8430EUnhRt10R6+FXLRSu3js8paMDd9UBT6ZluQ==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/polyfill" "^7.10.4"


### PR DESCRIPTION
Suite à ce commit https://github.com/cozy/create-cozy-app/commit/fa07a25 (dans la version 6.3.1)
Et en attendant un fix de ce dernier
```
### 🔧 Tech

* Revert `cozy-scripts` to 6.3.0 for prevent duplicate css.
```
