### PR TITLE
Prevent dacc service from crashing when there is no settings document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.9.1
+
+## 🐛 Bug Fixes
+
+* Prevent dacc service from crashing when there is no settings document
+
 # 0.9.0
 
 ## ✨ Features

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -3,7 +3,7 @@
   "slug": "coachco2",
   "icon": "icon.svg",
   "categories": [],
-  "version": "0.9.0",
+  "version": "0.9.1",
   "licence": "AGPL-3.0",
   "editor": "Cozy Cloud",
   "source": "https://github.com/cozy/coachCO2.git@build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coachco2",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "scripts": {
     "analyze": "COZY_SCRIPTS_ANALYZER=true yarn build",
     "lint": "yarn lint:js && yarn lint:styles",

--- a/src/lib/dacc.js
+++ b/src/lib/dacc.js
@@ -199,7 +199,7 @@ export const sendMeasuresForAccount = async (client, account) => {
  */
 export const runDACCService = async client => {
   const settings = await client.queryAll(buildSettingsQuery().definition)
-  if (!settings || !settings[0].allowSendDataToDacc) {
+  if (!settings?.[0]?.allowSendDataToDacc) {
     log('info', 'The user did not give consent to send data to DACC')
     return false
   }


### PR DESCRIPTION
This is basically a backport of a fix that was in 365a34b82f19e035b58449eb1ee2d6de358fc6ea.
```
### 🐛 Bug Fixes

* Prevent dacc service from crashing when there is no settings document
```
