### PR TITLE
Fix `BikeGoalManager` component when `bikeGoal` is not defined

### DIFF
--- a/src/components/Goals/BikeGoal/BikeGoalManager.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalManager.jsx
@@ -20,8 +20,12 @@ const style = {
 const BikeGoalManager = () => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
-  const { value } = useSettings('bikeGoal')
-  const { activated, showAlert = true, showAlertSuccess = true } = value
+  const { value: bikeGoal = {} } = useSettings('bikeGoal')
+  const {
+    activated = false,
+    showAlert = true,
+    showAlertSuccess = true
+  } = bikeGoal
 
   if (activated || showAlert) {
     return (


### PR DESCRIPTION
Initially, there is no `bikeGoal` object in the settings document, so this made the app crash.

(changelog omitted)