### PR TITLE
fix: Remove horizontal scroll on Settings page

### DIFF
--- a/src/components/CO2EmissionDaccAlertSwitcher.jsx
+++ b/src/components/CO2EmissionDaccAlertSwitcher.jsx
@@ -39,7 +39,7 @@ const CO2EmissionDaccAlertSwitcher = () => {
         primary={t('dacc.settings.showAlerter')}
       />
       <ListItemSecondaryAction>
-        <Switch edge="end" checked={value} onChange={handleChange} />
+        <Switch checked={value} onChange={handleChange} />
       </ListItemSecondaryAction>
     </ListItem>
   )

--- a/src/components/CO2EmissionDaccSwitcher.jsx
+++ b/src/components/CO2EmissionDaccSwitcher.jsx
@@ -36,12 +36,7 @@ const CO2EmissionDaccSwitcher = () => {
       </ListItemIcon>
       <ListItemText primary={t('dacc.settings.anonymous_participation')} />
       <ListItemSecondaryAction>
-        <Switch
-          color="primary"
-          edge="end"
-          checked={value}
-          onChange={handleChange}
-        />
+        <Switch color="primary" checked={value} onChange={handleChange} />
       </ListItemSecondaryAction>
     </ListItem>
   )

--- a/src/components/Goals/BikeGoal/BikeGoalAlertSuccessSwitcher.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAlertSuccessSwitcher.jsx
@@ -39,7 +39,7 @@ const BikeGoalAlertSuccessSwitcher = () => {
         primary={t('bikeGoal.settings.showAlerterSuccess')}
       />
       <ListItemSecondaryAction>
-        <Switch edge="end" checked={value} onChange={handleChange} />
+        <Switch checked={value} onChange={handleChange} />
       </ListItemSecondaryAction>
     </ListItem>
   )

--- a/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalAlertSwitcher.jsx
@@ -39,7 +39,7 @@ const BikeGoalAlertSwitcher = () => {
         primary={t('bikeGoal.settings.showAlerter')}
       />
       <ListItemSecondaryAction>
-        <Switch edge="end" checked={value} onChange={handleChange} />
+        <Switch checked={value} onChange={handleChange} />
       </ListItemSecondaryAction>
     </ListItem>
   )

--- a/src/components/Goals/BikeGoal/BikeGoalDaccSwitcher.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalDaccSwitcher.jsx
@@ -39,7 +39,7 @@ const BikeGoalDaccSwitcher = () => {
         primary={t('bikeGoal.settings.sendToDACC')}
       />
       <ListItemSecondaryAction>
-        <Switch edge="end" checked={value} onChange={handleChange} />
+        <Switch checked={value} onChange={handleChange} />
       </ListItemSecondaryAction>
     </ListItem>
   )

--- a/src/components/Goals/BikeGoal/BikeGoalOnboardedSwitcher.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalOnboardedSwitcher.jsx
@@ -54,7 +54,7 @@ const BikeGoalOnboardedSwitcher = () => {
         primary={t('bikeGoal.settings.hideOnboarding')}
       />
       <ListItemSecondaryAction>
-        <Switch edge="end" checked={isChecked} onChange={handleChange} />
+        <Switch checked={isChecked} onChange={handleChange} />
       </ListItemSecondaryAction>
     </ListItem>
   )

--- a/src/components/Goals/BikeGoal/BikeGoalSwitcher.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalSwitcher.jsx
@@ -47,12 +47,7 @@ const BikeGoalSwitcher = () => {
       </ListItemIcon>
       <ListItemText primary={t('bikeGoal.settings.participation')} />
       <ListItemSecondaryAction>
-        <Switch
-          color="primary"
-          edge="end"
-          checked={isChecked}
-          onChange={handleChange}
-        />
+        <Switch color="primary" checked={isChecked} onChange={handleChange} />
       </ListItemSecondaryAction>
     </ListItem>
   )


### PR DESCRIPTION
The `edge="end"` prop adds a negative margin (-8px) which in this case creates a horizontal offset.