### PR TITLE
fix: isGeolocationTrackingPossible returned null after a fresh flagship app install

### DIFF
--- a/src/components/GeolocationTracking/helpers.js
+++ b/src/components/GeolocationTracking/helpers.js
@@ -180,14 +180,14 @@ export const checkPermissionsAndEnableTrackingOrShowDialog = async ({
   }
 }
 
-export const isGeolocationTrackingPossible =
+export const isGeolocationTrackingPossible = () =>
   isFlagshipApp() && flag('coachco2.GPSMemory.enabled')
 
 export const checkAndSetGeolocationTrackingAvailability = async (
   webviewIntent,
   setIsGeolocationTrackingAvailable
 ) => {
-  if (isGeolocationTrackingPossible) {
+  if (isGeolocationTrackingPossible()) {
     try {
       const isAvailable =
         (await webviewIntent?.call('isAvailable', FEATURE_NAME)) || false


### PR DESCRIPTION
isGeolocationTrackingPossible was, after a fresh flagship app install, returing null because flags were not set yet.

Transforming it to a function solve the issue.