### PR TITLE
Add bike goal onboarding stepper

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cozy-intent": "^1.17.1",
     "cozy-logger": "^1.9.0",
     "cozy-realtime": "^4.2.1",
-    "cozy-ui": "^77.1.0",
+    "cozy-ui": "^77.3.0",
     "date-fns": "2.29.3",
     "humanize-duration": "3.27.1",
     "leaflet": "1.9.1",

--- a/src/components/Goals/BikeGoal/Edit/EditModalContent.jsx
+++ b/src/components/Goals/BikeGoal/Edit/EditModalContent.jsx
@@ -7,6 +7,9 @@ import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
 import Radio from 'cozy-ui/transpiled/react/Radios'
 import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
 
+import { toPercentage } from 'src/components/Goals/BikeGoal/Edit/helpers'
+import PercentageField from 'src/components/Goals/BikeGoal/Edit/PercentageField'
+
 const EditModalContent = ({ itemName, value, setValue }) => {
   const { t } = useI18n()
   const isError = !value
@@ -24,11 +27,9 @@ const EditModalContent = ({ itemName, value, setValue }) => {
   switch (itemName) {
     case 'workTimePercentage':
       return (
-        <TextField
+        <PercentageField
           {...commonProps}
-          type="number"
-          inputProps={{ inputMode: 'numeric' }}
-          onChange={ev => setValue(Number(ev.target.value))}
+          onChange={ev => setValue(toPercentage(Number(ev.target.value)))}
         />
       )
 

--- a/src/components/Goals/BikeGoal/Edit/ModificationModalContent.jsx
+++ b/src/components/Goals/BikeGoal/Edit/ModificationModalContent.jsx
@@ -18,12 +18,14 @@ import BottomIcon from 'cozy-ui/transpiled/react/Icons/Bottom'
 import ClockOutlineIcon from 'cozy-ui/transpiled/react/Icons/ClockOutline'
 
 import useSettings from 'src/hooks/useSettings'
+import { getSource } from 'src/components/Goals/BikeGoal/helpers'
 import EditModal from 'src/components/Goals/BikeGoal/Edit/EditModal'
 
 const ModificationModalContent = () => {
   const { t } = useI18n()
   const [showEditModal, setShowEditModal] = useState('')
   const { isLoading, value: bikeGoal, save } = useSettings('bikeGoal')
+  const { sourceIdentity, sourceType } = getSource()
 
   const isPartTimeWork = bikeGoal.workTime === 'part'
 
@@ -129,7 +131,9 @@ const ModificationModalContent = () => {
           </ListItemIcon>
           <ListItemText
             ellipsis={false}
-            primary={t('bikeGoal.edit.compare_progress')}
+            primary={t('bikeGoal.edit.compare_progress', {
+              source: sourceIdentity ?? t(`bikeGoal.employer.my_${sourceType}`)
+            })}
           />
           <ListItemSecondaryAction>
             <Switch

--- a/src/components/Goals/BikeGoal/Edit/PercentageField.jsx
+++ b/src/components/Goals/BikeGoal/Edit/PercentageField.jsx
@@ -1,0 +1,23 @@
+import React, { forwardRef } from 'react'
+
+import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField'
+
+const PercentageField = forwardRef((props, ref) => {
+  return (
+    <TextField
+      type="number"
+      inputProps={{
+        min: '0',
+        max: '100',
+        step: '1',
+        inputMode: 'numeric'
+      }}
+      {...props}
+      ref={ref}
+    />
+  )
+})
+
+PercentageField.displayName = 'PercentageField'
+
+export default PercentageField

--- a/src/components/Goals/BikeGoal/Edit/helpers.js
+++ b/src/components/Goals/BikeGoal/Edit/helpers.js
@@ -1,0 +1,6 @@
+export const toPercentage = value => {
+  if (value >= 0 && value <= 100) {
+    return Math.round(value)
+  }
+  return null
+}

--- a/src/components/Goals/BikeGoal/Edit/helpers.spec.js
+++ b/src/components/Goals/BikeGoal/Edit/helpers.spec.js
@@ -1,0 +1,18 @@
+import { toPercentage } from './helpers'
+
+describe('toPercentage', () => {
+  it('should accept integers between 0 and 100', () => {
+    expect(toPercentage(6)).toBe(6)
+    expect(toPercentage(94)).toBe(94)
+  })
+
+  it('should reject values not between 0 and 100', () => {
+    expect(toPercentage(-5)).toBe(null)
+    expect(toPercentage(105)).toBe(null)
+  })
+
+  it('should round', () => {
+    expect(toPercentage(0.6)).toBe(1)
+    expect(toPercentage(99.4)).toBe(99)
+  })
+})

--- a/src/components/Goals/BikeGoal/helpers.js
+++ b/src/components/Goals/BikeGoal/helpers.js
@@ -17,6 +17,29 @@ export const getBountyAmount = () => {
   return bountyAmount
 }
 
+export const getSource = () => {
+  const sourceIdentity = flag('coachco2.bikegoal.settings')?.sourceIdentity
+  const sourceType = flag('coachco2.bikegoal.settings')?.sourceType
+  const knownSourceTypes = ['custom', 'company', 'collectivity']
+  if (!sourceType) {
+    throw new Error('Flag "coachco2.bikegoal.settings" must be used')
+  }
+  if (!knownSourceTypes.includes(sourceType)) {
+    throw new Error(
+      `Flag "coachco2.bikegoal.settings"'s "sourceType" must be one of ${knownSourceTypes}`
+    )
+  }
+  if (sourceType === 'custom' && !sourceIdentity) {
+    throw new Error(
+      'Flag "coachco2.bikegoal.settings"\'s "sourceIdentity" must be a string when "sourceType" is set to "custom"'
+    )
+  }
+  return {
+    sourceType,
+    sourceIdentity: sourceType === 'custom' ? sourceIdentity : null
+  }
+}
+
 export const isGoalCompleted = timeseries => {
   if (!timeseries || timeseries.length === 0) return false
 

--- a/src/components/Views/BikeGoalOnboarding.jsx
+++ b/src/components/Views/BikeGoalOnboarding.jsx
@@ -1,36 +1,29 @@
-import React, { useReducer } from 'react'
+import React from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
-import Button from 'cozy-ui/transpiled/react/Buttons'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import { Stepper } from 'cozy-ui/transpiled/react/Stepper'
 
 import useSettings from 'src/hooks/useSettings'
+import BikeGoalOnboardingComparison from 'src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison'
+import BikeGoalOnboardingConclusion from 'src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion'
+import BikeGoalOnboardingDetection from 'src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingDetection'
+import BikeGoalOnboardingIntroduction from 'src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingIntroduction'
+import BikeGoalOnboardingNaming from 'src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming'
+import BikeGoalOnboardingTiming from 'src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming'
 
 const BikeGoalOnboarding = () => {
   const { t } = useI18n()
   const navigate = useNavigate()
-  const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
-  const {
-    isLoading,
-    value: bikeGoal = {},
-    save: setBikeGoal
-  } = useSettings('bikeGoal')
+
+  const { isLoading, value: onboardingStep = 0 } = useSettings(
+    'bikeGoal.onboardingStep'
+  )
 
   const handleBack = () => {
     navigate('..')
-  }
-
-  const handleForward = async () => {
-    toggleBusy()
-    await setBikeGoal({
-      ...bikeGoal,
-      onboarded: true,
-      activated: true,
-      showAlert: false
-    })
-    navigate('/bikegoal')
   }
 
   return (
@@ -47,14 +40,14 @@ const BikeGoalOnboarding = () => {
             />
           )}
           {!isLoading && (
-            <>
-              <div>⚠️ under construction ⚠️</div>
-              <Button
-                onClick={handleForward}
-                label={t('bikeGoal.onboarding.actions.finish')}
-                busy={isBusy}
-              />
-            </>
+            <Stepper activeStep={onboardingStep} orientation="vertical">
+              <BikeGoalOnboardingIntroduction />
+              <BikeGoalOnboardingNaming />
+              <BikeGoalOnboardingTiming />
+              <BikeGoalOnboardingDetection />
+              <BikeGoalOnboardingComparison />
+              <BikeGoalOnboardingConclusion />
+            </Stepper>
           )}
         </>
       }

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useReducer } from 'react'
+import React, { forwardRef, useReducer, useState } from 'react'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
@@ -26,7 +26,8 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
     value: bikeGoal = {},
     save: setBikeGoal
   } = useSettings('bikeGoal')
-  const { onboardingStep = 0, } = bikeGoal
+  const { onboardingStep = 0, sendToDacc = null } = bikeGoal
+  const [unsavedSendToDacc, setUnsavedSendToDacc] = useState(sendToDacc)
 
   const styles = createStyles()
 
@@ -65,12 +66,20 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
               </Typography>
               <RadioGroup className="u-mt-1">
                 <FormControlLabel
-                  control={<Radio />}
+                  control={
+                    <Radio
+                      checked={unsavedSendToDacc === true}
+                    />
+                  }
                   label={t('bikeGoal.onboarding.steps.comparison.compare')}
                   className="u-m-0"
                 />
                 <FormControlLabel
-                  control={<Radio />}
+                  control={
+                    <Radio
+                      checked={unsavedSendToDacc === false}
+                    />
+                  }
                   label={t('bikeGoal.onboarding.steps.comparison.doNotCompare')}
                   className="u-m-0"
                 />

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
@@ -11,6 +11,7 @@ import Radio from 'cozy-ui/transpiled/react/Radios'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import useSettings from 'src/hooks/useSettings'
+import BikeGoalDaccManager from 'src/components/DaccManager/BikeGoalDaccManager'
 
 const createStyles = () => ({
   typography: {
@@ -20,6 +21,7 @@ const createStyles = () => ({
 
 const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const [showPermissionsDialog, setShowPermissionsDialog] = useState(false)
   const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
   const {
     isLoading,
@@ -103,6 +105,17 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
           )}
         </StepContent>
       </Step>
+      {showPermissionsDialog && (
+        <BikeGoalDaccManager
+          onClose={() => setShowPermissionsDialog(false)}
+          onRefuse={() => {
+            setShowPermissionsDialog(false)
+          }}
+          onAccept={() => {
+            setShowPermissionsDialog(false)
+          }}
+        />
+      )}
     </>
   )
 })

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
@@ -47,6 +47,7 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep + 1,
+      sendToDacc: unsavedSendToDacc
     })
     toggleBusy()
   }
@@ -71,6 +72,7 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
                   control={
                     <Radio
                       checked={unsavedSendToDacc === true}
+                      onClick={() => setShowPermissionsDialog(true)}
                     />
                   }
                   label={t('bikeGoal.onboarding.steps.comparison.compare')}
@@ -80,6 +82,7 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
                   control={
                     <Radio
                       checked={unsavedSendToDacc === false}
+                      onClick={() => setUnsavedSendToDacc(false)}
                     />
                   }
                   label={t('bikeGoal.onboarding.steps.comparison.doNotCompare')}
@@ -110,9 +113,11 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
           onClose={() => setShowPermissionsDialog(false)}
           onRefuse={() => {
             setShowPermissionsDialog(false)
+            setUnsavedSendToDacc(false)
           }}
           onAccept={() => {
             setShowPermissionsDialog(false)
+            setUnsavedSendToDacc(true)
           }}
         />
       )}

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
@@ -4,6 +4,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
 import StepContent from 'cozy-ui/transpiled/react/StepContent'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
 import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
 import Radio from 'cozy-ui/transpiled/react/Radios'
