### PR TITLE
[DAT-27] feat: Add new DACC measures for trips

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -96,7 +96,7 @@
       "file": "services/fetchOpenPathTrips/coachco2.js",
       "trigger": "@hourly"
     },
-    "fetchOpenPathTripsByWebhook": {
+    "fetchOpenPathTripsWebhook": {
       "type": "node",
       "file": "services/fetchOpenPathTrips/coachco2.js",
       "trigger": "@webhook"

--- a/src/constants.js
+++ b/src/constants.js
@@ -262,6 +262,10 @@ export const DACC_MEASURE_NAME_TRIPS_COUNT = 'trips-count-monthly'
 export const DACC_MEASURE_NAME_TRIPS_CO2 = 'trips-CO2-monthly'
 export const DACC_MEASURE_NAME_TRIPS_DURATION = 'trips-duration-monthly'
 export const DACC_MEASURE_NAME_TRIPS_DISTANCE = 'trips-distance-monthly'
+export const DACC_MEASURE_NAME_SECTIONS_COUNT = 'sections-count-monthly'
+export const DACC_MEASURE_NAME_SECTIONS_CO2 = 'sections-CO2-monthly'
+export const DACC_MEASURE_NAME_SECTIONS_DURATION = 'sections-duration-monthly'
+export const DACC_MEASURE_NAME_SECTIONS_DISTANCE = 'sections-distance-monthly'
 export const DACC_EXPE_CONSENT_MEASURE = 'experimentation-consent'
 
 export const TIMESERIE_MIGRATION_SERVICE_NAME =

--- a/src/lib/daccCentreValDeLoireExpe.spec.js
+++ b/src/lib/daccCentreValDeLoireExpe.spec.js
@@ -11,10 +11,13 @@ describe('computeRawMeasures', () => {
 
   it('should handle timeseries without aggregation', () => {
     const timeseries = [{ aggregation: null }]
-    expect(computeRawMeasures(timeseries)).toEqual({})
+    expect(computeRawMeasures(timeseries)).toEqual({
+      sectionMeasures: {},
+      tripMeasures: {}
+    })
   })
 
-  it('should compute measures correctly for valid timeseries with start/end place', () => {
+  it('should compute section measures correctly for valid timeseries with start/end place', () => {
     const timeseries = [
       {
         startPlaceContact: {
@@ -92,10 +95,12 @@ describe('computeRawMeasures', () => {
       }
     }
 
-    expect(computeRawMeasures(timeseries)).toEqual(expected)
+    expect(computeRawMeasures(timeseries)).toMatchObject({
+      sectionMeasures: expected
+    })
   })
 
-  it('should compute measures correctly for valid timeseries without start/end place', () => {
+  it('should compute section measures correctly for valid timeseries without start/end place', () => {
     const timeseries = [
       {
         aggregation: {
@@ -132,10 +137,12 @@ describe('computeRawMeasures', () => {
       }
     }
 
-    expect(computeRawMeasures(timeseries)).toEqual(expected)
+    expect(computeRawMeasures(timeseries)).toMatchObject({
+      sectionMeasures: expected
+    })
   })
 
-  it('should correctly aggregate measures', () => {
+  it('should correctly aggregate section measures', () => {
     const timeseries = [
       {
         aggregation: {
@@ -175,7 +182,57 @@ describe('computeRawMeasures', () => {
       }
     }
 
-    expect(computeRawMeasures(timeseries)).toEqual(expected)
+    expect(computeRawMeasures(timeseries)).toMatchObject({
+      sectionMeasures: expected
+    })
+  })
+
+  it('should correctly aggregate trip measures', () => {
+    const timeseries = [
+      {
+        aggregation: {
+          modes: ['car'],
+          totalCO2: 100,
+          totalDistance: 20,
+          totalDuration: 10
+        }
+      },
+      {
+        aggregation: {
+          modes: ['bike', 'walk', 'bike'],
+          totalCO2: 0,
+          totalDistance: 10,
+          totalDuration: 5
+        }
+      },
+      {
+        aggregation: {
+          modes: ['car', 'car'],
+          totalCO2: 200,
+          totalDistance: 90,
+          totalDuration: 120
+        }
+      }
+    ]
+
+    const expected = {
+      'car//none/unknown': {
+        count: 2,
+        sumCO2: 300,
+        sumDuration: 130,
+        sumDistance: 110
+      },
+      'bike:walk//none/unknown': {
+        count: 1,
+        sumCO2: 0,
+        sumDuration: 5,
+        sumDistance: 10
+      }
+    }
+
+    expect(computeRawMeasures(timeseries)).toMatchObject({
+      tripMeasures: expected
+    })
   })
 
   it('should correctly set trip direction', () => {
@@ -220,7 +277,9 @@ describe('computeRawMeasures', () => {
       'bus/Poudlard/return/1': {},
       'walk/Poudlard/round/1': {}
     }
-    expect(computeRawMeasures(timeseries)).toMatchObject(expected)
+    expect(computeRawMeasures(timeseries)).toMatchObject({
+      sectionMeasures: expected
+    })
   })
 
   it('should correctly set main mode', () => {
@@ -253,7 +312,9 @@ describe('computeRawMeasures', () => {
       'bike//none/0': {},
       'bike//none/1': {}
     }
-    expect(computeRawMeasures(timeseries)).toMatchObject(expected)
+    expect(computeRawMeasures(timeseries)).toMatchObject({
+      sectionMeasures: expected
+    })
   })
 })
 


### PR DESCRIPTION
:warning:  Relies on https://github.com/cozy/coachCO2/pull/370 that must be merged first


- Rename previous trips-* measures into sections-* measures
- Add new trips-* measures for actual trips

```
### ✨ Features

* Add new trips measures
* Rename sections measures

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
