### PR TITLE
fix: Style of Paper component for certificate

### DIFF
--- a/src/components/Goals/BikeGoal/Certificate/CertificateGenerationContent.jsx
+++ b/src/components/Goals/BikeGoal/Certificate/CertificateGenerationContent.jsx
@@ -76,6 +76,7 @@ const CertificateGenerationContent = ({ certificate }) => {
               pathname: `../certificate/${certificate._id}`
             })
           }}
+          className="u-c-pointer"
         >
           <List>
             <ListItem>


### PR DESCRIPTION
In Desktop mode, the cursor should indicate a clickable item.