### PR TITLE
fix(BikeGoal): Helper to count days of bike goal was not correct

### DIFF
--- a/src/components/Goals/BikeGoal/helpers.js
+++ b/src/components/Goals/BikeGoal/helpers.js
@@ -1,5 +1,5 @@
 import flag from 'cozy-flags'
-import { countDays } from 'src/lib/timeseries'
+import { countUniqDays } from 'src/lib/timeseries'
 
 export const getDaysToReach = () => {
   const daysToReach = flag('coachco2.bikegoal.settings')?.daysToReach
@@ -20,13 +20,13 @@ export const getBountyAmount = () => {
 export const isGoalCompleted = timeseries => {
   if (!timeseries || timeseries.length === 0) return false
 
-  return countDays(timeseries) >= getDaysToReach()
+  return countUniqDays(timeseries) >= getDaysToReach()
 }
 
 export const countDaysOrDaysToReach = timeseries => {
   if (!timeseries || timeseries.length === 0) return 0
 
-  const days = countDays(timeseries)
+  const days = countUniqDays(timeseries)
   const daysToReach = getDaysToReach()
 
   return days < daysToReach ? days : daysToReach

--- a/src/components/Goals/BikeGoal/helpers.spec.js
+++ b/src/components/Goals/BikeGoal/helpers.spec.js
@@ -13,10 +13,10 @@ jest.mock('cozy-flags', () => name => {
 
 describe('isGoalCompleted', () => {
   it('should return true', () => {
-    const timeseries = [
-      { startDate: '2021-01-01T00:00:00', endDate: '2021-01-02T00:00:00' },
-      { startDate: '2021-03-01T00:00:00', endDate: '2021-03-02T00:00:00' }
-    ]
+    const timeseries = Array.from({ length: 30 }, (_, index) => ({
+      startDate: new Date(2021, 1, index + 1),
+      endDate: new Date(2021, 1, index + 1)
+    }))
 
     const res = isGoalCompleted(timeseries)
 
@@ -44,14 +44,14 @@ describe('countDaysOrDaysToReach', () => {
 
     const res = countDaysOrDaysToReach(timeseries)
 
-    expect(res).toBe(4)
+    expect(res).toBe(2)
   })
 
   it('should return the days to reach', () => {
-    const timeseries = [
-      { startDate: '2021-01-01T00:00:00', endDate: '2021-01-02T00:00:00' },
-      { startDate: '2021-06-01T00:00:00', endDate: '2021-06-01T00:00:00' }
-    ]
+    const timeseries = Array.from({ length: 40 }, (_, index) => ({
+      startDate: new Date(2021, 1, index + 1),
+      endDate: new Date(2021, 1, index + 1)
+    }))
 
     const res = countDaysOrDaysToReach(timeseries)
 
@@ -60,7 +60,7 @@ describe('countDaysOrDaysToReach', () => {
 })
 
 describe('makeGoalAchievementPercentage', () => {
-  it('should return 30', () => {
+  it('should return 7', () => {
     const timeseries = [
       { startDate: '2021-01-01T00:00:00', endDate: '2021-01-01T00:00:00' },
       { startDate: '2021-01-05T00:00:00', endDate: '2021-01-05T00:00:00' }
@@ -68,14 +68,14 @@ describe('makeGoalAchievementPercentage', () => {
 
     const res = makeGoalAchievementPercentage(timeseries)
 
-    expect(res).toBe(13)
+    expect(res).toBe(7)
   })
 
   it('should return 100', () => {
-    const timeseries = [
-      { startDate: '2021-01-01T00:00:00', endDate: '2021-01-02T00:00:00' },
-      { startDate: '2021-06-01T00:00:00', endDate: '2021-06-01T00:00:00' }
-    ]
+    const timeseries = Array.from({ length: 40 }, (_, index) => ({
+      startDate: new Date(2021, 1, index + 1),
+      endDate: new Date(2021, 1, index + 1)
+    }))
 
     const res = makeGoalAchievementPercentage(timeseries)
 

--- a/src/lib/timeseries.spec.js
+++ b/src/lib/timeseries.spec.js
@@ -802,7 +802,7 @@ describe('countDays', () => {
 })
 
 describe('getEarliestTimeserie', () => {
-  it('should return the number of days covered by timeseries', () => {
+  it('should return the earliest timeserie', () => {
     const timeseries = [
       { startDate: '2022-01-01T00:00:00', endDate: '2022-01-01T00:00:00' },
       { startDate: '2020-01-01T00:00:00', endDate: '2020-01-01T00:00:00' },

--- a/src/lib/timeseries.spec.js
+++ b/src/lib/timeseries.spec.js
@@ -43,8 +43,7 @@ import {
   setAggregationPurpose,
   setAutomaticPurpose,
   setManualPurpose,
-  computeFirstAndLastDay,
-  countDays,
+  countUniqDays,
   getEarliestTimeserie,
   filterTimeseriesByYear
 } from 'src/lib/timeseries'
@@ -769,35 +768,50 @@ describe('set purpose', () => {
   })
 })
 
-describe('computeFirstAndLastDay', () => {
-  it('should return first and last day', () => {
+describe('countUniqDays', () => {
+  it('should return the number of days for which there is a timeserie', () => {
     const timeseries = [
-      { startDate: '2021-01-01T00:00:00', endDate: '2021-01-02T00:00:00' },
-      { startDate: '2021-02-01T00:00:00', endDate: '2021-02-02T00:00:00' },
-      { startDate: '2021-03-01T00:00:00', endDate: '2021-03-02T00:00:00' }
+      { startDate: '2021-03-01T00:00:00', endDate: '2021-03-01T01:00:00' },
+      { startDate: '2021-01-01T00:00:00', endDate: '2021-01-01T00:00:00' },
+      { startDate: '2021-02-01T00:00:00', endDate: '2021-02-02T00:00:00' }
     ]
 
-    const res = computeFirstAndLastDay(timeseries)
+    const res = countUniqDays(timeseries)
 
-    expect(res).toStrictEqual({
-      firstDay: new Date('2021-01-01T00:00:00.000Z'),
-      lastDay: new Date('2021-03-02T00:00:00.000Z')
-    })
+    expect(res).toBe(3)
   })
-})
 
-describe('countDays', () => {
-  it('should return the number of days covered by timeseries', () => {
+  it('should not count two timeseries for the same day', () => {
     const timeseries = [
-      { startDate: '2021-01-01T00:00:00', endDate: '2021-01-02T00:00:00' },
-      { startDate: '2021-02-01T00:00:00', endDate: '2021-02-02T00:00:00' },
-      { startDate: '2021-02-01T10:00:00', endDate: '2021-02-02T10:00:00' },
-      { startDate: '2021-03-01T00:00:00', endDate: '2021-03-02T00:00:00' }
+      { startDate: '2021-01-01T00:00:00', endDate: '2021-01-01T00:00:00' },
+      { startDate: '2021-01-01T01:00:00', endDate: '2021-01-01T02:00:00' }
     ]
 
-    const res = countDays(timeseries)
+    const res = countUniqDays(timeseries)
 
-    expect(res).toBe(60)
+    expect(res).toBe(1)
+  })
+
+  it('should not count a timeserie if another one starts the next day less than 12 hours later', () => {
+    const timeseries = [
+      { startDate: '2021-01-01T20:00:00', endDate: '2021-01-01T20:30:00' },
+      { startDate: '2021-01-02T01:00:00', endDate: '2021-01-01T01:30:00' }
+    ]
+
+    const res = countUniqDays(timeseries)
+
+    expect(res).toBe(1)
+  })
+
+  it('should count a timeserie if another one starts the next day more than 12 hours later', () => {
+    const timeseries = [
+      { startDate: '2021-01-01T20:00:00', endDate: '2021-01-01T20:30:00' },
+      { startDate: '2021-01-02T09:00:00', endDate: '2021-01-01T09:30:00' }
+    ]
+
+    const res = countUniqDays(timeseries)
+
+    expect(res).toBe(2)
   })
 })
 


### PR DESCRIPTION
On ne comptait pas correctement le nombre de jour de l'objectif vélo.

On ne se base maintenant que sur le startDate d'un timeserie, on compte alors le nombre de jour pour lesquels il y a au moins un timeserie avec un startDate. En revanche : 
- s'il y a plusieurs timerserie pour un même jour, on n'en compte qu'un seul
- si un timerserie commence le lendemain moins de 12 heures plus tard qu'un timerserie de la veille, on ne le compte pas