### PR TITLE
chore: Add token for openpath account

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ yarn script:addTrip --url http://your_custom_url:port
 ```
 
 #### Add single account
-This script allows you to add a tracemob or openpath type account (use `--help` for more information)
+This script allows you to add a tracemob or openpath type account
+
+For openpath account you can specify a custom token. Specify a token set the `--source-account` option to `openpath`. (use `--help` for more information)
 
 ```
 yarn scripts:addAccount [-l, --login] <login>

--- a/scripts/accounts-fixtures.js
+++ b/scripts/accounts-fixtures.js
@@ -1,0 +1,26 @@
+const crypto = require('crypto')
+
+const { ACCOUNTS_DOCTYPE } = require('./helpers')
+
+module.exports = ({ accountType, login, token }) => {
+  const isOpenpathAccount = accountType === 'openpath'
+  return {
+    _type: ACCOUNTS_DOCTYPE,
+    _id: crypto.randomBytes(16).toString('hex'),
+    account_type: accountType,
+    auth: {
+      ...(!isOpenpathAccount && {
+        credentials_encrypted: crypto.randomBytes(16).toString('hex')
+      }),
+      login,
+      providerId: '0'
+    },
+    ...(isOpenpathAccount && { token }),
+    data: {
+      lastSavedManualDate: new Date().toISOString(),
+      lastSavedTripDate: new Date('2024-01-10').toISOString()
+    },
+    identifier: 'login',
+    state: null
+  }
+}

--- a/scripts/save-account.js
+++ b/scripts/save-account.js
@@ -5,6 +5,7 @@ const { ArgumentParser } = require('argparse')
 
 const { createClientInteractive } = require('cozy-client')
 
+const makeAccount = require('./accounts-fixtures')
 const {
   ACCOUNTS_DOCTYPE,
   ACCOUNT_TYPES,
@@ -23,6 +24,9 @@ const main = async () => {
     required: true,
     help: 'Use custom account login'
   })
+  parser.add_argument('-t', '--token', {
+    help: 'Use custom account token (force openpath account)'
+  })
   parser.add_argument('-u', '--url', {
     default: 'http://cozy.localhost:8080',
     help: 'Use custom url. Default: http://cozy.localhost:8080'
@@ -38,23 +42,18 @@ const main = async () => {
     }
   })
 
-  const accountType = ACCOUNT_TYPES[crypto.randomInt(0, ACCOUNT_TYPES.length)]
-  const account = {
-    _type: ACCOUNTS_DOCTYPE,
-    _id: crypto.randomBytes(16).toString('hex'),
-    account_type: args.account_type || accountType,
-    auth: {
-      credentials_encrypted: crypto.randomBytes(16).toString('hex'),
-      login: args.login,
-      providerId: '0'
-    },
-    data: {
-      lastSavedManualDate: new Date().toISOString(),
-      lastSavedTripDate: new Date('2024-01-10').toISOString()
-    },
-    identifier: 'login',
-    state: null
-  }
+  const accountType = args.token
+    ? 'openpath'
+    : args.account_type ||
+      ACCOUNT_TYPES[crypto.randomInt(0, ACCOUNT_TYPES.length)]
+
+  const token = args.token || crypto.randomBytes(16).toString('hex')
+
+  const account = makeAccount({
+    accountType,
+    login: args.login,
+    token
+  })
 
   await client.save(account)
   console.log(


### PR DESCRIPTION
```
### 🔧 Tech

* For `openpath` account you can specify a custom token. Specify a token set the `--source-account` option to `openpath`
```
