### PR TITLE
fix: Get correct title when contacts are associated to trips

### DIFF
--- a/src/lib/recurringPurposes.js
+++ b/src/lib/recurringPurposes.js
@@ -7,7 +7,7 @@ import {
   TRIPS_DISTANCE_SIMILARITY_RATIO,
   WORK_ADDRESS_CATEGORY
 } from 'src/constants'
-import { CONTACTS_DOCTYPE } from 'src/doctypes'
+import { CONTACTS_DOCTYPE, GEOJSON_DOCTYPE } from 'src/doctypes'
 import {
   getEndPlaceCoordinates,
   getStartPlaceCoordinates,
@@ -111,7 +111,7 @@ export const findClosestStartAndEnd = (timeserie, contacts) => {
   return { closestStart, closestEnd }
 }
 
-const setAddressContactRelationShip = ({
+export const setAddressContactRelationShip = ({
   timeserie,
   contact,
   addressId,
@@ -652,7 +652,13 @@ const saveTrips = async ({ client, timeseriesToUpdate, t }) => {
   if (timeseriesToUpdate.length > 0) {
     log('info', `${timeseriesToUpdate.length} trips to update`)
 
-    for (const timeserie of timeseriesToUpdate) {
+    // ATM, necessary because of https://github.com/cozy/cozy-client/issues/493
+    const timeseries = client.hydrateDocuments(
+      GEOJSON_DOCTYPE,
+      timeseriesToUpdate
+    )
+
+    for (const timeserie of timeseries) {
       set(
         timeserie,
         'aggregation.automaticTitle',

--- a/src/lib/recurringPurposes.spec.js
+++ b/src/lib/recurringPurposes.spec.js
@@ -17,7 +17,8 @@ import {
   findStartAndEnd,
   shouldSetCommutePurpose,
   findSimilarRecurringTimeseries,
-  filterTripsBasedOnDistance
+  filterTripsBasedOnDistance,
+  setAddressContactRelationShip
 } from './recurringPurposes'
 
 const mockClient = createMockClient({})
@@ -621,5 +622,43 @@ describe('filterTripsBasedOnDistance', () => {
       }
     ]
     expect(filterTripsBasedOnDistance(timeseries, 100)).toEqual(timeseries)
+  })
+})
+
+describe('setAddressContactRelationShip', () => {
+  it('should add the new relationship without overwrite the existing one', () => {
+    const timeserie = {
+      relationships: {
+        startPlaceContact: {
+          data: {
+            _id: '456',
+            _type: 'io.cozy.contacts'
+          }
+        }
+      }
+    }
+    const contact = {
+      _id: '123'
+    }
+    const addressId = 'abc'
+    const tsWithRel = setAddressContactRelationShip({
+      timeserie,
+      contact,
+      addressId,
+      relType: 'endPlaceContact'
+    })
+    const expected = {
+      relationships: {
+        startPlaceContact: { data: { _id: '456', _type: 'io.cozy.contacts' } },
+        endPlaceContact: {
+          data: {
+            _id: '123',
+            _type: 'io.cozy.contacts',
+            metadata: { addressId: 'abc' }
+          }
+        }
+      }
+    }
+    expect(tsWithRel).toEqual(expected)
   })
 })

--- a/src/lib/timeseries.js
+++ b/src/lib/timeseries.js
@@ -90,26 +90,40 @@ export const updateSectionMode = ({ timeserie, sectionId, mode }) => {
   return currentSectionsUpdated
 }
 
-export const makeAggregationTitle = (timeserie, t) => {
+/**
+ * Build a title based on contacts and display names.
+ *
+ * Note the timeserie MUST be hydrated with contacts relationship, which is not
+ * automatically done, notably in node.
+ * See: https://github.com/cozy/cozy-client/issues/493
+ *
+ *
+ * @param {import('./types').TimeseriesGeoJSON} timeserieWithContacts - The timeserie that may includes contacts
+ * @param {function(string)} t - The translation function
+ * @returns {string} The built title
+ */
+export const makeAggregationTitle = (timeserieWithContacts, t) => {
   const startLabelByContact = getPlaceLabelByContact({
-    timeserie,
+    timeserie: timeserieWithContacts,
     type: 'start',
     t
   })
   const endLabelByContact = getPlaceLabelByContact({
-    timeserie,
+    timeserie: timeserieWithContacts,
     type: 'end',
     t
   })
   const startCity =
-    getStartPlaceDisplayName(timeserie)?.split(',')?.[1]?.trim() || ''
+    getStartPlaceDisplayName(timeserieWithContacts)?.split(',')?.[1]?.trim() ||
+    ''
   const endCity =
-    getEndPlaceDisplayName(timeserie)?.split(',')?.[1]?.trim() || ''
+    getEndPlaceDisplayName(timeserieWithContacts)?.split(',')?.[1]?.trim() || ''
 
   if (startLabelByContact || endLabelByContact) {
     const startLabel =
-      startLabelByContact || getStartPlaceDisplayName(timeserie)
-    const endLabel = endLabelByContact || getEndPlaceDisplayName(timeserie)
+      startLabelByContact || getStartPlaceDisplayName(timeserieWithContacts)
+    const endLabel =
+      endLabelByContact || getEndPlaceDisplayName(timeserieWithContacts)
 
     return `${startLabel} > ${endLabel}`
   }
@@ -118,7 +132,7 @@ export const makeAggregationTitle = (timeserie, t) => {
     return `${startCity} > ${endCity}`.trim()
   }
 
-  return getEndPlaceDisplayName(timeserie)
+  return getEndPlaceDisplayName(timeserieWithContacts)
 }
 
 /**


### PR DESCRIPTION
The recurrence service is able to detect when a trip start or end should
be associated with a contact's address, because of their coordinates.

However, this was not correctly working, because the
`makeAggregationTitle` was expecting hydrated timeseries, i.e. including
complete contacts in their docs.
ATM this must be done manually in node.

```
### ✨ Features

* 

### 🐛 Bug Fixes

* Get correct title when contacts are automatically associated to trips

### 🔧 Tech

*
```
