### PR TITLE
feat: Update cozy-scripts to 6.3.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "cozy-ach": "^1.39.0",
     "cozy-bar": "7.16.0",
     "cozy-jobs-cli": "1.19.2",
-    "cozy-scripts": "6.3.0",
+    "cozy-scripts": "6.3.11",
     "eslint-config-cozy-app": "^4.1.1",
     "mockdate": "^3.0.5",
     "react-test-renderer": "18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5144,10 +5144,10 @@ cozy-release@1.10.0:
   dependencies:
     exec-sh "0.3.2"
 
-cozy-scripts@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-6.3.0.tgz#7365f1af997ec18a907df0ce7f9c51f5c64e332e"
-  integrity sha512-ChHOGJS9XKRSw/t1deTfPbNAYk4GkJBgDS618z0n3MNcvDy8430EUnhRt10R6+FXLRSu3js8paMDd9UBT6ZluQ==
+cozy-scripts@6.3.11:
+  version "6.3.11"
+  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-6.3.11.tgz#d2a1e101754210c7720026168e27d443b48df770"
+  integrity sha512-9Njzguyyy85eACuguCBSjID4RuWwH4BNg6jApagUhwtiBJjWt4c1l7m8tfiiwF9IA7rkocNw+szX8C16zDnRwg==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/polyfill" "^7.10.4"
@@ -10383,9 +10383,9 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
```
### 🔧 Tech

* Update cozy-scripts to 6.3.11, to get the latest fixes including the duplication of CSS files
```