### PR TITLE
fix: Sync geolocation tracking status on visibility change

### DIFF
--- a/src/components/Providers/GeolocationTrackingProvider.jsx
+++ b/src/components/Providers/GeolocationTrackingProvider.jsx
@@ -13,6 +13,7 @@ import {
   getNewPermissionAndEnabledTrackingOrShowDialog,
   checkAndSetGeolocationTrackingAvailability
 } from 'src/components/GeolocationTracking/helpers'
+import { useVisibilityChange } from 'src/hooks/useVisibilityChange'
 
 import { useClient } from 'cozy-client'
 import { isAndroid } from 'cozy-device-helper'
@@ -37,6 +38,7 @@ export const GeolocationTrackingProvider = ({ children }) => {
   const webviewIntent = useWebviewIntent()
   const client = useClient()
   const { t, lang } = useI18n()
+  const { visibilityState } = useVisibilityChange()
 
   const [isGeolocationTrackingAvailable, setIsGeolocationTrackingAvailable] =
     useState(null)
@@ -61,6 +63,16 @@ export const GeolocationTrackingProvider = ({ children }) => {
       setIsGeolocationQuotaExceeded
     )
   }, [webviewIntent])
+
+  useEffect(() => {
+    if (isGeolocationTrackingAvailable && visibilityState === 'visible') {
+      syncTrackingStatusWithFlagship(
+        webviewIntent,
+        setIsGeolocationTrackingEnabled,
+        setIsGeolocationQuotaExceeded
+      )
+    }
+  }, [webviewIntent, isGeolocationTrackingAvailable, visibilityState])
 
   const value = useMemo(
     () => ({

--- a/src/hooks/useVisibilityChange.js
+++ b/src/hooks/useVisibilityChange.js
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react'
+
+export const useVisibilityChange = () => {
+  const [visibilityState, setVisibilityState] = useState(
+    document.visibilityState
+  )
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setVisibilityState(document.visibilityState)
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [])
+
+  return { visibilityState }
+}


### PR DESCRIPTION
With the recent add of geolocation quota check on flagship side, the geolocation tracking can be disabled when the flagship app (with coachco2 opened) is in background. When the user will come back to the flagship app, the geolocation tracking will be disabled, but the geolocation tracking toggle on coachco2 will be enabled.

Here we solve the issue by syncing the geolocation tracking status when coachco2 becomes visible.

```
### 🐛 Bug Fixes

* Show correct geolocation tracking status if geolocation tracking has been disabled in background because of quota exceeded
```
