### PR TITLE
[DAT-26]  feat: Add webhook trigger for fetchOpenPathTrips service

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -96,6 +96,11 @@
       "file": "services/fetchOpenPathTrips/coachco2.js",
       "trigger": "@hourly"
     },
+    "fetchOpenPathTripsByWebhook": {
+      "type": "node",
+      "file": "services/fetchOpenPathTrips/coachco2.js",
+      "trigger": "@webhook"
+    },
     "timeseriesWithoutAggregateMigration": {
       "type": "node",
       "file": "services/timeseriesWithoutAggregateMigration/coachco2.js",

--- a/src/lib/openpath/queries.js
+++ b/src/lib/openpath/queries.js
@@ -1,10 +1,17 @@
 import {
+  buildAccountByToken,
   buildLastCreatedServiceAccountQuery,
   buildTimeseriesByDateRange
 } from 'src/queries/queries'
 
 export const queryLastServiceAccount = async client => {
   const accountsQuery = buildLastCreatedServiceAccountQuery().definition
+  const account = await client.query(accountsQuery)
+  return account && account.data?.length > 0 ? account.data[0] : null
+}
+
+export const queryAccountByToken = async (client, token) => {
+  const accountsQuery = buildAccountByToken({ token }).definition
   const account = await client.query(accountsQuery)
   return account && account.data?.length > 0 ? account.data[0] : null
 }

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -434,6 +434,25 @@ export const buildLastCreatedServiceAccountQuery = () => {
   }
 }
 
+export const buildAccountByToken = ({ token }) => {
+  const queryDef = Q(ACCOUNTS_DOCTYPE)
+    .where({
+      token: token
+    })
+    .partialIndex({
+      account_type: 'openpath'
+    })
+    .indexFields(['token'])
+    .limitBy(1)
+  return {
+    definition: queryDef,
+    options: {
+      as: `${ACCOUNTS_DOCTYPE}/account_type/openpath/token/${token}`,
+      fetchPolicy: CozyClient.fetchPolicies.olderThan(older30s)
+    }
+  }
+}
+
 export const buildSettingsQuery = () => ({
   definition: Q(CCO2_SETTINGS_DOCTYPE),
   options: {


### PR DESCRIPTION
This is useful to be able to request the service directly from a webhook, typically called from an openpath server.
Related to https://github.com/cozy/cozy-flagship-app/pull/1133



```
### ✨ Features

* Allow triggering fetchOpenPathTripsByWebhook service from webhook

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
