### PR TITLE
fix: The arrow filter must ignore multiple occurrences of the same month

### DIFF
--- a/src/components/SelectDates/SelectDates.jsx
+++ b/src/components/SelectDates/SelectDates.jsx
@@ -1,5 +1,4 @@
 import cx from 'classnames'
-import isEqual from 'date-fns/isEqual'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
 import DropdownMenuButton from 'src/components/SelectDates/DropdownMenuButton'
@@ -7,7 +6,9 @@ import {
   computeMonths,
   computeYears,
   makeNewDate,
-  isDisableNextPreviousButton
+  isDisableNextPreviousButton,
+  getUniqueDatePerMonth,
+  getNewDateByStep
 } from 'src/components/SelectDates/helpers'
 
 import Box from 'cozy-ui/transpiled/react/Box'
@@ -72,16 +73,19 @@ const SelectDates = ({ className, options, selectedDate, setSelectedDate }) => {
     setSelectedDate(newDate)
   }
 
-  const handleIconButtonClick = n => () => {
-    setSelectedDate(date => {
-      const curr = options.findIndex(opt => isEqual(opt, date))
-      const newDate = curr !== -1 ? options[curr + n] : null
+  const uniqueDatesPerMonth = useMemo(
+    () => getUniqueDatePerMonth(options),
+    [options]
+  )
 
-      if (newDate) {
-        return new Date(newDate.setMonth(newDate.getMonth()))
-      }
-      return date
-    })
+  const handleIconButtonClick = n => () => {
+    setSelectedDate(date =>
+      getNewDateByStep({
+        dates: uniqueDatesPerMonth,
+        currentDate: date,
+        step: n
+      })
+    )
   }
 
   const isDisabledIconButton = type =>

--- a/src/components/SelectDates/helpers.js
+++ b/src/components/SelectDates/helpers.js
@@ -1,5 +1,9 @@
 import memoize from 'lodash/memoize'
 
+import minilog from 'cozy-minilog'
+
+const log = minilog('components/SelectDates/helpers')
+
 /**
  * Returns an array of the names of all the months of the year
  * @param {string} lang - The language to be used (fr, en, etc.)
@@ -282,4 +286,50 @@ export const isDisableNextPreviousButton = ({
   }
 
   return false
+}
+
+/**
+ * @param {Date[]} dates - List of dates
+ * @returns {Date[]} - List of unique dates per month
+ */
+export const getUniqueDatePerMonth = dates => {
+  return dates.reduce((acc, curr) => {
+    const alreadyExists = acc.find(
+      date =>
+        date.getMonth() === curr.getMonth() &&
+        date.getFullYear() === curr.getFullYear()
+    )
+    if (!alreadyExists) acc.push(curr)
+    return acc
+  }, [])
+}
+
+/**
+ * Returns the new date according to the step
+ * @param {object} params
+ * @param {Date[]} params.dates - List of dates
+ * @param {Date} params.currentDate - The current date
+ * @param {number} params.step - The step to apply to the current date
+ * @returns {Date} - The new date
+ */
+export const getNewDateByStep = ({ dates, currentDate, step }) => {
+  const currentDateIndex = dates.findIndex(
+    opt =>
+      opt.getMonth() === currentDate.getMonth() &&
+      opt.getFullYear() === currentDate.getFullYear()
+  )
+
+  if (currentDateIndex === -1) {
+    log.error(`Date ${currentDate} not found in ${dates}`)
+    return currentDate
+  }
+
+  const newDate = dates[currentDateIndex + step]
+
+  if (newDate === undefined) {
+    log.error(`Index ${currentDateIndex + step} doesn't exist in ${dates}`)
+    return currentDate
+  }
+
+  return new Date(newDate.setMonth(newDate.getMonth()))
 }

--- a/src/components/SelectDates/helpers.spec.js
+++ b/src/components/SelectDates/helpers.spec.js
@@ -10,7 +10,9 @@ import {
   makeMonthsNameByCount,
   computeMonths,
   makeNewDate,
-  isDisableNextPreviousButton
+  isDisableNextPreviousButton,
+  getUniqueDatePerMonth,
+  getNewDateByStep
 } from './helpers'
 
 describe('makeAllMonthsName', () => {
@@ -308,5 +310,62 @@ describe('isDisableNextPreviousButton', () => {
         options: dates
       })
     ).toBe(true)
+  })
+})
+
+describe('getUniqueDatePerMonth', () => {
+  it('should return the unique dates per month', () => {
+    const dates = [
+      new Date('2022-01'),
+      new Date('2022-02'),
+      new Date('2022-02'),
+      new Date('2022-03'),
+      new Date('2022-03'),
+      new Date('2022-03')
+    ]
+
+    const result = getUniqueDatePerMonth(dates)
+
+    expect(result).toStrictEqual([
+      new Date('2022-01'),
+      new Date('2022-02'),
+      new Date('2022-03')
+    ])
+  })
+})
+
+describe('getNewDateByStep', () => {
+  it('should return the next date', () => {
+    const dates = [
+      new Date('2022-01'),
+      new Date('2022-04'),
+      new Date('2022-06')
+    ]
+    const currentDate = new Date('2022-01')
+    const result = getNewDateByStep({ step: 1, dates, currentDate })
+
+    expect(result).toEqual(new Date('2022-04'))
+  })
+  it('should return the previous date', () => {
+    const dates = [
+      new Date('2022-01'),
+      new Date('2022-04'),
+      new Date('2022-06')
+    ]
+    const currentDate = new Date('2022-06')
+    const result = getNewDateByStep({ step: -1, dates, currentDate })
+
+    expect(result).toEqual(new Date('2022-04'))
+  })
+  it('should return the current date if step is outside', () => {
+    const dates = [
+      new Date('2022-01'),
+      new Date('2022-04'),
+      new Date('2022-06')
+    ]
+    const currentDate = new Date('2022-06')
+    const result = getNewDateByStep({ step: 10, dates, currentDate })
+
+    expect(result).toEqual(currentDate)
   })
 })


### PR DESCRIPTION
Added a log if no date is found, because that shouldn't happen.