### PR TITLE
Activate ContactToPlace feature for every  purposes

### DIFF
--- a/src/components/EditDialogs/PurposeEditDialog/helpers.js
+++ b/src/components/EditDialogs/PurposeEditDialog/helpers.js
@@ -42,6 +42,14 @@ export const openContactToPlaceModalOrClose = ({
     } else if (!hasRelationshipByType(timeserie, 'end')) {
       setContactToPlaceType('end')
     }
+  } else {
+    if (
+      !hasRelationshipByType(timeserie, 'start') &&
+      !hasRelationshipByType(timeserie, 'end')
+    ) {
+      setContactToPlaceType('start')
+    }
   }
+
   onClose()
 }

--- a/src/components/Timeline/TimelineNode.jsx
+++ b/src/components/Timeline/TimelineNode.jsx
@@ -3,13 +3,8 @@ import React, { useMemo } from 'react'
 import { getPlaceLabelByContact } from 'src/components/ContactToPlace/helpers'
 import { useContactToPlace } from 'src/components/Providers/ContactToPlaceProvider'
 import { useTrip } from 'src/components/Providers/TripProvider'
-import { COMMUTE_PURPOSE } from 'src/constants'
 import { formatDate } from 'src/lib/helpers'
-import {
-  getTimeseriePurpose,
-  getPlaceDisplayName,
-  getPlaceDate
-} from 'src/lib/timeseries'
+import { getPlaceDisplayName, getPlaceDate } from 'src/lib/timeseries'
 
 import TimelineConnector from 'cozy-ui/transpiled/react/TimelineConnector'
 import TimelineContent from 'cozy-ui/transpiled/react/TimelineContent'
@@ -38,7 +33,7 @@ const useStyles = makeStyles(theme => ({
       padding: 0,
       flexGrow: 0
     },
-    cursor: ({ isCommute }) => (isCommute ? 'pointer' : undefined)
+    cursor: 'pointer'
   },
   contentWrapper: {
     display: 'flex',
@@ -53,11 +48,7 @@ const TimelineNode = ({ type }) => {
   const { t, f, lang } = useI18n()
   const { setType } = useContactToPlace()
   const { timeserie } = useTrip()
-
-  const purpose = getTimeseriePurpose(timeserie)
-  const isCommute = purpose === COMMUTE_PURPOSE
-
-  const classes = useStyles({ isCommute })
+  const classes = useStyles()
 
   const isNotEndNode = useMemo(() => type !== 'end', [type])
   const isStartNode = useMemo(() => type === 'start', [type])
@@ -72,10 +63,7 @@ const TimelineNode = ({ type }) => {
     : null
 
   return (
-    <TimelineItem
-      className={classes.item}
-      onClick={isCommute ? () => setType(type) : undefined}
-    >
+    <TimelineItem className={classes.item} onClick={() => setType(type)}>
       <TimelineSeparator>
         <TimelineDot
           className={cx({

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -70,7 +70,7 @@
   "contactToPlace": {
     "saveStartPlace": "Save the starting point?",
     "saveEndPlace": "Save the arrival point?",
-    "tooltip": "To automate this categorisation in the future, save this address in a contact record",
+    "tooltip": "To make this categorisation more reliable in the future, register this address in a contact record.",
     "submit": "Save",
     "delete": "Delete",
     "cancel": "Cancel",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -70,7 +70,7 @@
   "contactToPlace": {
     "saveStartPlace": "Enregistrer le point de départ ?",
     "saveEndPlace": "Enregistrer le point d'arrivée ?",
-    "tooltip": "Pour automatiser cette catégorisation à l'avenir, enregistrer cette adresse dans une fiche contact",
+    "tooltip": "Pour fiabiliser l’automatisation de cette catégorisation à l’avenir, enregistrer cette adresse dans une fiche contact.",
     "submit": "Enregistrer",
     "delete": "Supprimer",
     "cancel": "Annuler",


### PR DESCRIPTION
On active le fait de pouvoir cliquer sur un point de départ/arrivée afin d'y assigner un contact à tous les déplacements, quelque soit leur motif (réservé avant au seul motif domicile/travail)

Initialement on avait préféré mettre ces changement derrière un flag car une MEP est prévu aujourd'hui, mais on a tester la feature en live et il a été décidé de passer cette modification avant la MEP.