### PR TITLE
fix: Reserve the height for the graph

### DIFF
--- a/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
+++ b/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
@@ -23,12 +23,11 @@ const CO2EmissionsChart = () => {
     useSettings('CO2Emission.sendToDACC')
 
   const oneYearOldTimeseriesQuery =
-    buildOneYearOldTimeseriesWithAggregationByAccountId(account?._id)
+    buildOneYearOldTimeseriesWithAggregationByAccountId(account._id)
   const { data: oneYearOldTimeseries, ...queryResult } = useQueryAll(
     oneYearOldTimeseriesQuery.definition,
     {
-      ...oneYearOldTimeseriesQuery.options,
-      enabled: Boolean(account)
+      ...oneYearOldTimeseriesQuery.options
     }
   )
 
@@ -37,13 +36,15 @@ const CO2EmissionsChart = () => {
     measureName: DACC_MEASURE_NAME_CO2_MONTHLY
   })
 
-  const isLoading =
-    !account || isQueryLoading(queryResult) || queryResult.hasMore
-
-  if (isLoading || oneYearOldTimeseries.length === 0) {
-    return null
+  const isLoading = isQueryLoading(queryResult) || queryResult.hasMore
+  if (isLoading) {
+    return (
+      <div
+        className="u-mt-1 u-ph-half-s u-ph-2"
+        style={{ minHeight: '190px' }}
+      />
+    )
   }
-
   const showLegend = !isSettingsLoading && sendToDACC
   const options = makeOptions(theme)
   const data = makeData({


### PR DESCRIPTION
Since we render the CO2EmissionsChart only when we have an account & a timeseries, we are sur to display it when we render it.

So this is a quick fix to avoid visual glitch by reserving the 190px height.

The right solution should be to display an empty graph, but I didn't have the time to check how to do that.



```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
