### PR TITLE
Use SendToDACC bike goal option to show proper info

### DIFF
--- a/src/components/Goals/BikeGoal/BikeGoalAchievement.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAchievement.jsx
@@ -1,11 +1,8 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
-import {
-  getDaysToReach,
-  isGoalCompleted,
-  countDaysOrDaysToReach
-} from 'src/components/Goals/BikeGoal/helpers'
+import BikeGoalSummaryYearlyItem from 'src/components/Goals/BikeGoal/BikeGoalSummaryYearlyItem'
+import { isGoalCompleted } from 'src/components/Goals/BikeGoal/helpers'
 
 import Chip from 'cozy-ui/transpiled/react/Chips'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -26,17 +23,10 @@ const BikeGoalAchievement = ({ className, timeseries }) => {
   return (
     <div className={className}>
       {isMobile && <Typography variant="h3">{t('bikeGoal.title')}</Typography>}
-      <Typography
+      <BikeGoalSummaryYearlyItem
         className="u-mt-half"
-        style={{
-          color: isGoalCompleted(timeseries) && 'var(--successColor)'
-        }}
-      >
-        {t('bikeGoal.goal_progression', {
-          days: countDaysOrDaysToReach(timeseries),
-          daysToReach: getDaysToReach()
-        })}
-      </Typography>
+        timeseriesByYear={timeseries}
+      />
       {isGoalCompleted(timeseries) && (
         <div className="u-mt-1">
           <Chip

--- a/src/components/Goals/BikeGoal/BikeGoalAchievement.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAchievement.jsx
@@ -1,6 +1,8 @@
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
+import BikeGoalSummaryDaccItems from 'src/components/Goals/BikeGoal/BikeGoalSummaryDaccItems'
 import BikeGoalSummaryYearlyItem from 'src/components/Goals/BikeGoal/BikeGoalSummaryYearlyItem'
 import { isGoalCompleted } from 'src/components/Goals/BikeGoal/helpers'
 
@@ -11,7 +13,13 @@ import FileOutlineIcon from 'cozy-ui/transpiled/react/Icons/FileOutline'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
-const BikeGoalAchievement = ({ className, timeseries }) => {
+const style = {
+  BikeGoalSummaryItem: {
+    flex: '1 1 0'
+  }
+}
+
+const BikeGoalAchievement = ({ className, timeseries, sendToDACC }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const navigate = useNavigate()
@@ -22,11 +30,24 @@ const BikeGoalAchievement = ({ className, timeseries }) => {
 
   return (
     <div className={className}>
-      {isMobile && <Typography variant="h3">{t('bikeGoal.title')}</Typography>}
-      <BikeGoalSummaryYearlyItem
-        className="u-mt-half"
-        timeseriesByYear={timeseries}
-      />
+      {isMobile && (
+        <Typography className="u-mb-half" variant="h3">
+          {t('bikeGoal.title')}
+        </Typography>
+      )}
+      {sendToDACC ? (
+        <BikeGoalSummaryDaccItems
+          className={cx('u-mt-half', { 'u-ph-1 u-ta-center': isMobile })}
+          timeseries={timeseries}
+          body1={isMobile}
+          componentsProps={{ BikeGoalSummaryItem: style.BikeGoalSummaryItem }}
+        />
+      ) : (
+        <BikeGoalSummaryYearlyItem
+          className="u-mt-half"
+          timeseriesByYear={timeseries}
+        />
+      )}
       {isGoalCompleted(timeseries) && (
         <div className="u-mt-1">
           <Chip

--- a/src/components/Goals/BikeGoal/BikeGoalChart.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalChart.jsx
@@ -2,13 +2,14 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import {
   makeGoalAchievementPercentage,
-  makeIconSize
+  makeIconSize,
+  makeDaccAchievementPercentage
 } from 'src/components/Goals/BikeGoal/helpers'
 
 import Box from 'cozy-ui/transpiled/react/Box'
 import CircularChart from 'cozy-ui/transpiled/react/CircularChart'
 
-const BikeGoalChart = ({ timeseries, size, ...props }) => {
+const BikeGoalChart = ({ timeseries, sendToDACC, size, ...props }) => {
   const goalAchievementPercentage = makeGoalAchievementPercentage(timeseries)
   const iconSize = makeIconSize(size)
 
@@ -16,6 +17,12 @@ const BikeGoalChart = ({ timeseries, size, ...props }) => {
     <CircularChart
       size={size}
       primaryProps={{ value: goalAchievementPercentage, color: '#BA5AE8' }}
+      {...(sendToDACC && {
+        secondaryProps: {
+          value: makeDaccAchievementPercentage(),
+          color: '#BA5AE83D'
+        }
+      })}
       {...props}
     >
       <Box fontSize={iconSize}>🚴</Box>

--- a/src/components/Goals/BikeGoal/BikeGoalDaccSwitcher.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalDaccSwitcher.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import useSettings from 'src/hooks/useSettings'
+
+import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Switch from 'cozy-ui/transpiled/react/Switch'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import { makeStyles } from 'cozy-ui/transpiled/react/styles'
+
+const useStyles = makeStyles(() => ({
+  root: {
+    marginLeft: 0
+  },
+  labelPlacementStart: {
+    display: 'flex',
+    justifyContent: 'space-between'
+  }
+}))
+
+const BikeGoalDaccSwitcher = ({ className }) => {
+  const { t } = useI18n()
+  const { isMobile } = useBreakpoints()
+  const classes = useStyles()
+
+  const { isLoading, value, save } = useSettings('bikeGoal.sendToDACC')
+
+  const handleChange = ev => {
+    save(ev.target.checked)
+  }
+
+  return (
+    <div className={className}>
+      <FormControlLabel
+        classes={classes}
+        label={
+          <Typography style={{ color: 'var(--infoColor)' }}>
+            {t('bikeGoal.settings.sendToDACC')}
+          </Typography>
+        }
+        labelPlacement={isMobile ? 'start' : 'end'}
+        checked={!!value}
+        disabled={isLoading}
+        onChange={handleChange}
+        control={<Switch color="primary" />}
+      />
+    </div>
+  )
+}
+
+export default BikeGoalDaccSwitcher

--- a/src/components/Goals/BikeGoal/BikeGoalDialogMobile.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalDialogMobile.jsx
@@ -9,7 +9,11 @@ import { filterTimeseriesByYear } from 'src/lib/timeseries'
 
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 
-const BikeGoalDialogMobile = ({ timeseries, timeseriesQueryLeft }) => {
+const BikeGoalDialogMobile = ({
+  timeseries,
+  timeseriesQueryLeft,
+  sendToDACC
+}) => {
   const navigate = useNavigate()
   const { year } = useParams()
 
@@ -33,10 +37,12 @@ const BikeGoalDialogMobile = ({ timeseries, timeseriesQueryLeft }) => {
             paddingTop="1.5rem"
             marginTop="3rem"
             timeseries={timeseriesByYear}
+            sendToDACC={sendToDACC}
           />
           <BikeGoalAchievement
             className="u-flex u-flex-column u-flex-items-center"
             timeseries={timeseriesByYear}
+            sendToDACC={sendToDACC}
           />
           <BikeGoalList
             className="u-mt-2"

--- a/src/components/Goals/BikeGoal/BikeGoalSummary.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalSummary.jsx
@@ -1,11 +1,7 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import BikeGoalChart from 'src/components/Goals/BikeGoal/BikeGoalChart'
-import {
-  getDaysToReach,
-  isGoalCompleted,
-  countDaysOrDaysToReach
-} from 'src/components/Goals/BikeGoal/helpers'
+import BikeGoalSummaryYearlyItem from 'src/components/Goals/BikeGoal/BikeGoalSummaryYearlyItem'
 import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import { filterTimeseriesByYear } from 'src/lib/timeseries'
 import { buildBikeCommuteTimeseriesQueryByAccountId } from 'src/queries/queries'
@@ -15,6 +11,11 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Paper from 'cozy-ui/transpiled/react/Paper'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+
+const style = {
+  paper: { gap: '1rem' },
+  div: { height: 65 }
+}
 
 const BikeGoalSummary = () => {
   const { t } = useI18n()
@@ -53,29 +54,20 @@ const BikeGoalSummary = () => {
     <>
       <Paper
         elevation={2}
-        className="u-flex u-flex-items-center u-mh-1-s u-mh-2 u-mb-1 u-flex-items-start u-c-pointer"
+        className="u-flex u-flex-items-start-s u-flex-items-center u-mh-1-s u-mh-2 u-mb-1 u-p-1 u-c-pointer"
+        style={style.paper}
         onClick={() => navigate(`/bikegoal/${currentYear}/trips`)}
       >
-        <BikeGoalChart
-          timeseries={timeseriesByYear}
-          paddingTop="1rem"
-          paddingLeft="1.5rem"
-          size="small"
-        />
-        <div className="u-ml-1">
+        <div style={style.div}>
+          <BikeGoalChart timeseries={timeseriesByYear} size="small" />
+        </div>
+        <div>
           <Typography variant="h6">{t('bikeGoal.title')}</Typography>
-          <Typography
+          <BikeGoalSummaryYearlyItem
+            timeseriesByYear={timeseriesByYear}
             variant="caption"
-            style={{
-              whiteSpace: 'pre-line',
-              color: isGoalCompleted(timeseriesByYear) && 'var(--successColor)'
-            }}
-          >
-            {t('bikeGoal.goal_progression', {
-              days: countDaysOrDaysToReach(timeseriesByYear),
-              daysToReach: getDaysToReach()
-            })}
-          </Typography>
+            preLine
+          />
         </div>
       </Paper>
     </>

--- a/src/components/Goals/BikeGoal/BikeGoalSummary.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalSummary.jsx
@@ -1,12 +1,16 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import BikeGoalChart from 'src/components/Goals/BikeGoal/BikeGoalChart'
+import BikeGoalSummaryDaccItems from 'src/components/Goals/BikeGoal/BikeGoalSummaryDaccItems'
 import BikeGoalSummaryYearlyItem from 'src/components/Goals/BikeGoal/BikeGoalSummaryYearlyItem'
 import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import { filterTimeseriesByYear } from 'src/lib/timeseries'
-import { buildBikeCommuteTimeseriesQueryByAccountId } from 'src/queries/queries'
+import {
+  buildBikeCommuteTimeseriesQueryByAccountId,
+  buildSettingsQuery
+} from 'src/queries/queries'
 
-import { isQueryLoading, useQueryAll } from 'cozy-client'
+import { isQueryLoading, useQueryAll, useQuery } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Paper from 'cozy-ui/transpiled/react/Paper'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
@@ -22,6 +26,13 @@ const BikeGoalSummary = () => {
   const navigate = useNavigate()
   const { account, isAccountLoading } = useAccountContext()
 
+  const settingsQuery = buildSettingsQuery()
+  const { data: settings, ...settingsQueryLeft } = useQuery(
+    settingsQuery.definition,
+    settingsQuery.options
+  )
+  const isSettingsLoading = isQueryLoading(settingsQueryLeft)
+
   const timeseriesQuery = buildBikeCommuteTimeseriesQueryByAccountId(
     { accountId: account?._id },
     Boolean(account)
@@ -34,7 +45,8 @@ const BikeGoalSummary = () => {
   const isLoadingTimeseriesQuery =
     isQueryLoading(timeseriesQueryLeft) || timeseriesQueryLeft.hasMore
 
-  const isLoading = isAccountLoading || isLoadingTimeseriesQuery
+  const isLoading =
+    isAccountLoading || isLoadingTimeseriesQuery || isSettingsLoading
 
   if (isLoading) {
     return (
@@ -49,6 +61,7 @@ const BikeGoalSummary = () => {
 
   const currentYear = new Date().getFullYear().toString()
   const timeseriesByYear = filterTimeseriesByYear(timeseries, currentYear)
+  const sendToDACC = !!settings?.[0].bikeGoal?.sendToDACC
 
   return (
     <>
@@ -59,15 +72,23 @@ const BikeGoalSummary = () => {
         onClick={() => navigate(`/bikegoal/${currentYear}/trips`)}
       >
         <div style={style.div}>
-          <BikeGoalChart timeseries={timeseriesByYear} size="small" />
+          <BikeGoalChart
+            timeseries={timeseriesByYear}
+            sendToDACC={sendToDACC}
+            size="small"
+          />
         </div>
         <div>
           <Typography variant="h6">{t('bikeGoal.title')}</Typography>
-          <BikeGoalSummaryYearlyItem
-            timeseriesByYear={timeseriesByYear}
-            variant="caption"
-            preLine
-          />
+          {sendToDACC ? (
+            <BikeGoalSummaryDaccItems timeseries={timeseriesByYear} />
+          ) : (
+            <BikeGoalSummaryYearlyItem
+              timeseriesByYear={timeseriesByYear}
+              variant="caption"
+              preLine
+            />
+          )}
         </div>
       </Paper>
     </>

--- a/src/components/Goals/BikeGoal/BikeGoalSummaryDaccItems.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalSummaryDaccItems.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import BikeGoalSummaryItem from 'src/components/Goals/BikeGoal/BikeGoalSummaryItem'
+import {
+  countDaysOrDaysToReach,
+  isGoalCompleted,
+  getDaccAverageDays
+} from 'src/components/Goals/BikeGoal/helpers'
+
+import Divider from 'cozy-ui/transpiled/react/Divider'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+const BikeGoalSummaryDaccItems = ({
+  className,
+  timeseries,
+  body1,
+  componentsProps
+}) => {
+  const { t } = useI18n()
+
+  return (
+    <div className={`u-flex ${className}`}>
+      <BikeGoalSummaryItem
+        {...componentsProps.BikeGoalSummaryItem}
+        days={countDaysOrDaysToReach(timeseries)}
+        label={t('bikeGoal.my_progression')}
+        isSuccess={isGoalCompleted(timeseries)}
+        body1={body1}
+      />
+      <Divider
+        className="u-mh-1"
+        style={{ marginTop: 4 }}
+        orientation="vertical"
+        flexItem
+      />
+      <BikeGoalSummaryItem
+        {...componentsProps.BikeGoalSummaryItem}
+        days={getDaccAverageDays()}
+        label={t('bikeGoal.average_progression')}
+        color="#BA5AE83D"
+        body1={body1}
+      />
+    </div>
+  )
+}
+
+BikeGoalSummaryDaccItems.defaultProps = {
+  className: '',
+  componentsProps: {}
+}
+
+export default BikeGoalSummaryDaccItems

--- a/src/components/Goals/BikeGoal/BikeGoalSummaryItem.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalSummaryItem.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { getDaysToReach } from 'src/components/Goals/BikeGoal/helpers'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import CircleFilledIcon from 'cozy-ui/transpiled/react/Icons/CircleFilled'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+const createStyle = isSuccess => ({
+  color: isSuccess && 'var(--successColor)'
+})
+
+const BikeGoalSummaryItem = ({
+  days,
+  label,
+  color,
+  isSuccess,
+  body1,
+  ...props
+}) => {
+  const { t } = useI18n()
+
+  return (
+    <div {...props}>
+      <Icon
+        className="u-mr-half"
+        icon={CircleFilledIcon}
+        color={color}
+        size={8}
+      />
+      <Typography
+        display="inline"
+        variant={body1 ? 'body1' : 'caption'}
+        color="textPrimary"
+        style={createStyle(isSuccess)}
+      >
+        {t('bikeGoal.goal_progression', {
+          days,
+          daysToReach: getDaysToReach()
+        })}
+      </Typography>
+      <Typography variant="caption" style={createStyle(isSuccess)}>
+        {label}
+      </Typography>
+    </div>
+  )
+}
+
+BikeGoalSummaryItem.defaultProps = {
+  color: '#BA5AE8'
+}
+
+export default BikeGoalSummaryItem

--- a/src/components/Goals/BikeGoal/BikeGoalSummaryYearlyItem.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalSummaryYearlyItem.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import {
+  getDaysToReach,
+  isGoalCompleted,
+  countDaysOrDaysToReach
+} from 'src/components/Goals/BikeGoal/helpers'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+const createStyle = ({ timeseriesByYear, preLine }) => ({
+  whiteSpace: preLine && 'pre-line',
+  color: isGoalCompleted(timeseriesByYear) && 'var(--successColor)'
+})
+
+const BikeGoalSummaryYearlyItem = ({
+  className,
+  timeseriesByYear,
+  variant,
+  preLine
+}) => {
+  const { t } = useI18n()
+
+  return (
+    <Typography
+      className={className}
+      variant={variant}
+      style={createStyle({ timeseriesByYear, preLine })}
+    >
+      {t('bikeGoal.yearly_goal_progression', {
+        days: countDaysOrDaysToReach(timeseriesByYear),
+        daysToReach: getDaysToReach()
+      })}
+    </Typography>
+  )
+}
+
+export default BikeGoalSummaryYearlyItem

--- a/src/components/Goals/BikeGoal/BikeGoalViewDesktop.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalViewDesktop.jsx
@@ -10,7 +10,11 @@ import { filterTimeseriesByYear } from 'src/lib/timeseries'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
-const BikeGoalViewDesktop = ({ timeseries, timeseriesQueryLeft }) => {
+const BikeGoalViewDesktop = ({
+  timeseries,
+  timeseriesQueryLeft,
+  sendToDACC
+}) => {
   const { t } = useI18n()
   const navigate = useNavigate()
   const { year } = useParams()
@@ -21,7 +25,12 @@ const BikeGoalViewDesktop = ({ timeseries, timeseriesQueryLeft }) => {
     <>
       <Titlebar
         label={t('bikeGoal.title')}
-        subtitle={<BikeGoalAchievement timeseries={timeseriesByYear} />}
+        subtitle={
+          <BikeGoalAchievement
+            timeseries={timeseriesByYear}
+            sendToDACC={sendToDACC}
+          />
+        }
         onBack={() => navigate('/trips')}
       />
       <BikeGoalActions timeseries={timeseries} />
@@ -31,6 +40,7 @@ const BikeGoalViewDesktop = ({ timeseries, timeseriesQueryLeft }) => {
         top="2rem"
         right="2rem"
         timeseries={timeseriesByYear}
+        sendToDACC={sendToDACC}
       />
       <BikeGoalList
         className="u-mt-3"

--- a/src/components/Goals/BikeGoal/helpers.js
+++ b/src/components/Goals/BikeGoal/helpers.js
@@ -77,3 +77,12 @@ export const makeIconSize = size => {
 
 // TODO: right function should be create by @paultranvan soon
 export const getDaccAverageDays = () => 0.5
+
+export const makeDaccAchievementPercentage = () => {
+  const daccAverageDays = getDaccAverageDays()
+  const daysToReach = getDaysToReach()
+  const daysToUse =
+    daccAverageDays > daysToReach ? daysToReach : daccAverageDays
+
+  return Math.round((daysToUse / daysToReach) * 100)
+}

--- a/src/components/Goals/BikeGoal/helpers.js
+++ b/src/components/Goals/BikeGoal/helpers.js
@@ -74,3 +74,6 @@ export const makeIconSize = size => {
       return '4.5rem'
   }
 }
+
+// TODO: right function should be create by @paultranvan soon
+export const getDaccAverageDays = () => 0.5

--- a/src/components/Views/BikeGoal.jsx
+++ b/src/components/Views/BikeGoal.jsx
@@ -3,14 +3,24 @@ import BikeGoalDialogMobile from 'src/components/Goals/BikeGoal/BikeGoalDialogMo
 import BikeGoalViewDesktop from 'src/components/Goals/BikeGoal/BikeGoalViewDesktop'
 import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import SpinnerOrEmptyContent from 'src/components/SpinnerOrEmptyContent'
-import { buildBikeCommuteTimeseriesQueryByAccountId } from 'src/queries/queries'
+import {
+  buildBikeCommuteTimeseriesQueryByAccountId,
+  buildSettingsQuery
+} from 'src/queries/queries'
 
-import { isQueryLoading, useQueryAll } from 'cozy-client'
+import { isQueryLoading, useQueryAll, useQuery } from 'cozy-client'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 const Bikegoal = () => {
   const { account, isAccountLoading } = useAccountContext()
   const { isMobile } = useBreakpoints()
+
+  const settingsQuery = buildSettingsQuery()
+  const { data: settings, ...settingsQueryLeft } = useQuery(
+    settingsQuery.definition,
+    settingsQuery.options
+  )
+  const isSettingsLoading = isQueryLoading(settingsQueryLeft)
 
   const timeseriesQuery = buildBikeCommuteTimeseriesQueryByAccountId(
     { accountId: account?._id },
@@ -25,6 +35,7 @@ const Bikegoal = () => {
     isQueryLoading(timeseriesQueryLeft) || timeseriesQueryLeft.hasMore
 
   const isLoadingOrEmpty =
+    isSettingsLoading ||
     isAccountLoading ||
     !account ||
     isLoadingTimeseriesQuery ||
@@ -41,11 +52,14 @@ const Bikegoal = () => {
     )
   }
 
+  const sendToDACC = !!settings?.[0].bikeGoal?.sendToDACC
+
   if (isMobile) {
     return (
       <BikeGoalDialogMobile
         timeseries={timeseries}
         timeseriesQueryLeft={timeseriesQueryLeft}
+        sendToDACC={sendToDACC}
       />
     )
   }
@@ -54,6 +68,7 @@ const Bikegoal = () => {
     <BikeGoalViewDesktop
       timeseries={timeseries}
       timeseriesQueryLeft={timeseriesQueryLeft}
+      sendToDACC={sendToDACC}
     />
   )
 }

--- a/src/components/Views/Settings.jsx
+++ b/src/components/Views/Settings.jsx
@@ -6,6 +6,7 @@ import CO2EmissionDaccSwitcher from 'src/components/CO2EmissionDaccSwitcher'
 import CsvExporter from 'src/components/ExportCSV/CsvExporter'
 import BikeGoalAlertSuccessSwitcher from 'src/components/Goals/BikeGoal/BikeGoalAlertSuccessSwitcher'
 import BikeGoalAlertSwitcher from 'src/components/Goals/BikeGoal/BikeGoalAlertSwitcher'
+import BikeGoalDaccSwitcher from 'src/components/Goals/BikeGoal/BikeGoalDaccSwitcher'
 import BikeGoalOnboardedSwitcher from 'src/components/Goals/BikeGoal/BikeGoalOnboardedSwitcher'
 import BikeGoalSwitcher from 'src/components/Goals/BikeGoal/BikeGoalSwitcher'
 import {
@@ -55,6 +56,7 @@ export const Settings = () => {
                   <BikeGoalAlertSwitcher className="u-mt-1-half-s" />
                   <BikeGoalOnboardedSwitcher className="u-mt-1-half-s" />
                   <BikeGoalAlertSuccessSwitcher className="u-mt-1-half-s" />
+                  <BikeGoalDaccSwitcher className="u-mt-1-half-s" />
                 </>
               )}
             </>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -158,7 +158,10 @@
   },
   "bikeGoal": {
     "title": "Bike to work",
-    "goal_progression": "%{days}/%{daysToReach} days \nper year",
+    "yearly_goal_progression": "%{days}/%{daysToReach} days \nper year",
+    "goal_progression": "%{days}/%{daysToReach} days",
+    "my_progression": "My yearly progrsesion",
+    "average_progression": "Average group progression",
     "achievement_certificate": "Certificate of achievement",
     "goals": "Objectives",
     "about": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -214,9 +214,10 @@
     },
     "settings": {
       "participation": "Participate to the goal “Bike to work”",
-      "showAlerter": "Show bike goals alerter",
-      "hideOnboarding": "Hide bike goal onboarding",
-      "showAlerterSuccess": "Show the bike goal success alert"
+      "showAlerter": "Bike goal: Show bike goals alerter",
+      "hideOnboarding": "Bike goal: Hide bike goal onboarding",
+      "sendToDACC": "Bike goal: activate DACC",
+      "showAlerterSuccess": "Bike goal: Show the bike goal success alert"
     },
     "onboarding": {
       "title": "\"Sustainable mobility\" package",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -216,6 +216,7 @@
       "participation": "Participer à l'objectif “Aller au travail à vélo”",
       "showAlerter": "Objectif vélo : afficher l'alerter sur la homepage",
       "hideOnboarding": "Objectif vélo : masquer l'onboarding",
+      "sendToDACC": "Objectif vélo : activer le DACC",
       "showAlerterSuccess": "Objectif vélo : forcer l'affichage de l'alerte de succès sur la homepage"
     },
     "onboarding": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -158,7 +158,10 @@
   },
   "bikeGoal": {
     "title": "Aller au travail à vélo",
-    "goal_progression": "%{days}/%{daysToReach} jours \npar an",
+    "yearly_goal_progression": "%{days}/%{daysToReach} jours \npar an",
+    "goal_progression": "%{days}/%{daysToReach} jours",
+    "my_progression": "Ma progression annuelle",
+    "average_progression": "Progression moyenne du groupe",
     "achievement_certificate": "Attestation de réussite",
     "goals": "Objectifs",
     "about": {


### PR DESCRIPTION
Lorsque le DACC est activé pour l'objectif vélo, au même titre que pour les émissions CO², on affiche maintenant les valeurs du DACC dans les grapiques et cartouche d'information.

note: la partie récupération des datas du DACC ne sont pas encore en place, un mock est utilisé. A savoir que toute la feature FMD (bike goal) est derrière un flag



```
### ✨ Features

* Add bike goal dacc switcher for admin mode
* Use SendToDACC bike goal option to show proper info and charts

```