### PR TITLE
fix: Handle all modes from openpath

### DIFF
--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -7,6 +7,9 @@ import {
   SUBWAY_MODE,
   TRAIN_MODE,
   WALKING_MODE,
+  RUNNING_MODE,
+  ON_FOOT_MODE,
+  IN_VEHICLE_MODE,
   UNKNOWN_MODE,
   COMMUTE_PURPOSE,
   WORK_PURPOSE,
@@ -84,6 +87,7 @@ export const modes = [
   BUS_MODE,
   CAR_ELECTRIC_MODE,
   CAR_MODE,
+  IN_VEHICLE_MODE,
   CARPOOL_ELECTRIC_MODE,
   CARPOOL_MODE,
   MOTO_INF_250_MODE,
@@ -92,8 +96,10 @@ export const modes = [
   MOPED_MODE,
   SUBWAY_MODE,
   TRAIN_MODE,
-  UNKNOWN_MODE,
-  WALKING_MODE
+  WALKING_MODE,
+  ON_FOOT_MODE,
+  RUNNING_MODE,
+  UNKNOWN_MODE
 ]
 
 export const pickModeIcon = mode => {
@@ -106,13 +112,14 @@ export const pickModeIcon = mode => {
       return BikeIcon
     case BUS_ELECTRIC_MODE:
       return BusIcon
+    case CAR_MODE:
+    case IN_VEHICLE_MODE:
+      return CarIcon
     case BUS_MODE:
       return BusIcon
     case CAR_ELECTRIC_MODE:
     case CARPOOL_ELECTRIC_MODE:
       return ElectricCarIcon
-    case CAR_MODE:
-      return CarIcon
     case CARPOOL_MODE:
       return CarpoolingIcon
     case MOTO_INF_250_MODE:
@@ -126,10 +133,12 @@ export const pickModeIcon = mode => {
       return SubwayIcon
     case TRAIN_MODE:
       return TrainIcon
+    case WALKING_MODE:
+    case ON_FOOT_MODE:
+    case RUNNING_MODE:
+      return WalkIcon
     case UNKNOWN_MODE:
       return UnknownIcon
-    case WALKING_MODE:
-      return WalkIcon
     default:
       log('info', `Unknown mode ${mode}`, 'pickModeIcon')
       return pickModeIcon(UNKNOWN_MODE)
@@ -153,6 +162,7 @@ export const modeToColor = mode => {
     case CAR_ELECTRIC_MODE:
       return '#FC881C'
     case CAR_MODE:
+    case IN_VEHICLE_MODE:
       return '#FF7B5E'
     case CARPOOL_ELECTRIC_MODE:
       return '#80A5E1'
@@ -171,6 +181,8 @@ export const modeToColor = mode => {
     case UNKNOWN_MODE:
       return '#A4A7AC'
     case WALKING_MODE:
+    case ON_FOOT_MODE:
+    case RUNNING_MODE:
       return '#21B930'
     default:
       log('info', `Unknown mode ${mode}`, 'modeToColor')
@@ -271,6 +283,7 @@ export const getAverageCO2PerKmByMode = mode => {
     case CAR_ELECTRIC_MODE:
       return CAR_ELECTRIC_CO2_KG_PER_KM
     case CAR_MODE:
+    case IN_VEHICLE_MODE:
       return CAR_AVERAGE_CO2_KG_PER_KM
     case CARPOOL_ELECTRIC_MODE:
       return CARPOOL_ELECTRIC_CO2_KG_PER_KM
@@ -291,6 +304,8 @@ export const getAverageCO2PerKmByMode = mode => {
     case UNKNOWN_MODE:
       return UNKNOWN_AVERAGE_CO2_KG_PER_KM
     case WALKING_MODE:
+    case ON_FOOT_MODE:
+    case RUNNING_MODE:
       return WALKING_AVERAGE_CO2_KG_PER_KM
     default:
       return UNKNOWN_AVERAGE_CO2_KG_PER_KM
@@ -325,6 +340,8 @@ export const modeToCategory = mode => {
   switch (mode) {
     case AIR_MODE:
     case WALKING_MODE:
+    case ON_FOOT_MODE:
+    case RUNNING_MODE:
     case UNKNOWN_MODE:
       return null
     case BICYCLING_ELECTRIC_MODE:
@@ -338,6 +355,7 @@ export const modeToCategory = mode => {
       return PUBLIC_TRANSPORT_CATEGORY.name
     case CAR_ELECTRIC_MODE:
     case CAR_MODE:
+    case IN_VEHICLE_MODE:
     case CARPOOL_ELECTRIC_MODE:
     case CARPOOL_MODE:
       return CAR_CATEGORY.name

--- a/src/components/helpers.spec.js
+++ b/src/components/helpers.spec.js
@@ -11,6 +11,7 @@ describe('getAverageCO2PerKmByMode', () => {
       0.13733, // BUS_MODE
       0.0198, // CAR_ELECTRIC_MODE
       0.192, // CAR_MODE
+      0.192, // IN_VEHICLE_MODE,
       0.0099, // CARPOOL_ELECTRIC_MODE
       0.096, // CARPOOL_MODE
       0.0604, // MOTO_INF_250_MODE
@@ -20,7 +21,9 @@ describe('getAverageCO2PerKmByMode', () => {
       0.0033, // SUBWAY_MODE
       0.01061, // TRAIN_MODE
       0, // UNKNOWN_MODE
-      0 // WALKING_MODE
+      0, // WALKING_MODE
+      0, // ON_FOOT_MODE
+      0 // RUNNING_MODE
     ]
 
     expect(res).toEqual(expected)
@@ -38,6 +41,7 @@ describe('modeToCO2PerKm', () => {
       137, // BUS_MODE
       20, // CAR_ELECTRIC_MODE
       192, // CAR_MODE
+      192, // IN_VEHICLE_MODE
       10, // CARPOOL_ELECTRIC_MODE
       96, // CARPOOL_MODE
       60, // MOTO_INF_250_MODE
@@ -47,7 +51,9 @@ describe('modeToCO2PerKm', () => {
       3, // SUBWAY_MODE
       11, // TRAIN_MODE
       0, // UNKNOWN_MODE
-      0 // WALKING_MODE
+      0, // WALKING_MODE
+      0, // ON_FOOT_MODE
+      0 // RUNNING_MODE
     ]
 
     expect(res).toEqual(expected)

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,6 +18,11 @@ export const TRAIN_MODE = 'TRAIN'
 export const UNKNOWN_MODE = 'UNKNOWN'
 export const WALKING_MODE = 'WALKING'
 
+// Additional modes, see https://github.com/e-mission/e-mission-server/blob/gis-based-mode-detection/emission/core/wrapper/motionactivity.py
+export const IN_VEHICLE_MODE = 'IN_VEHICLE'
+export const ON_FOOT_MODE = 'ON_FOOT'
+export const RUNNING_MODE = 'RUNNING'
+
 export const BICYCLING_CATEGORY = {
   name: 'BICYCLING_CATEGORY',
   modes: [BICYCLING_MODE, BICYCLING_ELECTRIC_MODE, SCOOTER_ELECTRIC_MODE]
@@ -28,7 +33,13 @@ export const MOTO_CATEGORY = {
 }
 export const CAR_CATEGORY = {
   name: 'CAR_CATEGORY',
-  modes: [CAR_MODE, CAR_ELECTRIC_MODE, CARPOOL_MODE, CARPOOL_ELECTRIC_MODE]
+  modes: [
+    CAR_MODE,
+    IN_VEHICLE_MODE,
+    CAR_ELECTRIC_MODE,
+    CARPOOL_MODE,
+    CARPOOL_ELECTRIC_MODE
+  ]
 }
 export const PUBLIC_TRANSPORT_CATEGORY = {
   name: 'PUBLIC_TRANSPORT_CATEGORY',

--- a/src/lib/metrics.js
+++ b/src/lib/metrics.js
@@ -47,9 +47,12 @@ import {
   SUBWAY_MODE,
   TRAIN_MODE,
   UNKNOWN_AVERAGE_CO2_KG_PER_KM,
+  IN_VEHICLE_MODE,
   UNKNOWN_MODE,
   WALKING_AVERAGE_CO2_KG_PER_KM,
-  WALKING_MODE
+  WALKING_MODE,
+  ON_FOOT_MODE,
+  RUNNING_MODE
 } from 'src/constants'
 
 /**
@@ -89,6 +92,7 @@ export const computeCO2Section = section => {
       totalCO2 += distance * CAR_ELECTRIC_CO2_KG_PER_KM
       break
     case CAR_MODE:
+    case IN_VEHICLE_MODE:
       // TODO: should depends on the energy type + number of passengers
       totalCO2 += distance * CAR_AVERAGE_CO2_KG_PER_KM
       break
@@ -120,6 +124,8 @@ export const computeCO2Section = section => {
       totalCO2 += distance * UNKNOWN_AVERAGE_CO2_KG_PER_KM
       break
     case WALKING_MODE:
+    case RUNNING_MODE:
+    case ON_FOOT_MODE:
       totalCO2 += distance * WALKING_AVERAGE_CO2_KG_PER_KM
       break
     default:
@@ -151,6 +157,8 @@ export const computeCaloriesSection = section => {
   let MET
   switch (section.mode) {
     case WALKING_MODE:
+    case ON_FOOT_MODE:
+    case RUNNING_MODE:
       if (speed <= SLOW_WALKING_MAX_SPEED) {
         MET = MET_WALKING_SLOW
       } else if (speed <= MEDIUM_WALKING_MAX_SPEED) {

--- a/src/lib/timeseries.spec.js
+++ b/src/lib/timeseries.spec.js
@@ -323,6 +323,10 @@ describe('Aggregation', () => {
           timeseries: expect.any(Array),
           totalCO2: expect.any(Number)
         },
+        IN_VEHICLE: {
+          timeseries: expect.any(Array),
+          totalCO2: expect.any(Number)
+        },
         CARPOOL: {
           timeseries: expect.any(Array),
           totalCO2: expect.any(Number)
@@ -347,7 +351,15 @@ describe('Aggregation', () => {
           timeseries: expect.any(Array),
           totalCO2: expect.any(Number)
         },
+        ON_FOOT: {
+          timeseries: expect.any(Array),
+          totalCO2: expect.any(Number)
+        },
         SCOOTER_ELECTRIC: {
+          timeseries: expect.any(Array),
+          totalCO2: expect.any(Number)
+        },
+        RUNNING: {
           timeseries: expect.any(Array),
           totalCO2: expect.any(Number)
         },

--- a/src/lib/trips.js
+++ b/src/lib/trips.js
@@ -47,7 +47,9 @@ export const getFeatureMode = (feature, appSetting) => {
     mode => defaultTransportModeByGroup?.[modeToCategory(mode)] === mode
   )
 
-  const sensedMode = sensedOriginalMode.split('PREDICTEDMODETYPES.')[1]
+  const sensedMode =
+    sensedOriginalMode.split('PREDICTEDMODETYPES.')[1] ||
+    sensedOriginalMode.split('MOTIONTYPES.')[1]
   const isSupportedSensedMode = modes.includes(sensedMode)
 
   return (

--- a/src/lib/trips.spec.js
+++ b/src/lib/trips.spec.js
@@ -149,4 +149,22 @@ describe('getFeatureMode', () => {
 
     expect(result).toBe('UNKNOWN')
   })
+
+  it('should return the sensed mode for both prefix', () => {
+    let result = getFeatureMode({
+      properties: {
+        sensed_mode: 'PredictedModeTypes.CAR'
+      }
+    })
+
+    expect(result).toBe('CAR')
+
+    result = getFeatureMode({
+      properties: {
+        sensed_mode: 'MotionTypes.IN_VEHICLE'
+      }
+    })
+
+    expect(result).toBe('IN_VEHICLE')
+  })
 })


### PR DESCRIPTION
In some cases, it happens that openpath computes a Depending on the motion detection, openpath has a different set of modes:
https://github.com/e-mission/e-mission-server/blob/gis-based-mode-detection/emission/core/wrapper/motionactivity.py#L12 vs
https://github.com/e-mission/e-mission-server/blob/gis-based-mode-detection/emission/core/wrapper/modeprediction.py#L17

The fist one was not supported, causing unexpected unknown modes.



```
### ✨ Features

*

### 🐛 Bug Fixes

* Handle all modes coming from openpath

### 🔧 Tech

*
```
