### PR TITLE
Fix: Month selector on the trips Analytics page

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Cozy's apps use a standard set of _npm scripts_ to run common tasks, like watch,
 
 You can import fixtures to quickly deal with data.
 
+⚠️ You need to run the `timeseriesWithoutAggregateMigration` services after any insertion to make your trips usable in the app. See [below](#Aggregation_service) for more details.
+
+#### Add multiple trips
 
 Finally, run the following command to import fixtures:
 
@@ -43,7 +46,8 @@ yarn ACH import accounts/tracemob.json --url http://your_custom_url:port
 yarn ACH script timeseries/importGeojson --url http://your_custom_url:port
 ```
 
-Then you can generate a random trip by running
+#### Add single trips
+Then you can generate a random trip by running (use `--help` for more information)
 ```
 yarn scripts:addTrip
 ```
@@ -53,7 +57,7 @@ Or if you don't use the defaut `http://cozy.localhost:8080`:
 yarn script:addTrip --url http://your_custom_url:port
 ```
 
-⚠️ You need to run the `timeseriesWithoutAggregateMigration` services after any insertion to make your trips usable in the app. See [below](#Aggregation_service) for more details.
+
 
 
 ### Aggregation service

--- a/scripts/save-random-trip.js
+++ b/scripts/save-random-trip.js
@@ -1,5 +1,7 @@
+/* eslint-disable no-console */
 const { ArgumentParser } = require('argparse')
-const subSeconds = require('date-fns/subSeconds')
+const addSeconds = require('date-fns/addSeconds')
+const isValidDate = require('date-fns/isValid')
 
 const { createClientInteractive, Q } = require('cozy-client')
 
@@ -33,9 +35,15 @@ const deg2rad = deg => {
 
 const main = async () => {
   const parser = new ArgumentParser()
-  parser.addArgument('--source-account')
-  parser.addArgument('--url', { defaultValue: 'http://cozy.localhost:8080' })
-  parser.addArgument('-u', {})
+  parser.addArgument('--source-account', { help: 'Use custom source account' })
+  parser.addArgument('--url', {
+    defaultValue: 'http://cozy.localhost:8080',
+    help: 'Use custom url. Default: http://cozy.localhost:8080'
+  })
+  parser.addArgument('-u', {
+    help: 'Use custom url. Default: http://cozy.localhost:8080'
+  })
+  parser.addArgument('--date', { help: 'Add an start date. Ex.: 2024-01-01' })
   const args = parser.parseArgs()
 
   const client = await createClientInteractive({
@@ -100,8 +108,10 @@ const main = async () => {
   const durationH = distanceKm / speedKmh
   const durationS = durationH * 3600
 
-  const endDate = new Date().toISOString()
-  const startDate = subSeconds(new Date(endDate), durationS).toISOString()
+  const startDate = isValidDate(new Date(args.date))
+    ? new Date(args.date).toISOString()
+    : new Date().toISOString()
+  const endDate = addSeconds(new Date(startDate), durationS).toISOString()
 
   let sensedMode = 'PredictedModeTypes.'
   if (speedKmh < 15) {

--- a/src/components/SelectDates/helpers.js
+++ b/src/components/SelectDates/helpers.js
@@ -153,17 +153,23 @@ export const computeMonths = memoize(({ dates, selectedDate, lang }) => {
 
   // create dropdownMonths
   let monthCount = 12
-
   if (isSelectedYearSameAsLatestYear) {
     monthCount = latestDate.getMonth() + 1
   } else if (isSelectedYearSameAsEarliestYear) {
     monthCount = 12 - earliestDate.getMonth()
   }
 
+  /**
+   * In the case where there are trips only over one year `isSelectedYearSameAsEarliestYear` & `isSelectedYearSameAsLatestYear` are true.
+In this specific case we want to slice the months from the beginning.
+   */
+  const endToStart =
+    isSelectedYearSameAsEarliestYear &&
+    isSelectedYearSameAsEarliestYear !== isSelectedYearSameAsLatestYear
   const dropdownMonths = makeMonthsNameByCount({
     monthCount,
     allMonthsName,
-    endToStart: isSelectedYearSameAsEarliestYear
+    endToStart
   })
 
   // create selectedIndex


### PR DESCRIPTION
Dans le cas où il n'y a que des trajets sur une même année, les booléens `isSelectedYearSameAsEarliestYear` & `isSelectedYearSameAsLatestYear` sont vrais.
Dans ce cas précis, nous souhaitons garder les premiers mois de l'année, jusqu'au mois du dernier trajet.

```
### 🐛 Bug Fixes

* Month selector on the trips Analytics page

### 🔧 Tech

* Generate trip with custom date
```
