### PR TITLE
fix: Build releases with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ cache: yarn
 branches:
   only:
   - master
-  # detect also branch like release/x.y.z or release/x.y.z-beta.n
-  - /^release\/\d+\.\d+\.\d+(\-beta.\d+)?$/
+  # detect also tag like x.y.z or x.y.z-beta.n as travis consider them to be branches
+  - /^\d+\.\d+\.\d+(\-beta.\d+)?$/
 
 env:
   global:


### PR DESCRIPTION
This is the fix I made to unlock release 0.11.1 last Friday. Travis detects tags again, so it's better to run releases with this trigger. The build was not launched with the release/x.y.z branch until a new commit was detected

```
### 🔧 Tech

* Update Travis configuration to track release tags
```
