### PR TITLE
fix: Contact not reset in ContactToPlaceDialog when delete it

### DIFF
--- a/src/components/ContactToPlace/ContactToPlaceDialog.jsx
+++ b/src/components/ContactToPlace/ContactToPlaceDialog.jsx
@@ -16,8 +16,13 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 const ContactToPlaceDialog = ({ isLoading }) => {
   const [showTooltip, setShowTooltip] = useState(false)
-  const { type, setType } = useContactToPlace()
+  const { type, setType, setContact } = useContactToPlace()
   const { t } = useI18n()
+
+  const handleClose = () => {
+    setContact(null)
+    setType()
+  }
 
   return (
     <ConfirmDialog
@@ -56,7 +61,7 @@ const ContactToPlaceDialog = ({ isLoading }) => {
         )
       }
       actions={<ContactToPlaceDialogActions />}
-      onClose={() => setType()}
+      onClose={handleClose}
     />
   )
 }

--- a/src/components/ContactToPlace/ContactToPlaceDialogActions.jsx
+++ b/src/components/ContactToPlace/ContactToPlaceDialogActions.jsx
@@ -16,7 +16,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 const ContactToPlaceDialogActions = () => {
   const [showError, setShowError] = useState(false)
-  const { type, isSameContact, contact, setType, label, category } =
+  const { type, isSameContact, contact, setContact, setType, label, category } =
     useContactToPlace()
   const { t } = useI18n()
   const { timeserie } = useTrip()
@@ -29,6 +29,7 @@ const ContactToPlaceDialogActions = () => {
     if (!contact) {
       return setShowError(true)
     }
+    setContact(null)
 
     showAlert(t('contactToPlace.addSuccess'), 'success')
     if (type === 'start' && !hasRelationshipByType(timeserie, 'end')) {
@@ -52,6 +53,7 @@ const ContactToPlaceDialogActions = () => {
 
   const handleDelete = async () => {
     showAlert(t('contactToPlace.removeSuccess'), 'success')
+    setContact(null)
     onClose()
     await removeRelationship({ client, timeserie, type, t, contact })
   }


### PR DESCRIPTION
The local state of the contact in the useContactToPlace hook was not reset when validating the form (deletion or creation),
nor when closing the modal containing the form.



```
### 🐛 Bug Fixes

* Contact can be set to start & end place on trip
```
