### PR TITLE
feat: Filter recurring loop trips on distance

### DIFF
--- a/scripts/remove-purposes.js
+++ b/scripts/remove-purposes.js
@@ -26,6 +26,9 @@ const main = async () => {
     .where({
       startDate: {
         $gt: fromDate
+      },
+      aggregation: {
+        $exists: true
       }
     })
     .limitBy(null)

--- a/src/constants.js
+++ b/src/constants.js
@@ -258,3 +258,6 @@ export const MAX_DACC_MEASURES_SENT = 12
 export const RECURRING_PURPOSES_SERVICE_NAME = 'recurringPurposes'
 // Maximum distance ratio gap between trips to be considered as similar
 export const TRIPS_DISTANCE_SIMILARITY_RATIO = 0.1
+
+export const START_END_DISTANCE_THRESHOLD_M = 50 // meters
+export const COORDINATES_DISTANCE_THRESHOLD_M = 200 // meters

--- a/src/lib/dacc.spec.js
+++ b/src/lib/dacc.spec.js
@@ -13,7 +13,8 @@ jest.mock('cozy-client', () => ({
     dacc: {
       sendMeasureToDACC: jest.fn(),
       fetchAggregatesFromDACC: jest.fn()
-    }
+    },
+    geo: { geodesicDistance: jest.fn() }
   }
 }))
 jest.mock('cozy-flags')

--- a/src/lib/exportTripsToCSV.spec.js
+++ b/src/lib/exportTripsToCSV.spec.js
@@ -20,7 +20,8 @@ jest.mock('cozy-client', () => ({
       uploadFileWithConflictStrategy: jest.fn(() => ({
         data: { _id: 'fileId00', name: 'fileName00' }
       }))
-    }
+    },
+    geo: { geodesicDistance: jest.fn() }
   }
 }))
 

--- a/src/lib/recurringPurposes.js
+++ b/src/lib/recurringPurposes.js
@@ -64,6 +64,9 @@ export const findClosestStartAndEnd = (timeserie, contacts) => {
     minEndDistance = Number.MAX_SAFE_INTEGER
   for (const contact of contacts) {
     for (const address of contact.address) {
+      if (!address?.geo?.geo) {
+        continue
+      }
       const addressCoordinates = {
         lon: address.geo.geo[0],
         lat: address.geo.geo[1]

--- a/src/lib/recurringPurposes.spec.js
+++ b/src/lib/recurringPurposes.spec.js
@@ -16,7 +16,8 @@ import {
   areSimiliarTimeseriesByCoordinates,
   findStartAndEnd,
   shouldSetCommutePurpose,
-  findSimilarRecurringTimeseries
+  findSimilarRecurringTimeseries,
+  filterTripsBasedOnDistance
 } from './recurringPurposes'
 
 const mockClient = createMockClient({})
@@ -595,5 +596,30 @@ describe('shouldSetCommutePurpose', () => {
     end = { address: {} }
     expect(shouldSetCommutePurpose(start, end)).toEqual(false)
     expect(shouldSetCommutePurpose(null, null)).toEqual(false)
+  })
+})
+
+describe('filterTripsBasedOnDistance', () => {
+  it('should filter out trips with a distance too high', () => {
+    const timeseries = [
+      {
+        aggregation: { totalDistance: 1000 }
+      },
+      {
+        aggregation: { totalDistance: 500 }
+      }
+    ]
+    expect(filterTripsBasedOnDistance(timeseries, 100)).toEqual([])
+  })
+  it('should keep trips with a distance close enough', () => {
+    const timeseries = [
+      {
+        aggregation: { totalDistance: 105 }
+      },
+      {
+        aggregation: { totalDistance: 95 }
+      }
+    ]
+    expect(filterTripsBasedOnDistance(timeseries, 100)).toEqual(timeseries)
   })
 })

--- a/src/lib/recurringPurposes.spec.js
+++ b/src/lib/recurringPurposes.spec.js
@@ -479,6 +479,22 @@ describe('findStartAndEnd', () => {
     expect(matchingEnd).toEqual(null)
   })
 
+  it('should not consider addresses without geo info', () => {
+    const mockContact = [
+      {
+        name: 'toto',
+        address: [
+          {
+            id: 1
+          }
+        ]
+      }
+    ]
+    const { matchingStart, matchingEnd } = findStartAndEnd({}, mockContact)
+    expect(matchingStart).toEqual(null)
+    expect(matchingEnd).toEqual(null)
+  })
+
   it('should find the exact matching start and end places', () => {
     const ts = mockTimeserie({
       startCoordinates: [-3, 7],

--- a/src/lib/timeseries.spec.js
+++ b/src/lib/timeseries.spec.js
@@ -30,7 +30,8 @@ import {
   filterTimeseriesByYear,
   updateSectionMode,
   getStartPlaceCoordinates,
-  getEndPlaceCoordinates
+  getEndPlaceCoordinates,
+  isLoopTrip
 } from 'src/lib/timeseries'
 import { getSectionsFromTrip } from 'src/lib/trips'
 import { mockF } from 'test/lib/I18n'
@@ -998,5 +999,49 @@ describe('get start/end place coordinates', () => {
   })
   it('should return empty when there is no start place', () => {
     expect(getEndPlaceCoordinates(timeseriesWithNoCoordinates)).toEqual({})
+  })
+})
+
+describe('is Loop trip', () => {
+  it('should return true when start and end points are close enough', () => {
+    const timeserie = {
+      aggregation: {
+        coordinates: {
+          startPoint: {
+            lat: 46.4536633,
+            lon: -0.8119085
+          },
+          endPoint: {
+            lat: 46.4536632,
+            lon: -0.8119086
+          }
+        }
+      }
+    }
+    expect(isLoopTrip(timeserie)).toEqual(true)
+  })
+  it('should return false when start and end points are too far', () => {
+    const timeserie = {
+      aggregation: {
+        coordinates: {
+          startPoint: {
+            lat: 46.4536633,
+            lon: -0.8119085
+          },
+          endPoint: {
+            lon: 46.4536633,
+            lat: -0.8119085
+          }
+        }
+      }
+    }
+    expect(isLoopTrip(timeserie)).toEqual(false)
+  })
+  it('should return false when coordinates are missing', () => {
+    expect(
+      isLoopTrip({
+        coordinates: {}
+      })
+    ).toEqual(false)
   })
 })


### PR DESCRIPTION
When trying to find recurring timeseries with same purpose, 
 we rely on the coordinates, as we consider that trips with
same start / end points have quite often the same purpose.
However, when the start / end points are the same, this assumption seems less relevant: typically trips from and to the home address can have multiple purposes.
That is why we introduce a special case for "loop trip":  we filter out trips with a too high difference in distance  to only set  same purposes to roughly-same-distance loop trips.
This is obviously not perfect, and should probably be eventually improved, but might be a good enough quick win for now.

```
### ✨ Features

* Filter recurring loop trips on distance

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
