### PR TITLE
feat: Query DACC to get avg bike goal days

### DIFF
--- a/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
+++ b/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
@@ -3,6 +3,7 @@ import ChartLegend from 'src/components/CO2EmissionsChart/VerticalBarChart/Chart
 import VerticalBarChart from 'src/components/CO2EmissionsChart/VerticalBarChart/VerticalBarChart'
 import { makeOptions, makeData } from 'src/components/CO2EmissionsChart/helpers'
 import { useAccountContext } from 'src/components/Providers/AccountProvider'
+import { DACC_MEASURE_NAME_CO2_MONTHLY } from 'src/constants'
 import useFetchDACCAggregates from 'src/hooks/useFetchDACCAggregates'
 import useSettings from 'src/hooks/useSettings'
 import { buildOneYearOldTimeseriesWithAggregationByAccountId } from 'src/queries/queries'
@@ -31,7 +32,10 @@ const CO2EmissionsChart = () => {
     }
   )
 
-  const { data: globalAverages } = useFetchDACCAggregates(sendToDACC)
+  const { data: globalAverages } = useFetchDACCAggregates({
+    hasConsent: sendToDACC,
+    measureName: DACC_MEASURE_NAME_CO2_MONTHLY
+  })
 
   const isLoading =
     !account || isQueryLoading(queryResult) || queryResult.hasMore

--- a/src/components/Goals/BikeGoal/BikeGoalChart.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalChart.jsx
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   makeGoalAchievementPercentage,
   makeIconSize,
   makeDaccAchievementPercentage
 } from 'src/components/Goals/BikeGoal/helpers'
+import { DACC_MEASURE_NAME_BIKE_GOAL } from 'src/constants'
+import useFetchDACCAggregates from 'src/hooks/useFetchDACCAggregates'
 import { buildSettingsQuery } from 'src/queries/queries'
 
 import { isQueryLoading, useQuery } from 'cozy-client'
