### PR TITLE
feat: Improve wording

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -74,7 +74,7 @@
     "delete": "Delete",
     "cancel": "Cancel",
     "dismiss": "No, thanks",
-    "contact": "Contact",
+    "contact": "Save as contact",
     "label": "Label",
     "noLabel": "No label",
     "custom": "Customised",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -74,7 +74,7 @@
     "delete": "Supprimer",
     "cancel": "Annuler",
     "dismiss": "Non, merci",
-    "contact": "Contact",
+    "contact": "Enregistrer dans une fiche contact",
     "label": "Libellé",
     "noLabel": "Aucun libellé",
     "custom": "Personnalisé",


### PR DESCRIPTION
When asking to save a start/end place, we only displayed "Contact" to the user, which can be misleading.


