### PR TITLE
Make "of" part of the source identity

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -203,7 +203,7 @@
       "workTime_full": "Full time",
       "workTime_part": "Half-time or part-time",
       "workTimePercentage": "Percentage of working time",
-      "compare_progress": "Compare my progress with that of %{source}",
+      "compare_progress": "Compare my progress with that %{source}",
       "cancel": "Cancel",
       "submit": "Ok",
       "required": "This field is required"
@@ -232,7 +232,7 @@
           "percentage": "Percentage"
         },
         "comparison": {
-          "comparisonLegend": "It is possible to display the average progression of the members of %{source} who participate in the goal. To do so, you will be asked to also participate in the establishment of this average. Your progression data will be aggregated and sent anonymously, and will not contain any identifiers or locations.",
+          "comparisonLegend": "It is possible to display the average progression of the members %{source} who participate in the goal. To do so, you will be asked to also participate in the establishment of this average. Your progression data will be aggregated and sent anonymously, and will not contain any identifiers or locations.",
           "compare": "Compare my progression",
           "doNotCompare": "Do not compare my progression"
         }
@@ -248,10 +248,10 @@
       }
     },
     "employer": {
-      "my_company": "my company",
-      "your_company": "your company",
-      "my_collectivity": "my collectivity",
-      "your_collectivity": "your collectivity"
+      "my_company": "of my company",
+      "your_company": "of your company",
+      "my_collectivity": "of my collectivity",
+      "your_collectivity": "of your collectivity"
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -203,7 +203,7 @@
       "workTime_full": "Temps plein",
       "workTime_part": "Mi-temps ou temps partiel",
       "workTimePercentage": "Pourcentage du temps de travail",
-      "compare_progress": "Comparer ma progression avec celle de %{source}",
+      "compare_progress": "Comparer ma progression avec celle %{source}",
       "cancel": "Annuler",
       "submit": "Ok",
       "required": "Ce champ est obligatoire"
@@ -232,7 +232,7 @@
           "percentage": "Pourcentage"
         },
         "comparison": {
-          "comparisonLegend": "Il vous est possible d’afficher la progression moyenne des membres de %{source} qui participent à l’objectif. Pour cela, il vous sera demandé de participer également à la constitution de cette moyenne.\n\nVos données de progression seront agrégées et envoyées anonymement, elles ne contiendront aucun identifiant ni lieux.",
+          "comparisonLegend": "Il vous est possible d’afficher la progression moyenne des membres %{source} qui participent à l’objectif. Pour cela, il vous sera demandé de participer également à la constitution de cette moyenne.\n\nVos données de progression seront agrégées et envoyées anonymement, elles ne contiendront aucun identifiant ni lieux.",
           "compare": "Comparer ma progression",
           "doNotCompare": "Ne pas comparer ma progression"
         }
@@ -248,10 +248,10 @@
       }
     },
     "employer": {
-      "my_company": "mon entreprise",
-      "your_company": "votre entreprise",
-      "my_collectivity": "ma collectivité",
-      "your_collectivity": "votre collectivité"
+      "my_company": "de mon entreprise",
+      "your_company": "de votre entreprise",
+      "my_collectivity": "de ma collectivité",
+      "your_collectivity": "de votre collectivité"
     }
   }
 }


### PR DESCRIPTION
So it can be customized. This has the downside to not be localizable.

(changelog omitted)