@@ -12,12 +14,22 @@ import Box from 'cozy-ui/transpiled/react/Box'
 import CircularChart from 'cozy-ui/transpiled/react/CircularChart'
 
 const BikeGoalChart = ({ timeseries, sendToDACC, size, ...props }) => {
+  const [hasDACCConsent, setHasDACCConsent] = useState(false)
   const settingsQuery = buildSettingsQuery()
   const { data: settings, ...settingsQueryLeft } = useQuery(
     settingsQuery.definition,
     settingsQuery.options
   )
-  const isLoading = isQueryLoading(settingsQueryLeft)
+  useEffect(() => {
+    const consent = settings?.[0].bikeGoal?.sendToDACC
+    setHasDACCConsent(!!consent)
+  }, [settings])
+
+  const { data: avgDays, isLoading: isDACCLoading } = useFetchDACCAggregates({
+    hasConsent: hasDACCConsent,
+    measureName: DACC_MEASURE_NAME_BIKE_GOAL
+  })
+  const isLoading = isQueryLoading(settingsQueryLeft) && isDACCLoading
 
   if (isLoading) {
     return null
@@ -35,7 +47,7 @@ const BikeGoalChart = ({ timeseries, sendToDACC, size, ...props }) => {
       primaryProps={{ value: goalAchievementPercentage, color: '#BA5AE8' }}
       {...(sendToDACC && {
         secondaryProps: {
-          value: makeDaccAchievementPercentage(settings),
+          value: makeDaccAchievementPercentage(settings, avgDays),
           color: '#BA5AE83D'
         }
       })}

--- a/src/components/Goals/BikeGoal/BikeGoalSummaryItem.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalSummaryItem.jsx
@@ -27,6 +27,7 @@ const BikeGoalSummaryItem = ({
     settingsQuery.options
   )
   const isLoading = isQueryLoading(settingsQueryLeft)
+  const avgGroupDays = days || '-'
 
   if (isLoading) {
     return null
@@ -47,7 +48,7 @@ const BikeGoalSummaryItem = ({
         style={createStyle(isSuccess)}
       >
         {t('bikeGoal.goal_progression', {
-          days,
+          days: avgGroupDays,
           daysToReach: getDaysToReach(settings)
         })}
       </Typography>

--- a/src/components/Goals/BikeGoal/helpers.js
+++ b/src/components/Goals/BikeGoal/helpers.js
@@ -63,11 +63,10 @@ export const makeIconSize = size => {
   }
 }
 
-// TODO: right function should be create by @paultranvan soon
-export const getDaccAverageDays = () => 0.5
-
-export const makeDaccAchievementPercentage = settings => {
-  const daccAverageDays = getDaccAverageDays()
+export const makeDaccAchievementPercentage = (settings, daccAverageDays) => {
+  if (!daccAverageDays) {
+    return 0
+  }
   const daysToReach = getDaysToReach(settings)
   const daysToUse =
     daccAverageDays > daysToReach ? daysToReach : daccAverageDays

--- a/src/hooks/useFetchDACCAggregates.spec.jsx
+++ b/src/hooks/useFetchDACCAggregates.spec.jsx
@@ -1,23 +1,38 @@
 import { renderHook } from '@testing-library/react-hooks'
 import React from 'react'
+import {
+  DACC_MEASURE_NAME_BIKE_GOAL,
+  DACC_MEASURE_NAME_CO2_MONTHLY
+} from 'src/constants'
 import useFetchDACCAggregates from 'src/hooks/useFetchDACCAggregates'
+import { fetchYesterdayBikeGoalFromDACC } from 'src/lib/daccBikeGoal'
 import { fetchMonthlyAverageCO2FromDACCFor11Month } from 'src/lib/daccMonthlyCO2'
 import AppLike from 'test/AppLike'
 
 import { createMockClient } from 'cozy-client'
+import flag from 'cozy-flags'
 
 jest.mock('src/lib/daccMonthlyCO2')
+jest.mock('src/lib/daccBikeGoal')
+jest.mock('cozy-flags')
 
+jest.mock('src/lib/daccBikeGoal', () => ({
+  ...jest.requireActual('src/lib/daccBikeGoal'),
+  fetchYesterdayBikeGoalFromDACC: jest.fn()
+}))
 const client = createMockClient({})
 
-const setup = ({ sendToDACC }) => {
+const setup = ({ sendToDACC, measureName }) => {
   const wrapper = ({ children }) => (
     <AppLike client={client}>{children}</AppLike>
   )
 
-  return renderHook(() => useFetchDACCAggregates(sendToDACC), {
-    wrapper
-  })
+  return renderHook(
+    () => useFetchDACCAggregates({ hasConsent: sendToDACC, measureName }),
+    {
+      wrapper
+    }
+  )
 }
 
 describe('useFetchDACCAggregates', () => {
@@ -29,15 +44,34 @@ describe('useFetchDACCAggregates', () => {
     expect(result.current.data).toBe(null)
   })
 
-  it('should return average data', async () => {
+  it('should return average data for co2 monthly', async () => {
     fetchMonthlyAverageCO2FromDACCFor11Month.mockResolvedValue([
       { avg: 42, sum: 58 },
       { avg: 64, sum: 102 }
     ])
-    const { result, waitForNextUpdate } = setup({ sendToDACC: true })
+    const { result, waitForNextUpdate } = setup({
+      sendToDACC: true,
+      measureName: DACC_MEASURE_NAME_CO2_MONTHLY
+    })
     await waitForNextUpdate()
 
     expect(result.current.isLoading).toBe(false)
     expect(result.current.data).toEqual([42, 64])
+  })
+
+  it('should return average data for bike goal', async () => {
+    fetchYesterdayBikeGoalFromDACC.mockResolvedValue([
+      { avg: 42, groups: [{ groupName: 'Cozy' }] }
+    ])
+    flag.mockReturnValue({ sourceName: 'Cozy' })
+
+    const { result, waitForNextUpdate } = setup({
+      sendToDACC: true,
+      measureName: DACC_MEASURE_NAME_BIKE_GOAL
+    })
+    await waitForNextUpdate()
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.data).toEqual(42)
   })
 })

--- a/src/lib/daccBikeGoal.spec.js
+++ b/src/lib/daccBikeGoal.spec.js
@@ -84,3 +84,30 @@ describe('sendBikeGoalMeasuresForAccount', () => {
     )
   })
 })
+
+describe('getAvgForGroupName', () => {
+  it('should get the avg value for the given group', () => {
+    const aggs = [
+      {
+        avg: 4.544,
+        groups: [{ groupName: 'Cozy' }]
+      },
+      {
+        avg: 2.32,
+        groups: [{ groupName: 'Hyperion' }]
+      }
+    ]
+    flag.mockReturnValue({ sourceName: 'Cozy' })
+    expect(dacc.getAvgDaysForGroupName(aggs, 'Cozy')).toEqual(5)
+  })
+  it('should return null when the given group is not found', () => {
+    const aggs = [
+      {
+        avg: 4.544,
+        groups: [{ groupName: 'Cozy' }]
+      }
+    ]
+    flag.mockReturnValue({ sourceName: 'Hyperion' })
+    expect(dacc.getAvgDaysForGroupName(aggs, 'Hyperion')).toEqual(null)
+  })
+})


### PR DESCRIPTION
Users can visualize the average bike goal status for their own group and compare themselves



