### PR TITLE
[DAT-29] feat: Log errors if negative values are met

### DIFF
--- a/src/lib/daccCentreValDeLoireExpe.js
+++ b/src/lib/daccCentreValDeLoireExpe.js
@@ -98,6 +98,8 @@ export const sendCentreValDeLoireMeasuresToDACC = async (client, account) => {
         Object.keys(measures.sectionMeasures).length
       } measures with user type:  ${userType}`
     )
+    logSanityChecksErrors(measures.sectionMeasures)
+
     const daccSectionMeasures = await buildDACCMeasures({
       measures: measures.sectionMeasures,
       userType,
@@ -313,6 +315,39 @@ export const computeRawMeasures = timeseries => {
     }
   }
   return { sectionMeasures, tripMeasures }
+}
+
+/**
+ * Log errors if there are sanity checks errors
+ *
+ * @param {MeasuresDict} measures - The measures to check
+ */
+const logSanityChecksErrors = measures => {
+  const errors = sanityChecks(measures)
+  for (const err of errors) {
+    logService('error', err)
+  }
+}
+
+/**
+ * Perform sanity checks on measures
+ * @param {MeasuresDict} measures - The measures to check
+ *
+ * @returns {Array<string>} the errors message
+ */
+export const sanityChecks = measures => {
+  const sanityErrors = []
+  for (const key of Object.keys(measures)) {
+    const measure = measures[key]
+
+    for (const agg in measure) {
+      if (measure[agg] < 0) {
+        const msg = `Error: Negative value found: ${agg}: ${measure[agg]}`
+        sanityErrors.push(msg)
+      }
+    }
+  }
+  return sanityErrors
 }
 
 const buildConsentMeasure = userType => {

--- a/src/lib/daccCentreValDeLoireExpe.spec.js
+++ b/src/lib/daccCentreValDeLoireExpe.spec.js
@@ -1,7 +1,8 @@
 import {
   GROUP_ID,
   computeRawMeasures,
-  getMainModeFromSections
+  getMainModeFromSections,
+  sanityChecks
 } from './daccCentreValDeLoireExpe'
 
 describe('computeRawMeasures', () => {
@@ -335,5 +336,22 @@ describe('getMainModeFromSections', () => {
   it('should handle a single section', () => {
     const sections = [{ mode: 'walk', distance: 20 }]
     expect(getMainModeFromSections(sections)).toBe('walk')
+  })
+})
+
+describe('sanity checks', () => {
+  it('should return an error when negative values are met', () => {
+    const measures = {
+      1: { count: -1, sumCO2: -10, sumDuration: 10 }
+    }
+    const errors = sanityChecks(measures)
+    expect(errors.length).toEqual(2)
+  })
+  it('should return nothing when nothing wrong', () => {
+    const measures = {
+      1: { count: 1, sumCO2: 10, sumDuration: 10 }
+    }
+    const errors = sanityChecks(measures)
+    expect(errors.length).toEqual(0)
   })
 })


### PR DESCRIPTION
We noticed a case of negative values on the DACC side. To better understand, we add some logs when such
data is met.



```
### ✨ Features

* Add error logs when negative values are met on DACC service

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
