### PR TITLE
[DAT-25] feat: Add DACC mesure for consent

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -262,6 +262,7 @@ export const DACC_MEASURE_NAME_TRIPS_COUNT = 'trips-count-monthly'
 export const DACC_MEASURE_NAME_TRIPS_CO2 = 'trips-CO2-monthly'
 export const DACC_MEASURE_NAME_TRIPS_DURATION = 'trips-duration-monthly'
 export const DACC_MEASURE_NAME_TRIPS_DISTANCE = 'trips-distance-monthly'
+export const DACC_EXPE_CONSENT_MEASURE = 'experimentation-consent'
 
 export const TIMESERIE_MIGRATION_SERVICE_NAME =
   'timeseriesWithoutAggregateMigration'


### PR DESCRIPTION
This is useful to measure how many users gave their explicit consent to participate to the experimentation.



```
### ✨ Features

* Add new DACC measure for consent 

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
