### PR TITLE
fix: setIsloadingDate to false when no account

### DIFF
--- a/src/components/SelectDatesWrapper.jsx
+++ b/src/components/SelectDatesWrapper.jsx
@@ -46,6 +46,12 @@ const SelectDatesWrapper = () => {
         setOptions(options)
       }
     }
+    if (!account) {
+      setIsSelectedDateLoading(false)
+    }
+    if (account && isLoading && !isSelectedDateLoading) {
+      setIsSelectedDateLoading(true)
+    }
   }, [
     account,
     isLoading,


### PR DESCRIPTION
Since we can't not make the query when there is no account, we should set the data loading to false.

Next commit will be to not render this component if there is no account in order to make it easier to understand and to simplify the code.
