### PR TITLE
fix: Edit Location request dialogs to fit Play Store requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "cozy-logger": "^1.10.1",
     "cozy-realtime": "^5.0.0",
     "cozy-sharing": "^10.0.0",
-    "cozy-ui": "^95.1.0",
+    "cozy-ui": "^95.6.0",
     "date-fns": "2.29.3",
     "humanize-duration": "3.27.1",
     "leaflet": "1.9.1",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -313,7 +313,7 @@
   },
   "geolocationTracking": {
     "locationRefusedDialog": {
-      "description": "To record your movements, you need to give Cozy access to your \"location\" and \"physical activity\". You will be redirected to the app settings."
+      "description": "Your Cozy needs access to additional data in order to help you analyze your movements. This data will NEVER be transmitted to anyone without your explicit request.\n\nYou will be redirected to the app's settings to authorize it to ALWAYS access your phone's position, even when the app is not in use, and PHYSICAL ACTIVITY, movement and shape data.."
     },
     "installOpenPathKonnectorDialog": {
       "description": "This feature requires the OpenPath connector to be installed",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -313,7 +313,7 @@
   },
   "geolocationTracking": {
     "locationRefusedDialog": {
-      "description": "Pour enregistrer vos déplacements, vous devez donner accès à Cozy à votre « position » et à votre « activité physique ». Vous allez être redirigé vers les paramètres de l'app."
+      "description": "Votre Cozy a besoin d'accéder à des données supplémentaires afin de vous aider à analyser vos déplacements. Elles ne seront JAMAIS transmises à qui que ce soit sans votre demande explicite.\n\nVous allez être redirigé vers les paramètres de l'app afin de l'autoriser à TOUJOURS accéder à la position de votre téléphone, donc aussi lorsque l'app n'est pas utilisée, et au données d'ACTIVITÉ PHYSIQUE, mouvements et formes."
     },
     "installOpenPathKonnectorDialog": {
       "description": "Cette fonctionnalité demande l'installation du connecteur OpenPath",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9075,10 +9075,10 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@^95.1.0:
-  version "95.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-95.1.0.tgz#07789fd4c7c4e491c3ea773f97cbd8f9cb19d374"
-  integrity sha512-ZFpbd3qtkitm9sA4/+qEs4TrZORYsWCMFiUC0tSjPRfzgMI9F+QohyJ4khXs1tIkkSBO1f7YyKpEJwVFoqLUsg==
+cozy-ui@^95.6.0:
+  version "95.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-95.6.0.tgz#b645676985aae0e73e49ef5f3988aafc8ecd1d09"
+  integrity sha512-2srZ9VgaXnKfdIglzPz0YSc8tOKM4TeEdCfMa8CcYXi3LRieDP6nIWqOFyULkBOiriKlGA98xOMAwDEmWp+aRA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -15636,9 +15636,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
We got rejected by Play Store because both AllowLocationDialog and LocationRefusedDialog did not contains required wordings

Based on google documentation, those dialogs must:
- Indicate how location is used in the background by including one of these phrases: “background” / “when the app is closed” / “always in use” / “when the app is not in use”.
- Include a list of all the features that use location in the background.

Related PR: https://github.com/cozy/cozy-ui/pull/2519

```
### ✨ Features

*

### 🐛 Bug Fixes

* Edit Location request dialogs to fit Play Store requirements

### 🔧 Tech

*
```
