### PR TITLE
BikeGoal: fix actions position in mobile and list order

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cozy-intent": "^1.17.1",
     "cozy-logger": "^1.9.0",
     "cozy-realtime": "^4.2.1",
-    "cozy-ui": "^77.3.0",
+    "cozy-ui": "^77.4.0",
     "date-fns": "2.29.3",
     "humanize-duration": "3.27.1",
     "leaflet": "1.9.1",

--- a/src/components/Goals/BikeGoal/BikeGoalActions.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalActions.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
@@ -19,7 +20,9 @@ const BikeGoalActions = ({ timeseries }) => {
 
   return (
     <div
-      className="u-flex u-flex-justify-end u-pos-absolute u-top-m"
+      className={cx('u-flex u-flex-justify-end', {
+        'u-pos-absolute u-top-m': !isMobile
+      })}
       style={styles.actions}
     >
       <BikeGoalDateSelector timeseries={timeseries} />

--- a/src/components/Goals/BikeGoal/BikeGoalDialogMobile.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalDialogMobile.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { useNavigate, useParams } from 'react-router-dom'
 
-import { IllustrationDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 
 import BikeGoalList from 'src/components/Goals/BikeGoal/BikeGoalList'
 import BikeGoalAchievement from 'src/components/Goals/BikeGoal/BikeGoalAchievement'
@@ -17,13 +17,18 @@ const BikeGoalDialogMobile = ({ timeseries, timeseriesQueryLeft }) => {
   const timeseriesByYear = filterTimeseriesByYear(timeseries, year)
 
   return (
-    <IllustrationDialog
+    <Dialog
       open
-      onBack={() => navigate('/trips')}
+      onClose={() => navigate('/trips')}
       disableGutters
+      componentsProps={{
+        dialogTitle: {
+          className: 'u-p-0'
+        }
+      }}
+      title={<BikeGoalActions timeseries={timeseries} />}
       content={
         <>
-          <BikeGoalActions timeseries={timeseries} />
           <BikeGoalChart
             display="flex"
             paddingTop="1.5rem"

--- a/src/lib/timeseries.js
+++ b/src/lib/timeseries.js
@@ -470,7 +470,7 @@ export const computeMonthsAndCO2s = (timeseries, f) => {
 export const countUniqDays = timeseries => {
   let count = 0
 
-  const sortedTimeseriesByStartdateAsc = timeseries.sort((a, b) => {
+  const sortedTimeseriesByStartdateAsc = [...timeseries].sort((a, b) => {
     return getStartDate(a) - getStartDate(b)
   })
 

--- a/src/lib/timeseries.spec.js
+++ b/src/lib/timeseries.spec.js
@@ -813,6 +813,20 @@ describe('countUniqDays', () => {
 
     expect(res).toBe(2)
   })
+
+  it('should not change order of initial timeseries', () => {
+    const timeseries = [
+      { startDate: '2021-01-02T00:00:00', endDate: '2021-01-02T00:00:00' },
+      { startDate: '2021-01-01T00:00:00', endDate: '2021-01-01T00:00:00' }
+    ]
+
+    countUniqDays(timeseries)
+
+    expect(timeseries[0]).toStrictEqual({
+      startDate: '2021-01-02T00:00:00',
+      endDate: '2021-01-02T00:00:00'
+    })
+  })
 })
 
 describe('getEarliestTimeserie', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5259,10 +5259,10 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@^77.3.0:
-  version "77.3.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-77.3.0.tgz#dab629b5ce479e4de167e1ef3ac038cdce0963c5"
-  integrity sha512-ymEiiIV3TEjZZcSOrPYD1h7ihs0ETlb6MoksNOfovpYuFcJv+s/YyvoQKkM4OT8SYfPr3TLIV8EHGX00Z6iJDQ==
+cozy-ui@^77.4.0:
+  version "77.4.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-77.4.0.tgz#d73d4528303baa3885bfc229504f28243a4e1252"
+  integrity sha512-Q01XJwT5ZHPaKY17RApWiGdIDCJdwhDH23oUcIbc1uiZzTD43efOLdvh3oBJyyhSzoym+8OJkLjbmHXagndEog==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"


### PR DESCRIPTION
Les boutons d'actions sur mobile étaient aboluste en haut à droite, donc le contenu passait en-dessous, ce qui ne convenait pas.

On corrige également un mutate sur l'ordre de tri de la liste :facepalm:

Pas de changelog on n'apporte pas de différence par rapport à la version précédente de l'app