### PR TITLE
Fix contact creation

### DIFF
--- a/scripts/remove-purposes.js
+++ b/scripts/remove-purposes.js
@@ -9,6 +9,7 @@ const main = async () => {
   parser.addArgument('--only-automatic-purposes', { defaultValue: false })
   parser.addArgument('--from-date', { defaultValue: null })
   parser.addArgument('--remove-recurring', { defaultValue: true })
+  parser.addArgument('--remove-relationships', { defaultValue: false })
   const args = parser.parseArgs()
 
   const client = await createClientInteractive({
@@ -50,6 +51,10 @@ const main = async () => {
     }
     if (args.remove_recurring) {
       delete doc.aggregation.recurring
+      shouldUpdate = true
+    }
+    if (args.remove_relationships) {
+      delete doc.relationships
       shouldUpdate = true
     }
     if (shouldUpdate) {

--- a/src/components/Providers/ContactToPlaceProvider.jsx
+++ b/src/components/Providers/ContactToPlaceProvider.jsx
@@ -30,7 +30,8 @@ const ContactToPlaceProvider = ({ children }) => {
   const [category, setCategory] = useState()
   const { timeserie } = useTrip()
 
-  const contactId = getRelationshipByType(timeserie, type)?.data?._id || ' '
+  const contactId =
+    getRelationshipByType(timeserie, type)?.data?._id || contact?._id || ' '
   const contactsQuery = buildContactsQueryById(contactId)
   const { data: fetchedContact, ...contactsQueryResult } = useQuery(
     contactsQuery.definition,
@@ -62,7 +63,7 @@ const ContactToPlaceProvider = ({ children }) => {
     setContact(fetchedContact)
     setLabel(getLabelByType({ contact: fetchedContact, timeserie, type }))
     setCategory(getCategoryByType({ contact: fetchedContact, timeserie, type }))
-  }, [type, fetchedContact?._id, timeserie?._id]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [type, fetchedContact?._rev, fetchedContact?._id, timeserie?._id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <ContactToPlaceContext.Provider value={value}>


### PR DESCRIPTION
When creating a new contact, a Cozy Contact service is triggered with a
5 sec debounce. This service updates the contact and create a new _rev,
which can cause conflicts. And when conflicts arise, the contact is
never actually linked to the trip in database, making the feature
pointless. Even worse, the user was never informed about it, the error
being silent.

Fortunately, the Cozy realtime is there to dynamically updates the contact
with the new data.
Unfortunately, this was not properly handled: the contact itself was
never queried, and, once queried, never set in the state.

The conflicts should now be avoided, making the world a better place.
And for even more peace, see: https://github.com/cozy/cozy-client/issues/1414

```
### ✨ Features

* 

### 🐛 Bug Fixes

* Fix failed trip association with contact addresses  

### 🔧 Tech

* Add script option to remove relationships
```