@@ -54,6 +55,16 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
                   className="u-m-0"
                 />
               </RadioGroup>
+              <div className="u-mt-1">
+                <Button
+                  label={t('bikeGoal.onboarding.actions.next')}
+                />
+                <Button
+                  label={t('bikeGoal.onboarding.actions.previous')}
+                  variant="text"
+                  className="u-ml-half"
+                />
+              </div>
             </>
           )}
         </StepContent>

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
@@ -25,8 +25,23 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
     value: bikeGoal = {},
     save: setBikeGoal
   } = useSettings('bikeGoal')
+  const { onboardingStep = 0, } = bikeGoal
 
   const styles = createStyles()
+
+  const handleBack = async () => {
+    await setBikeGoal({
+      ...bikeGoal,
+      onboardingStep: onboardingStep - 1
+    })
+  }
+
+  const handleForward = async () => {
+    await setBikeGoal({
+      ...bikeGoal,
+      onboardingStep: onboardingStep + 1,
+    })
+  }
 
   return (
     <>
@@ -57,9 +72,11 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
               </RadioGroup>
               <div className="u-mt-1">
                 <Button
+                  onClick={handleForward}
                   label={t('bikeGoal.onboarding.actions.next')}
                 />
                 <Button
+                  onClick={handleBack}
                   label={t('bikeGoal.onboarding.actions.previous')}
                   variant="text"
                   className="u-ml-half"

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
@@ -1,0 +1,50 @@
+import React, { forwardRef } from 'react'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
+import StepContent from 'cozy-ui/transpiled/react/StepContent'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
+import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
+import Radio from 'cozy-ui/transpiled/react/Radios'
+
+const createStyles = () => ({
+  typography: {
+    whiteSpace: 'pre-line'
+  }
+})
+
+const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
+  const { t } = useI18n()
+
+  const styles = createStyles()
+
+  return (
+    <>
+      <Step {...props} ref={ref}>
+        <StepLabel>{t('bikeGoal.edit.compare_progress')}</StepLabel>
+        <StepContent>
+          <Typography style={styles.typography}>
+            {t('bikeGoal.onboarding.steps.comparison.comparisonLegend')}
+          </Typography>
+          <RadioGroup className="u-mt-1">
+            <FormControlLabel
+              control={<Radio />}
+              label={t('bikeGoal.onboarding.steps.comparison.compare')}
+              className="u-m-0"
+            />
+            <FormControlLabel
+              control={<Radio />}
+              label={t('bikeGoal.onboarding.steps.comparison.doNotCompare')}
+              className="u-m-0"
+            />
+          </RadioGroup>
+        </StepContent>
+      </Step>
+    </>
+  )
+})
+
+BikeGoalOnboardingComparison.displayName = 'BikeGoalOnboardingComparison'
+
+export default BikeGoalOnboardingComparison

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
@@ -11,6 +11,7 @@ import Radio from 'cozy-ui/transpiled/react/Radios'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import useSettings from 'src/hooks/useSettings'
+import { getSource } from 'src/components/Goals/BikeGoal/helpers'
 import BikeGoalDaccManager from 'src/components/DaccManager/BikeGoalDaccManager'
 
 const createStyles = () => ({
@@ -30,6 +31,7 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
   } = useSettings('bikeGoal')
   const { onboardingStep = 0, sendToDacc = null } = bikeGoal
   const [unsavedSendToDacc, setUnsavedSendToDacc] = useState(sendToDacc)
+  const { sourceType, sourceIdentity } = getSource()
 
   const styles = createStyles()
 
@@ -62,7 +64,11 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
   return (
     <>
       <Step {...props} ref={ref}>
-        <StepLabel>{t('bikeGoal.edit.compare_progress')}</StepLabel>
+        <StepLabel>
+          {t('bikeGoal.edit.compare_progress', {
+            source: sourceIdentity ?? t(`bikeGoal.employer.my_${sourceType}`)
+          })}
+        </StepLabel>
         <StepContent>
           {isLoading ? (
             <Spinner
@@ -72,7 +78,10 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
           ) : (
             <>
               <Typography style={styles.typography}>
-                {t('bikeGoal.onboarding.steps.comparison.comparisonLegend')}
+                {t('bikeGoal.onboarding.steps.comparison.comparisonLegend', {
+                  source:
+                    sourceIdentity ?? t(`bikeGoal.employer.your_${sourceType}`)
+                })}
               </Typography>
               <RadioGroup className="u-mt-1">
                 <FormControlLabel

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
@@ -52,6 +52,13 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
     toggleBusy()
   }
 
+  const isForwardDisabled = () => {
+    if (unsavedSendToDacc == null) {
+      return true
+    }
+    return false
+  }
+
   return (
     <>
       <Step {...props} ref={ref}>
@@ -93,7 +100,7 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
                 <Button
                   onClick={handleForward}
                   label={t('bikeGoal.onboarding.actions.next')}
-                  disabled={isBusy}
+                  disabled={isBusy || isForwardDisabled()}
                 />
                 <Button
                   onClick={handleBack}

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
@@ -7,6 +7,9 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
 import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
 import Radio from 'cozy-ui/transpiled/react/Radios'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+import useSettings from 'src/hooks/useSettings'
 
 const createStyles = () => ({
   typography: {
@@ -16,6 +19,11 @@ const createStyles = () => ({
 
 const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const {
+    isLoading,
+    value: bikeGoal = {},
+    save: setBikeGoal
+  } = useSettings('bikeGoal')
 
   const styles = createStyles()
 
@@ -24,21 +32,30 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
       <Step {...props} ref={ref}>
         <StepLabel>{t('bikeGoal.edit.compare_progress')}</StepLabel>
         <StepContent>
-          <Typography style={styles.typography}>
-            {t('bikeGoal.onboarding.steps.comparison.comparisonLegend')}
-          </Typography>
-          <RadioGroup className="u-mt-1">
-            <FormControlLabel
-              control={<Radio />}
-              label={t('bikeGoal.onboarding.steps.comparison.compare')}
-              className="u-m-0"
+          {isLoading ? (
+            <Spinner
+              size="xxlarge"
+              className="u-flex u-flex-justify-center u-m-1"
             />
-            <FormControlLabel
-              control={<Radio />}
-              label={t('bikeGoal.onboarding.steps.comparison.doNotCompare')}
-              className="u-m-0"
-            />
-          </RadioGroup>
+          ) : (
+            <>
+              <Typography style={styles.typography}>
+                {t('bikeGoal.onboarding.steps.comparison.comparisonLegend')}
+              </Typography>
+              <RadioGroup className="u-mt-1">
+                <FormControlLabel
+                  control={<Radio />}
+                  label={t('bikeGoal.onboarding.steps.comparison.compare')}
+                  className="u-m-0"
+                />
+                <FormControlLabel
+                  control={<Radio />}
+                  label={t('bikeGoal.onboarding.steps.comparison.doNotCompare')}
+                  className="u-m-0"
+                />
+              </RadioGroup>
+            </>
+          )}
         </StepContent>
       </Step>
     </>

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingComparison.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useReducer } from 'react'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
@@ -20,6 +20,7 @@ const createStyles = () => ({
 
 const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
   const {
     isLoading,
     value: bikeGoal = {},
@@ -30,17 +31,21 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
   const styles = createStyles()
 
   const handleBack = async () => {
+    toggleBusy()
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep - 1
     })
+    toggleBusy()
   }
 
   const handleForward = async () => {
+    toggleBusy()
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep + 1,
     })
+    toggleBusy()
   }
 
   return (
@@ -74,13 +79,16 @@ const BikeGoalOnboardingComparison = forwardRef((props, ref) => {
                 <Button
                   onClick={handleForward}
                   label={t('bikeGoal.onboarding.actions.next')}
+                  disabled={isBusy}
                 />
                 <Button
                   onClick={handleBack}
                   label={t('bikeGoal.onboarding.actions.previous')}
+                  disabled={isBusy}
                   variant="text"
                   className="u-ml-half"
                 />
+                {isBusy && <Spinner className="u-ml-half" />}
               </div>
             </>
           )}

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
@@ -4,7 +4,9 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
 import StepContent from 'cozy-ui/transpiled/react/StepContent'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
+import useSettings from 'src/hooks/useSettings'
 import { getBountyAmount } from 'src/components/Goals/BikeGoal/helpers'
 
 const createStyles = () => ({
@@ -15,6 +17,11 @@ const createStyles = () => ({
 
 const BikeGoalOnboardingConclusion = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const {
+    isLoading,
+    value: bikeGoal = {},
+    save: setBikeGoal
+  } = useSettings('bikeGoal')
   const bountyAmount = getBountyAmount()
 
   const styles = createStyles()
@@ -23,9 +30,18 @@ const BikeGoalOnboardingConclusion = forwardRef((props, ref) => {
     <Step {...props} ref={ref}>
       <StepLabel>{t('bikeGoal.about.once_goal_reach.title')}</StepLabel>
       <StepContent>
-        <Typography style={styles.typography}>
-          {t('bikeGoal.about.once_goal_reach.content', { bountyAmount })}
-        </Typography>
+        {isLoading ? (
+          <Spinner
+            size="xxlarge"
+            className="u-flex u-flex-justify-center u-m-1"
+          />
+        ) : (
+          <>
+            <Typography style={styles.typography}>
+              {t('bikeGoal.about.once_goal_reach.content', { bountyAmount })}
+            </Typography>
+          </>
+        )}
       </StepContent>
     </Step>
   )

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
@@ -1,0 +1,36 @@
+import React, { forwardRef } from 'react'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
+import StepContent from 'cozy-ui/transpiled/react/StepContent'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+import { getBountyAmount } from 'src/components/Goals/BikeGoal/helpers'
+
+const createStyles = () => ({
+  typography: {
+    whiteSpace: 'pre-line'
+  }
+})
+
+const BikeGoalOnboardingConclusion = forwardRef((props, ref) => {
+  const { t } = useI18n()
+  const bountyAmount = getBountyAmount()
+
+  const styles = createStyles()
+
+  return (
+    <Step {...props} ref={ref}>
+      <StepLabel>{t('bikeGoal.about.once_goal_reach.title')}</StepLabel>
+      <StepContent>
+        <Typography style={styles.typography}>
+          {t('bikeGoal.about.once_goal_reach.content', { bountyAmount })}
+        </Typography>
+      </StepContent>
+    </Step>
+  )
+})
+
+BikeGoalOnboardingConclusion.displayName = 'BikeGoalOnboardingConclusion'
+
+export default BikeGoalOnboardingConclusion

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
@@ -44,6 +44,9 @@ const BikeGoalOnboardingConclusion = forwardRef((props, ref) => {
     toggleBusy()
     await setBikeGoal({
       ...bikeGoal,
+      onboarded: true,
+      activated: true,
+      showAlert: false
     })
     toggleBusy()
     navigate('/bikegoal')

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useReducer } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -20,6 +20,7 @@ const createStyles = () => ({
 const BikeGoalOnboardingConclusion = forwardRef((props, ref) => {
   const { t } = useI18n()
   const navigate = useNavigate()
+  const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
   const {
     isLoading,
     value: bikeGoal = {},
@@ -31,16 +32,20 @@ const BikeGoalOnboardingConclusion = forwardRef((props, ref) => {
   const styles = createStyles()
 
   const handleBack = async () => {
+    toggleBusy()
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep - 1
     })
+    toggleBusy()
   }
 
   const handleForward = async () => {
+    toggleBusy()
     await setBikeGoal({
       ...bikeGoal,
     })
+    toggleBusy()
     navigate('/bikegoal')
   }
 
@@ -62,13 +67,16 @@ const BikeGoalOnboardingConclusion = forwardRef((props, ref) => {
               <Button
                 onClick={handleForward}
                 label={t('bikeGoal.onboarding.actions.finish')}
+                disabled={isBusy}
               />
               <Button
                 onClick={handleBack}
                 label={t('bikeGoal.onboarding.actions.previous')}
+                disabled={isBusy}
                 variant="text"
                 className="u-ml-half"
               />
+              {isBusy && <Spinner className="u-ml-half" />}
             </div>
           </>
         )}

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
@@ -46,7 +46,8 @@ const BikeGoalOnboardingConclusion = forwardRef((props, ref) => {
       ...bikeGoal,
       onboarded: true,
       activated: true,
-      showAlert: false
+      showAlert: false,
+      showAlertSuccess: true
     })
     toggleBusy()
     navigate('/bikegoal')

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
@@ -18,14 +19,30 @@ const createStyles = () => ({
 
 const BikeGoalOnboardingConclusion = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const navigate = useNavigate()
   const {
     isLoading,
     value: bikeGoal = {},
     save: setBikeGoal
   } = useSettings('bikeGoal')
+  const { onboardingStep = 0 } = bikeGoal
   const bountyAmount = getBountyAmount()
 
   const styles = createStyles()
+
+  const handleBack = async () => {
+    await setBikeGoal({
+      ...bikeGoal,
+      onboardingStep: onboardingStep - 1
+    })
+  }
+
+  const handleForward = async () => {
+    await setBikeGoal({
+      ...bikeGoal,
+    })
+    navigate('/bikegoal')
+  }
 
   return (
     <Step {...props} ref={ref}>
@@ -43,9 +60,11 @@ const BikeGoalOnboardingConclusion = forwardRef((props, ref) => {
             </Typography>
             <div className="u-mt-1">
               <Button
+                onClick={handleForward}
                 label={t('bikeGoal.onboarding.actions.finish')}
               />
               <Button
+                onClick={handleBack}
                 label={t('bikeGoal.onboarding.actions.previous')}
                 variant="text"
                 className="u-ml-half"

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingConclusion.jsx
@@ -4,6 +4,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
 import StepContent from 'cozy-ui/transpiled/react/StepContent'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import useSettings from 'src/hooks/useSettings'
@@ -40,6 +41,16 @@ const BikeGoalOnboardingConclusion = forwardRef((props, ref) => {
             <Typography style={styles.typography}>
               {t('bikeGoal.about.once_goal_reach.content', { bountyAmount })}
             </Typography>
+            <div className="u-mt-1">
+              <Button
+                label={t('bikeGoal.onboarding.actions.finish')}
+              />
+              <Button
+                label={t('bikeGoal.onboarding.actions.previous')}
+                variant="text"
+                className="u-ml-half"
+              />
+            </div>
           </>
         )}
       </StepContent>

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingDetection.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingDetection.jsx
@@ -1,0 +1,33 @@
+import React, { forwardRef } from 'react'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
+import StepContent from 'cozy-ui/transpiled/react/StepContent'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+const createStyles = () => ({
+  typography: {
+    whiteSpace: 'pre-line'
+  }
+})
+
+const BikeGoalOnboardingDetection = forwardRef((props, ref) => {
+  const { t } = useI18n()
+
+  const styles = createStyles()
+
+  return (
+    <Step {...props} ref={ref}>
+      <StepLabel>{t('bikeGoal.about.how_trips_detected.title')}</StepLabel>
+      <StepContent>
+        <Typography style={styles.typography}>
+          {t('bikeGoal.about.how_trips_detected.content')}
+        </Typography>
+      </StepContent>
+    </Step>
+  )
+})
+
+BikeGoalOnboardingDetection.displayName = 'BikeGoalOnboardingDetection'
+
+export default BikeGoalOnboardingDetection

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingDetection.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingDetection.jsx
@@ -4,6 +4,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
 import StepContent from 'cozy-ui/transpiled/react/StepContent'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import useSettings from 'src/hooks/useSettings'
@@ -38,6 +39,16 @@ const BikeGoalOnboardingDetection = forwardRef((props, ref) => {
             <Typography style={styles.typography}>
               {t('bikeGoal.about.how_trips_detected.content')}
             </Typography>
+            <div className="u-mt-1">
+              <Button
+                label={t('bikeGoal.onboarding.actions.next')}
+              />
+              <Button
+                label={t('bikeGoal.onboarding.actions.previous')}
+                variant="text"
+                className="u-ml-half"
+              />
+            </div>
           </>
         )}
       </StepContent>

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingDetection.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingDetection.jsx
@@ -4,6 +4,9 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
 import StepContent from 'cozy-ui/transpiled/react/StepContent'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+import useSettings from 'src/hooks/useSettings'
 
 const createStyles = () => ({
   typography: {
@@ -13,6 +16,11 @@ const createStyles = () => ({
 
 const BikeGoalOnboardingDetection = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const {
+    isLoading,
+    value: bikeGoal = {},
+    save: setBikeGoal
+  } = useSettings('bikeGoal')
 
   const styles = createStyles()
 
@@ -20,9 +28,18 @@ const BikeGoalOnboardingDetection = forwardRef((props, ref) => {
     <Step {...props} ref={ref}>
       <StepLabel>{t('bikeGoal.about.how_trips_detected.title')}</StepLabel>
       <StepContent>
-        <Typography style={styles.typography}>
-          {t('bikeGoal.about.how_trips_detected.content')}
-        </Typography>
+        {isLoading ? (
+          <Spinner
+            size="xxlarge"
+            className="u-flex u-flex-justify-center u-m-1"
+          />
+        ) : (
+          <>
+            <Typography style={styles.typography}>
+              {t('bikeGoal.about.how_trips_detected.content')}
+            </Typography>
+          </>
+        )}
       </StepContent>
     </Step>
   )

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingDetection.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingDetection.jsx
@@ -22,8 +22,23 @@ const BikeGoalOnboardingDetection = forwardRef((props, ref) => {
     value: bikeGoal = {},
     save: setBikeGoal
   } = useSettings('bikeGoal')
+  const { onboardingStep = 0 } = bikeGoal
 
   const styles = createStyles()
+
+  const handleBack = async () => {
+    await setBikeGoal({
+      ...bikeGoal,
+      onboardingStep: onboardingStep - 1
+    })
+  }
+
+  const handleForward = async () => {
+    await setBikeGoal({
+      ...bikeGoal,
+      onboardingStep: onboardingStep + 1
+    })
+  }
 
   return (
     <Step {...props} ref={ref}>
@@ -41,9 +56,11 @@ const BikeGoalOnboardingDetection = forwardRef((props, ref) => {
             </Typography>
             <div className="u-mt-1">
               <Button
+                onClick={handleForward}
                 label={t('bikeGoal.onboarding.actions.next')}
               />
               <Button
+                onClick={handleBack}
                 label={t('bikeGoal.onboarding.actions.previous')}
                 variant="text"
                 className="u-ml-half"

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingDetection.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingDetection.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useReducer } from 'react'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
@@ -17,6 +17,7 @@ const createStyles = () => ({
 
 const BikeGoalOnboardingDetection = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
   const {
     isLoading,
     value: bikeGoal = {},
@@ -27,17 +28,21 @@ const BikeGoalOnboardingDetection = forwardRef((props, ref) => {
   const styles = createStyles()
 
   const handleBack = async () => {
+    toggleBusy()
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep - 1
     })
+    toggleBusy()
   }
 
   const handleForward = async () => {
+    toggleBusy()
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep + 1
     })
+    toggleBusy()
   }
 
   return (
@@ -58,13 +63,16 @@ const BikeGoalOnboardingDetection = forwardRef((props, ref) => {
               <Button
                 onClick={handleForward}
                 label={t('bikeGoal.onboarding.actions.next')}
+                disabled={isBusy}
               />
               <Button
                 onClick={handleBack}
                 label={t('bikeGoal.onboarding.actions.previous')}
+                disabled={isBusy}
                 variant="text"
                 className="u-ml-half"
               />
+              {isBusy && <Spinner className="u-ml-half" />}
             </div>
           </>
         )}

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingIntroduction.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingIntroduction.jsx
@@ -23,9 +23,17 @@ const BikeGoalOnboardingIntroduction = forwardRef((props, ref) => {
     value: bikeGoal = {},
     save: setBikeGoal
   } = useSettings('bikeGoal')
+  const { onboardingStep = 0 } = bikeGoal
   const bountyAmount = getBountyAmount()
 
   const styles = createStyles()
+
+  const handleForward = async () => {
+    await setBikeGoal({
+      ...bikeGoal,
+      onboardingStep: onboardingStep + 1
+    })
+  }
 
   return (
     <Step {...props} ref={ref}>
@@ -43,6 +51,7 @@ const BikeGoalOnboardingIntroduction = forwardRef((props, ref) => {
             </Typography>
             <div className="u-mt-1">
               <Button
+                onClick={handleForward}
                 label={t('bikeGoal.onboarding.actions.next')}
               />
             </div>

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingIntroduction.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingIntroduction.jsx
@@ -4,7 +4,9 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
 import StepContent from 'cozy-ui/transpiled/react/StepContent'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
+import useSettings from 'src/hooks/useSettings'
 import { getBountyAmount } from 'src/components/Goals/BikeGoal/helpers'
 
 const createStyles = () => ({
@@ -15,6 +17,11 @@ const createStyles = () => ({
 
 const BikeGoalOnboardingIntroduction = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const {
+    isLoading,
+    value: bikeGoal = {},
+    save: setBikeGoal
+  } = useSettings('bikeGoal')
   const bountyAmount = getBountyAmount()
 
   const styles = createStyles()
@@ -23,9 +30,18 @@ const BikeGoalOnboardingIntroduction = forwardRef((props, ref) => {
     <Step {...props} ref={ref}>
       <StepLabel>{t('bikeGoal.about.intro.title')}</StepLabel>
       <StepContent>
-        <Typography style={styles.typography}>
-          {t('bikeGoal.about.intro.content', { bountyAmount })}
-        </Typography>
+        {isLoading ? (
+          <Spinner
+            size="xxlarge"
+            className="u-flex u-flex-justify-center u-m-1"
+          />
+        ) : (
+          <>
+            <Typography style={styles.typography}>
+              {t('bikeGoal.about.intro.content', { bountyAmount })}
+            </Typography>
+          </>
+        )}
       </StepContent>
     </Step>
   )

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingIntroduction.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingIntroduction.jsx
@@ -4,6 +4,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
 import StepContent from 'cozy-ui/transpiled/react/StepContent'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import useSettings from 'src/hooks/useSettings'
@@ -40,6 +41,11 @@ const BikeGoalOnboardingIntroduction = forwardRef((props, ref) => {
             <Typography style={styles.typography}>
               {t('bikeGoal.about.intro.content', { bountyAmount })}
             </Typography>
+            <div className="u-mt-1">
+              <Button
+                label={t('bikeGoal.onboarding.actions.next')}
+              />
+            </div>
           </>
         )}
       </StepContent>

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingIntroduction.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingIntroduction.jsx
@@ -1,0 +1,36 @@
+import React, { forwardRef } from 'react'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
+import StepContent from 'cozy-ui/transpiled/react/StepContent'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+import { getBountyAmount } from 'src/components/Goals/BikeGoal/helpers'
+
+const createStyles = () => ({
+  typography: {
+    whiteSpace: 'pre-line'
+  }
+})
+
+const BikeGoalOnboardingIntroduction = forwardRef((props, ref) => {
+  const { t } = useI18n()
+  const bountyAmount = getBountyAmount()
+
+  const styles = createStyles()
+
+  return (
+    <Step {...props} ref={ref}>
+      <StepLabel>{t('bikeGoal.about.intro.title')}</StepLabel>
+      <StepContent>
+        <Typography style={styles.typography}>
+          {t('bikeGoal.about.intro.content', { bountyAmount })}
+        </Typography>
+      </StepContent>
+    </Step>
+  )
+})
+
+BikeGoalOnboardingIntroduction.displayName = 'BikeGoalOnboardingIntroduction'
+
+export default BikeGoalOnboardingIntroduction

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingIntroduction.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingIntroduction.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useReducer } from 'react'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
@@ -18,6 +18,7 @@ const createStyles = () => ({
 
 const BikeGoalOnboardingIntroduction = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
   const {
     isLoading,
     value: bikeGoal = {},
@@ -29,10 +30,12 @@ const BikeGoalOnboardingIntroduction = forwardRef((props, ref) => {
   const styles = createStyles()
 
   const handleForward = async () => {
+    toggleBusy()
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep + 1
     })
+    toggleBusy()
   }
 
   return (
@@ -53,7 +56,9 @@ const BikeGoalOnboardingIntroduction = forwardRef((props, ref) => {
               <Button
                 onClick={handleForward}
                 label={t('bikeGoal.onboarding.actions.next')}
+                disabled={isBusy}
               />
+              {isBusy && <Spinner className="u-ml-half" />}
             </div>
           </>
         )}

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
@@ -66,20 +66,24 @@ const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
             <Typography>
               {t('bikeGoal.onboarding.steps.naming.nameLegend')}
             </Typography>
-            <TextField
-              variant="outlined"
-              label={t('bikeGoal.edit.lastname')}
-              defaultValue={unsavedLastname}
-              onChange={event => setUnsavedLastname(event.target.value)}
-              className="u-db u-mt-1"
-            />
-            <TextField
-              variant="outlined"
-              label={t('bikeGoal.edit.firstname')}
-              defaultValue={unsavedFirstname}
-              onChange={event => setUnsavedFirstname(event.target.value)}
-              className="u-db u-mt-1"
-            />
+            <div>
+              <TextField
+                variant="outlined"
+                label={t('bikeGoal.edit.lastname')}
+                defaultValue={unsavedLastname}
+                onChange={event => setUnsavedLastname(event.target.value)}
+                className="u-w-5 u-mt-1"
+              />
+            </div>
+            <div>
+              <TextField
+                variant="outlined"
+                label={t('bikeGoal.edit.firstname')}
+                defaultValue={unsavedFirstname}
+                onChange={event => setUnsavedFirstname(event.target.value)}
+                className="u-w-5 u-mt-1"
+              />
+            </div>
             <div className="u-mt-1">
               <Button
                 onClick={handleForward}

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useReducer } from 'react'
+import React, { forwardRef, useReducer, useState } from 'react'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
@@ -18,7 +18,9 @@ const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
     value: bikeGoal = {},
     save: setBikeGoal
   } = useSettings('bikeGoal')
-  const { onboardingStep = 0, } = bikeGoal
+  const { onboardingStep = 0, lastname = '', firstname = '' } = bikeGoal
+  const [unsavedLastname, setUnsavedLastname] = useState(lastname)
+  const [unsavedFirstname, setUnsavedFirstname] = useState(firstname)
 
   const handleBack = async () => {
     toggleBusy()
@@ -55,11 +57,13 @@ const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
             <TextField
               variant="outlined"
               label={t('bikeGoal.edit.lastname')}
+              defaultValue={unsavedLastname}
               className="u-db u-mt-1"
             />
             <TextField
               variant="outlined"
               label={t('bikeGoal.edit.firstname')}
+              defaultValue={unsavedFirstname}
               className="u-db u-mt-1"
             />
             <div className="u-mt-1">

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
@@ -42,6 +42,16 @@ const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
     toggleBusy()
   }
 
+  const isForwardDisabled = () => {
+    if (unsavedFirstname === '') {
+      return true
+    }
+    if (unsavedLastname === '') {
+      return true
+    }
+    return false
+  }
+
   return (
     <Step {...props} ref={ref}>
       <StepLabel>{t('bikeGoal.onboarding.steps.naming.title')}</StepLabel>
@@ -74,7 +84,7 @@ const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
               <Button
                 onClick={handleForward}
                 label={t('bikeGoal.onboarding.actions.next')}
-                disabled={isBusy}
+                disabled={isBusy || isForwardDisabled()}
               />
               <Button
                 onClick={handleBack}

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useReducer } from 'react'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
@@ -12,6 +12,7 @@ import useSettings from 'src/hooks/useSettings'
 
 const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
   const {
     isLoading,
     value: bikeGoal = {},
@@ -20,17 +21,21 @@ const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
   const { onboardingStep = 0, } = bikeGoal
 
   const handleBack = async () => {
+    toggleBusy()
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep - 1
     })
+    toggleBusy()
   }
 
   const handleForward = async () => {
+    toggleBusy()
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep + 1,
     })
+    toggleBusy()
   }
 
   return (
@@ -61,13 +66,16 @@ const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
               <Button
                 onClick={handleForward}
                 label={t('bikeGoal.onboarding.actions.next')}
+                disabled={isBusy}
               />
               <Button
                 onClick={handleBack}
                 label={t('bikeGoal.onboarding.actions.previous')}
+                disabled={isBusy}
                 variant="text"
                 className="u-ml-half"
               />
+              {isBusy && <Spinner className="u-ml-half" />}
             </div>
           </>
         )}

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
@@ -1,0 +1,36 @@
+import React, { forwardRef } from 'react'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
+import StepContent from 'cozy-ui/transpiled/react/StepContent'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField'
+
+const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
+  const { t } = useI18n()
+
+  return (
+    <Step {...props} ref={ref}>
+      <StepLabel>{t('bikeGoal.onboarding.steps.naming.title')}</StepLabel>
+      <StepContent>
+        <Typography>
+          {t('bikeGoal.onboarding.steps.naming.nameLegend')}
+        </Typography>
+        <TextField
+          variant="outlined"
+          label={t('bikeGoal.edit.lastname')}
+          className="u-db u-mt-1"
+        />
+        <TextField
+          variant="outlined"
+          label={t('bikeGoal.edit.firstname')}
+          className="u-db u-mt-1"
+        />
+      </StepContent>
+    </Step>
+  )
+})
+
+BikeGoalOnboardingNaming.displayName = 'BikeGoalOnboardingNaming'
+
+export default BikeGoalOnboardingNaming

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
@@ -36,6 +36,8 @@ const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep + 1,
+      lastname: unsavedLastname,
+      firstname: unsavedFirstname
     })
     toggleBusy()
   }
@@ -58,12 +60,14 @@ const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
               variant="outlined"
               label={t('bikeGoal.edit.lastname')}
               defaultValue={unsavedLastname}
+              onChange={event => setUnsavedLastname(event.target.value)}
               className="u-db u-mt-1"
             />
             <TextField
               variant="outlined"
               label={t('bikeGoal.edit.firstname')}
               defaultValue={unsavedFirstname}
+              onChange={event => setUnsavedFirstname(event.target.value)}
               className="u-db u-mt-1"
             />
             <div className="u-mt-1">

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
@@ -4,6 +4,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
 import StepContent from 'cozy-ui/transpiled/react/StepContent'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
@@ -41,6 +42,16 @@ const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
               label={t('bikeGoal.edit.firstname')}
               className="u-db u-mt-1"
             />
+            <div className="u-mt-1">
+              <Button
+                label={t('bikeGoal.onboarding.actions.next')}
+              />
+              <Button
+                label={t('bikeGoal.onboarding.actions.previous')}
+                variant="text"
+                className="u-ml-half"
+              />
+            </div>
           </>
         )}
       </StepContent>

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
@@ -5,27 +5,44 @@ import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
 import StepContent from 'cozy-ui/transpiled/react/StepContent'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+import useSettings from 'src/hooks/useSettings'
 
 const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const {
+    isLoading,
+    value: bikeGoal = {},
+    save: setBikeGoal
+  } = useSettings('bikeGoal')
 
   return (
     <Step {...props} ref={ref}>
       <StepLabel>{t('bikeGoal.onboarding.steps.naming.title')}</StepLabel>
       <StepContent>
-        <Typography>
-          {t('bikeGoal.onboarding.steps.naming.nameLegend')}
-        </Typography>
-        <TextField
-          variant="outlined"
-          label={t('bikeGoal.edit.lastname')}
-          className="u-db u-mt-1"
-        />
-        <TextField
-          variant="outlined"
-          label={t('bikeGoal.edit.firstname')}
-          className="u-db u-mt-1"
-        />
+        {isLoading ? (
+          <Spinner
+            size="xxlarge"
+            className="u-flex u-flex-justify-center u-m-1"
+          />
+        ) : (
+          <>
+            <Typography>
+              {t('bikeGoal.onboarding.steps.naming.nameLegend')}
+            </Typography>
+            <TextField
+              variant="outlined"
+              label={t('bikeGoal.edit.lastname')}
+              className="u-db u-mt-1"
+            />
+            <TextField
+              variant="outlined"
+              label={t('bikeGoal.edit.firstname')}
+              className="u-db u-mt-1"
+            />
+          </>
+        )}
       </StepContent>
     </Step>
   )

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingNaming.jsx
@@ -17,6 +17,21 @@ const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
     value: bikeGoal = {},
     save: setBikeGoal
   } = useSettings('bikeGoal')
+  const { onboardingStep = 0, } = bikeGoal
+
+  const handleBack = async () => {
+    await setBikeGoal({
+      ...bikeGoal,
+      onboardingStep: onboardingStep - 1
+    })
+  }
+
+  const handleForward = async () => {
+    await setBikeGoal({
+      ...bikeGoal,
+      onboardingStep: onboardingStep + 1,
+    })
+  }
 
   return (
     <Step {...props} ref={ref}>
@@ -44,9 +59,11 @@ const BikeGoalOnboardingNaming = forwardRef((props, ref) => {
             />
             <div className="u-mt-1">
               <Button
+                onClick={handleForward}
                 label={t('bikeGoal.onboarding.actions.next')}
               />
               <Button
+                onClick={handleBack}
                 label={t('bikeGoal.onboarding.actions.previous')}
                 variant="text"
                 className="u-ml-half"

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
@@ -1,0 +1,40 @@
+import React, { forwardRef } from 'react'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
+import StepContent from 'cozy-ui/transpiled/react/StepContent'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
+import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
+import Radio from 'cozy-ui/transpiled/react/Radios'
+
+const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
+  const { t } = useI18n()
+
+  return (
+    <Step {...props} ref={ref}>
+      <StepLabel>{t('bikeGoal.edit.workTime')}</StepLabel>
+      <StepContent>
+        <Typography>
+          {t('bikeGoal.onboarding.steps.timing.timeLegend')}
+        </Typography>
+        <RadioGroup className="u-mt-1">
+          <FormControlLabel
+            control={<Radio />}
+            label={t('bikeGoal.onboarding.steps.timing.fullTime')}
+            className="u-m-0"
+          />
+          <FormControlLabel
+            control={<Radio />}
+            label={t('bikeGoal.onboarding.steps.timing.partTime')}
+            className="u-m-0"
+          />
+        </RadioGroup>
+      </StepContent>
+    </Step>
+  )
+})
+
+BikeGoalOnboardingTiming.displayName = 'BikeGoalOnboardingTiming'
+
+export default BikeGoalOnboardingTiming

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
@@ -19,6 +19,23 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
     value: bikeGoal = {},
     save: setBikeGoal
   } = useSettings('bikeGoal')
+  const {
+    onboardingStep = 0,
+  } = bikeGoal
+
+  const handleBack = async () => {
+    await setBikeGoal({
+      ...bikeGoal,
+      onboardingStep: onboardingStep - 1
+    })
+  }
+
+  const handleForward = async () => {
+    await setBikeGoal({
+      ...bikeGoal,
+      onboardingStep: onboardingStep + 1,
+    })
+  }
 
   return (
     <Step {...props} ref={ref}>
@@ -48,9 +65,11 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
             </RadioGroup>
             <div className="u-mt-1">
               <Button
+                onClick={handleForward}
                 label={t('bikeGoal.onboarding.actions.next')}
               />
               <Button
+                onClick={handleBack}
                 label={t('bikeGoal.onboarding.actions.previous')}
                 variant="text"
                 className="u-ml-half"

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
@@ -7,29 +7,46 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
 import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
 import Radio from 'cozy-ui/transpiled/react/Radios'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+import useSettings from 'src/hooks/useSettings'
 
 const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const {
+    isLoading,
+    value: bikeGoal = {},
+    save: setBikeGoal
+  } = useSettings('bikeGoal')
 
   return (
     <Step {...props} ref={ref}>
       <StepLabel>{t('bikeGoal.edit.workTime')}</StepLabel>
       <StepContent>
-        <Typography>
-          {t('bikeGoal.onboarding.steps.timing.timeLegend')}
-        </Typography>
-        <RadioGroup className="u-mt-1">
-          <FormControlLabel
-            control={<Radio />}
-            label={t('bikeGoal.onboarding.steps.timing.fullTime')}
-            className="u-m-0"
+        {isLoading ? (
+          <Spinner
+            size="xxlarge"
+            className="u-flex u-flex-justify-center u-m-1"
           />
-          <FormControlLabel
-            control={<Radio />}
-            label={t('bikeGoal.onboarding.steps.timing.partTime')}
-            className="u-m-0"
-          />
-        </RadioGroup>
+        ) : (
+          <>
+            <Typography>
+              {t('bikeGoal.onboarding.steps.timing.timeLegend')}
+            </Typography>
+            <RadioGroup className="u-mt-1">
+              <FormControlLabel
+                control={<Radio />}
+                label={t('bikeGoal.onboarding.steps.timing.fullTime')}
+                className="u-m-0"
+              />
+              <FormControlLabel
+                control={<Radio />}
+                label={t('bikeGoal.onboarding.steps.timing.partTime')}
+                className="u-m-0"
+              />
+            </RadioGroup>
+          </>
+        )}
       </StepContent>
     </Step>
   )

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
@@ -45,6 +45,8 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep + 1,
+      workTime: unsavedWorkTime,
+      workTimePercentage: unsavedWorkTimePercentage
     })
     toggleBusy()
   }
@@ -68,6 +70,7 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
                 control={
                   <Radio
                     checked={unsavedWorkTime === 'full'}
+                    onClick={() => setUnsavedWorkTime('full')}
                   />
                 }
                 label={t('bikeGoal.edit.workTime_full')}
@@ -77,6 +80,7 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
                 control={
                   <Radio
                     checked={unsavedWorkTime === 'part'}
+                    onClick={() => setUnsavedWorkTime('part')}
                   />
                 }
                 label={t('bikeGoal.edit.workTime_part')}
@@ -105,6 +109,13 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
                         <Typography variant="body1">%</Typography>
                       </InputAdornment>
                     )
+                  }}
+                  onChange={event => {
+                    if (event.target.value.match(/^\d+$/)) {
+                      setUnsavedWorkTimePercentage(Number(event.target.value))
+                    } else {
+                      setUnsavedWorkTimePercentage(0)
+                    }
                   }}
                   className="u-db u-mt-1"
                 />

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useReducer } from 'react'
+import React, { forwardRef, useReducer, useState } from 'react'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
@@ -22,7 +22,9 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
   } = useSettings('bikeGoal')
   const {
     onboardingStep = 0,
+    workTime = null,
   } = bikeGoal
+  const [unsavedWorkTime, setUnsavedWorkTime] = useState(workTime)
 
   const handleBack = async () => {
     toggleBusy()
@@ -58,12 +60,20 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
             </Typography>
             <RadioGroup className="u-mt-1">
               <FormControlLabel
-                control={<Radio />}
+                control={
+                  <Radio
+                    checked={unsavedWorkTime === 'full'}
+                  />
+                }
                 label={t('bikeGoal.onboarding.steps.timing.fullTime')}
                 className="u-m-0"
               />
               <FormControlLabel
-                control={<Radio />}
+                control={
+                  <Radio
+                    checked={unsavedWorkTime === 'part'}
+                  />
+                }
                 label={t('bikeGoal.onboarding.steps.timing.partTime')}
                 className="u-m-0"
               />

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
@@ -1,10 +1,12 @@
 import React, { forwardRef, useReducer, useState } from 'react'
+import InputAdornment from '@material-ui/core/InputAdornment'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
 import StepContent from 'cozy-ui/transpiled/react/StepContent'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import Button from 'cozy-ui/transpiled/react/Buttons'
+import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField'
 import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
 import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
 import Radio from 'cozy-ui/transpiled/react/Radios'
@@ -78,6 +80,32 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
                 className="u-m-0"
               />
             </RadioGroup>
+            {unsavedWorkTime === 'part' && (
+              <>
+                <Typography className="u-mt-1">
+                  {t('bikeGoal.onboarding.steps.timing.percentageLegend')}
+                </Typography>
+                <TextField
+                  variant="outlined"
+                  type="number"
+                  inputProps={{
+                    min: '0',
+                    max: '100',
+                    step: '1',
+                    inputMode: 'numeric'
+                  }}
+                  label={t('bikeGoal.onboarding.steps.timing.percentage')}
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <Typography variant="body1">%</Typography>
+                      </InputAdornment>
+                    )
+                  }}
+                  className="u-db u-mt-1"
+                />
+              </>
+            )}
             <div className="u-mt-1">
               <Button
                 onClick={handleForward}

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
@@ -6,13 +6,14 @@ import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
 import StepContent from 'cozy-ui/transpiled/react/StepContent'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import Button from 'cozy-ui/transpiled/react/Buttons'
-import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField'
 import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
 import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
 import Radio from 'cozy-ui/transpiled/react/Radios'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import useSettings from 'src/hooks/useSettings'
+import { toPercentage } from 'src/components/Goals/BikeGoal/Edit/helpers'
+import PercentageField from 'src/components/Goals/BikeGoal/Edit/PercentageField'
 
 const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
   const { t } = useI18n()
@@ -55,8 +56,13 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
     if (unsavedWorkTime == null) {
       return true
     }
-    if (unsavedWorkTime === 'part' && unsavedWorkTimePercentage === 0) {
-      return true
+    if (unsavedWorkTime === 'part') {
+      if (unsavedWorkTimePercentage == null) {
+        return true
+      }
+      if (unsavedWorkTimePercentage === 0) {
+        return true
+      }
     }
     return false
   }
@@ -103,15 +109,8 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
                   {t('bikeGoal.onboarding.steps.timing.percentageLegend')}
                 </Typography>
                 <div>
-                  <TextField
+                  <PercentageField
                     variant="outlined"
-                    type="number"
-                    inputProps={{
-                      min: '0',
-                      max: '100',
-                      step: '1',
-                      inputMode: 'numeric'
-                    }}
                     label={t('bikeGoal.onboarding.steps.timing.percentage')}
                     defaultValue={unsavedWorkTimePercentage}
                     InputProps={{
@@ -122,11 +121,9 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
                       )
                     }}
                     onChange={event => {
-                      if (event.target.value.match(/^\d+$/)) {
-                        setUnsavedWorkTimePercentage(Number(event.target.value))
-                      } else {
-                        setUnsavedWorkTimePercentage(0)
-                      }
+                      setUnsavedWorkTimePercentage(
+                        toPercentage(Number(event.target.value))
+                      )
                     }}
                     className="u-w-5 u-mt-1"
                   />

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useReducer } from 'react'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
@@ -14,6 +14,7 @@ import useSettings from 'src/hooks/useSettings'
 
 const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
   const { t } = useI18n()
+  const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
   const {
     isLoading,
     value: bikeGoal = {},
@@ -24,17 +25,21 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
   } = bikeGoal
 
   const handleBack = async () => {
+    toggleBusy()
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep - 1
     })
+    toggleBusy()
   }
 
   const handleForward = async () => {
+    toggleBusy()
     await setBikeGoal({
       ...bikeGoal,
       onboardingStep: onboardingStep + 1,
     })
+    toggleBusy()
   }
 
   return (
@@ -67,13 +72,16 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
               <Button
                 onClick={handleForward}
                 label={t('bikeGoal.onboarding.actions.next')}
+                disabled={isBusy}
               />
               <Button
                 onClick={handleBack}
                 label={t('bikeGoal.onboarding.actions.previous')}
+                disabled={isBusy}
                 variant="text"
                 className="u-ml-half"
               />
+              {isBusy && <Spinner className="u-ml-half" />}
             </div>
           </>
         )}

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
@@ -102,33 +102,35 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
                 <Typography className="u-mt-1">
                   {t('bikeGoal.onboarding.steps.timing.percentageLegend')}
                 </Typography>
-                <TextField
-                  variant="outlined"
-                  type="number"
-                  inputProps={{
-                    min: '0',
-                    max: '100',
-                    step: '1',
-                    inputMode: 'numeric'
-                  }}
-                  label={t('bikeGoal.onboarding.steps.timing.percentage')}
-                  defaultValue={unsavedWorkTimePercentage}
-                  InputProps={{
-                    endAdornment: (
-                      <InputAdornment position="end">
-                        <Typography variant="body1">%</Typography>
-                      </InputAdornment>
-                    )
-                  }}
-                  onChange={event => {
-                    if (event.target.value.match(/^\d+$/)) {
-                      setUnsavedWorkTimePercentage(Number(event.target.value))
-                    } else {
-                      setUnsavedWorkTimePercentage(0)
-                    }
-                  }}
-                  className="u-db u-mt-1"
-                />
+                <div>
+                  <TextField
+                    variant="outlined"
+                    type="number"
+                    inputProps={{
+                      min: '0',
+                      max: '100',
+                      step: '1',
+                      inputMode: 'numeric'
+                    }}
+                    label={t('bikeGoal.onboarding.steps.timing.percentage')}
+                    defaultValue={unsavedWorkTimePercentage}
+                    InputProps={{
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <Typography variant="body1">%</Typography>
+                        </InputAdornment>
+                      )
+                    }}
+                    onChange={event => {
+                      if (event.target.value.match(/^\d+$/)) {
+                        setUnsavedWorkTimePercentage(Number(event.target.value))
+                      } else {
+                        setUnsavedWorkTimePercentage(0)
+                      }
+                    }}
+                    className="u-w-5 u-mt-1"
+                  />
+                </div>
               </>
             )}
             <div className="u-mt-1">

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
@@ -4,6 +4,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Step, StepLabel } from 'cozy-ui/transpiled/react/Stepper'
 import StepContent from 'cozy-ui/transpiled/react/StepContent'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
 import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
 import Radio from 'cozy-ui/transpiled/react/Radios'
@@ -45,6 +46,16 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
                 className="u-m-0"
               />
             </RadioGroup>
+            <div className="u-mt-1">
+              <Button
+                label={t('bikeGoal.onboarding.actions.next')}
+              />
+              <Button
+                label={t('bikeGoal.onboarding.actions.previous')}
+                variant="text"
+                className="u-ml-half"
+              />
+            </div>
           </>
         )}
       </StepContent>

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
@@ -51,6 +51,16 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
     toggleBusy()
   }
 
+  const isForwardDisabled = () => {
+    if (unsavedWorkTime == null) {
+      return true
+    }
+    if (unsavedWorkTime === 'part' && unsavedWorkTimePercentage === 0) {
+      return true
+    }
+    return false
+  }
+
   return (
     <Step {...props} ref={ref}>
       <StepLabel>{t('bikeGoal.edit.workTime')}</StepLabel>
@@ -125,7 +135,7 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
               <Button
                 onClick={handleForward}
                 label={t('bikeGoal.onboarding.actions.next')}
-                disabled={isBusy}
+                disabled={isBusy || isForwardDisabled()}
               />
               <Button
                 onClick={handleBack}

--- a/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
+++ b/src/components/Views/BikeGoalOnboardingSteps/BikeGoalOnboardingTiming.jsx
@@ -25,8 +25,11 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
   const {
     onboardingStep = 0,
     workTime = null,
+    workTimePercentage = 0
   } = bikeGoal
   const [unsavedWorkTime, setUnsavedWorkTime] = useState(workTime)
+  const [unsavedWorkTimePercentage, setUnsavedWorkTimePercentage] =
+    useState(workTimePercentage)
 
   const handleBack = async () => {
     toggleBusy()
@@ -67,7 +70,7 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
                     checked={unsavedWorkTime === 'full'}
                   />
                 }
-                label={t('bikeGoal.onboarding.steps.timing.fullTime')}
+                label={t('bikeGoal.edit.workTime_full')}
                 className="u-m-0"
               />
               <FormControlLabel
@@ -76,7 +79,7 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
                     checked={unsavedWorkTime === 'part'}
                   />
                 }
-                label={t('bikeGoal.onboarding.steps.timing.partTime')}
+                label={t('bikeGoal.edit.workTime_part')}
                 className="u-m-0"
               />
             </RadioGroup>
@@ -95,6 +98,7 @@ const BikeGoalOnboardingTiming = forwardRef((props, ref) => {
                     inputMode: 'numeric'
                   }}
                   label={t('bikeGoal.onboarding.steps.timing.percentage')}
+                  defaultValue={unsavedWorkTimePercentage}
                   InputProps={{
                     endAdornment: (
                       <InputAdornment position="end">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -229,7 +229,9 @@
         "timing": {
           "timeLegend": "You currently have a employment contract:",
           "fullTime": "Full-time",
-          "partTime": "Half-time or part-time"
+          "partTime": "Half-time or part-time",
+          "percentageLegend": "Fill in the percentage of your working time:",
+          "percentage": "Percentage"
         },
         "comparison": {
           "comparisonLegend": "It is possible to display the average progression of the members of your company who participate in the goal. To do so, you will be asked to also participate in the establishment of this average. Your progression data will be aggregated and sent anonymously, and will not contain any identifiers or locations.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -228,8 +228,6 @@
         },
         "timing": {
           "timeLegend": "You currently have a employment contract:",
-          "fullTime": "Full-time",
-          "partTime": "Half-time or part-time",
           "percentageLegend": "Fill in the percentage of your working time:",
           "percentage": "Percentage"
         },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -217,7 +217,9 @@
     "onboarding": {
       "title": "\"Sustainable mobility\" package",
       "actions": {
-        "finish": "Finish"
+        "finish": "Finish",
+        "previous": "Previous",
+        "next": "Next"
       },
       "steps": {
         "naming": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -203,7 +203,7 @@
       "workTime_full": "Full time",
       "workTime_part": "Half-time or part-time",
       "workTimePercentage": "Percentage of working time",
-      "compare_progress": "Compare my progress with that of my company",
+      "compare_progress": "Compare my progress with that of %{source}",
       "cancel": "Cancel",
       "submit": "Ok",
       "required": "This field is required"
@@ -232,7 +232,7 @@
           "percentage": "Percentage"
         },
         "comparison": {
-          "comparisonLegend": "It is possible to display the average progression of the members of your company who participate in the goal. To do so, you will be asked to also participate in the establishment of this average. Your progression data will be aggregated and sent anonymously, and will not contain any identifiers or locations.",
+          "comparisonLegend": "It is possible to display the average progression of the members of %{source} who participate in the goal. To do so, you will be asked to also participate in the establishment of this average. Your progression data will be aggregated and sent anonymously, and will not contain any identifiers or locations.",
           "compare": "Compare my progression",
           "doNotCompare": "Do not compare my progression"
         }
@@ -245,6 +245,12 @@
         "show": "Certificate - Bike to work.pdf",
         "generate": "Generate a new certificate"
       }
+    },
+    "employer": {
+      "my_company": "my company",
+      "your_company": "your company",
+      "my_collectivity": "my collectivity",
+      "your_collectivity": "your collectivity"
     }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -218,6 +218,22 @@
       "title": "\"Sustainable mobility\" package",
       "actions": {
         "finish": "Finish"
+      },
+      "steps": {
+        "naming": {
+          "title": "Lastname and firstname",
+          "nameLegend": "Fill in the following information:"
+        },
+        "timing": {
+          "timeLegend": "You currently have a employment contract:",
+          "fullTime": "Full-time",
+          "partTime": "Half-time or part-time"
+        },
+        "comparison": {
+          "comparisonLegend": "It is possible to display the average progression of the members of your company who participate in the goal. To do so, you will be asked to also participate in the establishment of this average. Your progression data will be aggregated and sent anonymously, and will not contain any identifiers or locations.",
+          "compare": "Compare my progression",
+          "doNotCompare": "Do not compare my progression"
+        }
       }
     },
     "certificateGeneration": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -203,7 +203,7 @@
       "workTime_full": "Temps plein",
       "workTime_part": "Mi-temps ou temps partiel",
       "workTimePercentage": "Pourcentage du temps de travail",
-      "compare_progress": "Comparer ma progression avec celle de mon entreprise",
+      "compare_progress": "Comparer ma progression avec celle de %{source}",
       "cancel": "Annuler",
       "submit": "Ok",
       "required": "Ce champ est obligatoire"
@@ -232,7 +232,7 @@
           "percentage": "Pourcentage"
         },
         "comparison": {
-          "comparisonLegend": "Il vous est possible d’afficher la progression moyenne des membres de votre entreprise qui participent à l’objectif. Pour cela, il vous sera demandé de participer également à la constituation de cette moyenne.\n\nVos données de progression seront agrégées et envoyées anonymement, elles ne contiendront aucun identifiant ni lieux.",
+          "comparisonLegend": "Il vous est possible d’afficher la progression moyenne des membres de %{source} qui participent à l’objectif. Pour cela, il vous sera demandé de participer également à la constituation de cette moyenne.\n\nVos données de progression seront agrégées et envoyées anonymement, elles ne contiendront aucun identifiant ni lieux.",
           "compare": "Comparer ma progression",
           "doNotCompare": "Ne pas comparer ma progression"
         }
@@ -245,6 +245,12 @@
         "show": "Certificat - Aller travailler à vélo.pdf",
         "generate": "Générer une nouvelle attestation"
       }
+    },
+    "employer": {
+      "my_company": "mon entreprise",
+      "your_company": "votre entreprise",
+      "my_collectivity": "ma collectivité",
+      "your_collectivity": "votre collectivité"
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -229,7 +229,9 @@
         "timing": {
           "timeLegend": "Vous disposez actuellement d’un contrat de travail à :",
           "fullTime": "Temps plein",
-          "partTime": "Mi-temps ou temps partiel"
+          "partTime": "Mi-temps ou temps partiel",
+          "percentageLegend": "Renseignez le pourcentage de votre temps de travail :",
+          "percentage": "Pourcentage"
         },
         "comparison": {
           "comparisonLegend": "Il vous est possible d’afficher la progression moyenne des membres de votre entreprise qui participent à l’objectif. Pour cela, il vous sera demandé de participer également à la constituation de cette moyenne.\n\nVos données de progression seront agrégées et envoyées anonymement, elles ne contiendront aucun identifiant ni lieux.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -217,7 +217,9 @@
     "onboarding": {
       "title": "Forfait \"mobilités durables\"",
       "actions": {
-        "finish": "Terminer"
+        "finish": "Terminer",
+        "previous": "Précédent",
+        "next": "Suivant"
       },
       "steps": {
         "naming": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -228,8 +228,6 @@
         },
         "timing": {
           "timeLegend": "Vous disposez actuellement d’un contrat de travail à :",
-          "fullTime": "Temps plein",
-          "partTime": "Mi-temps ou temps partiel",
           "percentageLegend": "Renseignez le pourcentage de votre temps de travail :",
           "percentage": "Pourcentage"
         },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -218,6 +218,22 @@
       "title": "Forfait \"mobilités durables\"",
       "actions": {
         "finish": "Terminer"
+      },
+      "steps": {
+        "naming": {
+          "title": "Nom et prénom",
+          "nameLegend": "Renseignez les informations suivantes :"
+        },
+        "timing": {
+          "timeLegend": "Vous disposez actuellement d’un contrat de travail à :",
+          "fullTime": "Temps plein",
+          "partTime": "Mi-temps ou temps partiel"
+        },
+        "comparison": {
+          "comparisonLegend": "Il vous est possible d’afficher la progression moyenne des membres de votre entreprise qui participent à l’objectif. Pour cela, il vous sera demandé de participer également à la constituation de cette moyenne.\n\nVos données de progression seront agrégées et envoyées anonymement, elles ne contiendront aucun identifiant ni lieux.",
+          "compare": "Comparer ma progression",
+          "doNotCompare": "Ne pas comparer ma progression"
+        }
       }
     },
     "certificateGeneration": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5259,10 +5259,10 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@^77.1.0:
-  version "77.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-77.1.0.tgz#e76a4bf220d51aa438711f850b4b93077e9b1f43"
-  integrity sha512-AuZAuIKrG91rmn+dD8oS7ta4zm1saZw5yigs1bQvSGBbqOUp77ZkcMonM7VsC2edZv6f5CLmhbM/u8cdgP91lw==
+cozy-ui@^77.3.0:
+  version "77.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-77.3.0.tgz#dab629b5ce479e4de167e1ef3ac038cdce0963c5"
+  integrity sha512-ymEiiIV3TEjZZcSOrPYD1h7ihs0ETlb6MoksNOfovpYuFcJv+s/YyvoQKkM4OT8SYfPr3TLIV8EHGX00Z6iJDQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -10383,9 +10383,9 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
This adds the onboarding stepper that can be opened from the blue alerter or from the settings.
Please note that the stepper is not fully compliant with the specs and will soon or later need Cozy UI to be updated with cozy/cozy-ui#2280 included.

```
### ✨ Features

* Add the onboarding for the bike goal feature
* Allow to customize the source identity via a flag
```
