### PR TITLE
chore: Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+node_js:
+  - '16'
+  - '20'
 dist: jammy
 cache: yarn
 branches:
@@ -23,8 +26,15 @@ jobs:
     - name: 'Lint'
       stage: 'prebuild'
       script: yarn lint
-    - name: 'Tests'
+    - name: 'Unit tests node 16'
       stage: 'prebuild'
+      node_js:
+        - 16
+      script: yarn test
+    - name: 'Unit tests node 20'
+      stage: 'prebuild'
+      node_js:
+        - 20
       script: yarn test
     - name: 'Build app'
       stage: 'build'

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cozy-ach": "^1.49.0",
     "cozy-bar": "7.16.0",
     "cozy-jobs-cli": "1.19.2",
-    "cozy-scripts": "^8.1.2",
+    "cozy-scripts": "^8.2.0",
     "eslint": "8.48.0",
     "eslint-config-cozy-app": "6.1.0",
     "eslint-config-prettier": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "coachco2",
   "version": "0.12.0",
   "engines": {
-    "node": "~20"
+    "node": "~16 || ~20"
   },
   "scripts": {
     "analyze": "COZY_SCRIPTS_ANALYZER=true yarn build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8955,10 +8955,10 @@ cozy-release@1.10.0:
   dependencies:
     exec-sh "0.3.2"
 
-cozy-scripts@^8.1.2:
-  version "8.1.2"
-  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-8.1.2.tgz#5ff1ef11328215f2955d8d7620992326fa86dcad"
-  integrity sha512-4MvcWim6nAAzSllnkQUsgXTkzKTvYnePk38kWS/14W5w7Ip0VZql0BtewWMc1Sm07yAcyik9Of/i1yX3CxcOQA==
+cozy-scripts@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-8.2.0.tgz#a3286078ab331e55e24fcc41ef3d20b90a5c64cc"
+  integrity sha512-kAHBOkPBP/2nkpP/EU9I54HrUEcTusxx2j745RWuTK+Ag/QtqVccLxYQdFo+Bf69akNXJ8cMfM3YQc24VpqFRQ==
   dependencies:
     "@babel/core" "7.10.0"
     "@babel/polyfill" "^7.10.4"
@@ -15636,9 +15636,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
```
### 🔧 Tech

* Update `cozy-scripts` from `8.1.2` to `8.2.0`
* Update travis config, keep tests in node 16 and node 20 because currently services are executed with node 16.
```
