### PR TITLE
fix: Avoid blinking page on load

### DIFF
--- a/src/components/EmptyContent/EmptyContentManager.jsx
+++ b/src/components/EmptyContent/EmptyContentManager.jsx
@@ -15,6 +15,10 @@ const EmptyContentManager = () => {
   const { isGeolocationTrackingAvailable, isGeolocationTrackingEnabled } =
     useGeolocationTracking()
 
+  const isGeolocationTrackingLoading =
+    isGeolocationTrackingAvailable === null ||
+    isGeolocationTrackingEnabled === null
+
   const otherAccounts = accounts.filter(
     allAccount => allAccount._id !== account?._id
   )
@@ -22,7 +26,7 @@ const EmptyContentManager = () => {
   const results = useQueries(queriesByAccountsId)
   const isLoading = isQueriesLoading(results)
 
-  if (isLoading) {
+  if (isLoading || isGeolocationTrackingLoading) {
     return (
       <Spinner size="xxlarge" className="u-flex u-flex-justify-center u-mt-1" />
     )

--- a/src/components/GeolocationTracking/helpers.js
+++ b/src/components/GeolocationTracking/helpers.js
@@ -83,7 +83,7 @@ export const syncTrackingStatusWithFlagship = async (
 ) => {
   const { enabled } = (await webviewIntent?.call(
     'getGeolocationTrackingStatus'
-  )) || { enabled: false }
+  )) || { enabled: null }
   setIsGeolocationTrackingEnabled(enabled)
 }
 
@@ -190,7 +190,7 @@ export const checkAndSetGeolocationTrackingAvailability = async (
   if (isGeolocationTrackingPossible()) {
     try {
       const isAvailable =
-        (await webviewIntent?.call('isAvailable', FEATURE_NAME)) || false
+        (await webviewIntent?.call('isAvailable', FEATURE_NAME)) || null
 
       setIsGeolocationTrackingAvailable(isAvailable)
     } catch {

--- a/src/components/Providers/GeolocationTrackingProvider.jsx
+++ b/src/components/Providers/GeolocationTrackingProvider.jsx
@@ -40,9 +40,9 @@ export const GeolocationTrackingProvider = ({ children }) => {
   const { t, lang } = useI18n()
 
   const [isGeolocationTrackingAvailable, setIsGeolocationTrackingAvailable] =
-    useState(false)
+    useState(null)
   const [isGeolocationTrackingEnabled, setIsGeolocationTrackingEnabled] =
-    useState(false)
+    useState(null)
   const [showLocationRequestableDialog, setShowLocationRequestableDialog] =
     useState(false)
   const [showLocationRefusedDialog, setShowLocationRefusedDialog] =


### PR DESCRIPTION
On coachco2 loading, we can see page switching very quickly between InstallApp and Welcome page because by default we displayed InstallApp page, and after a request to the flagship app we decided to stay on this page or change to Welcome page.

Now we wait to be sure of the value of isGeolocationTrackingAvailable and isGeolocationTrackingEnabled before displaying something.