### PR TITLE
feat: On SMP edit, do not use the ellipsis to see the entire group name

### DIFF
--- a/src/components/Goals/BikeGoal/Edit/ModificationModalContent.jsx
+++ b/src/components/Goals/BikeGoal/Edit/ModificationModalContent.jsx
@@ -124,7 +124,7 @@ const ModificationModalContent = () => {
           </>
         )}
 
-        <ListItem button onClick={handleSendToDACC}>
+        <ListItem ellipsis={false} button onClick={handleSendToDACC}>
           <ListItemIcon>
             <Icon icon={CompareIcon} />
           </ListItemIcon>


### PR DESCRIPTION
```
### ✨ Features

* On SMP edit, do not use the ellipsis to see the entire group name
```
