### PR TITLE
chore: Refactor Travis CI stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
-node_js:
-  - '16'
-  - '20'
+node_js: 16
 dist: jammy
 cache: yarn
 branches:
@@ -28,13 +26,11 @@ jobs:
       script: yarn lint
     - name: 'Unit tests node 16'
       stage: 'prebuild'
-      node_js:
-        - 16
+      node_js: 16
       script: yarn test
     - name: 'Unit tests node 20'
       stage: 'prebuild'
-      node_js:
-        - 20
+      node_js: 20
       script: yarn test
     - name: 'Build app'
       stage: 'build'


### PR DESCRIPTION
```
### 🔧 Tech

* Travis executes the yarn test command by default when we specify multiple node versions at the root.
In this case we run the tests twice.
```
