### PR TITLE
[DAT-18] feat: Compute geojson aggregation in fetch service

### DIFF
--- a/src/lib/openpath/lib.spec.js
+++ b/src/lib/openpath/lib.spec.js
@@ -53,13 +53,15 @@ describe('konnector', () => {
         properties: {
           distance: 100,
           start_fmt_time: '2021-02-01T12:00'
-        }
+        },
+        features: []
       },
       {
         properties: {
           distance: 50,
           start_fmt_time: '2021-02-01T14:00'
-        }
+        },
+        features: []
       }
     ]
     const fullTripsDay2 = [
@@ -67,7 +69,8 @@ describe('konnector', () => {
         properties: {
           distance: 200,
           start_fmt_time: '2021-02-02T12:00'
-        }
+        },
+        features: []
       }
     ]
 

--- a/src/lib/openpath/normalizeData.js
+++ b/src/lib/openpath/normalizeData.js
@@ -1,0 +1,59 @@
+import { GEOJSON_DOCTYPE } from 'src/doctypes'
+import { initPolyglot } from 'src/lib/services'
+import { computeAggregatedTimeseries } from 'src/lib/timeseries'
+import { getSectionsFromTrip } from 'src/lib/trips'
+import { buildSettingsQuery } from 'src/queries/queries'
+
+const { t } = initPolyglot()
+
+/**
+ * @typedef {import("cozy-client/dist/index").CozyClient} CozyClient
+ * @typedef {import('./types').TimeseriesGeoJSON} TimeseriesGeoJSON
+ * @typedef {import('./types').RawGeoJSON} RawGeoJSON
+ */
+
+/**
+ * Normalize trips to timeseries
+ *
+ * @typedef {object} Params
+ * @property {string} device - The capturing device
+ *
+ * @param {Cozyclient} client - The cozy client instance
+ * @param {RawGeoJSON>} trips - The trip to normalize
+ * @param {Params} params - Additional params
+ * @returns {Array<TimeseriesGeoJSON>} the normalized timeseries
+ */
+export const normalizeTrips = async (client, trips, { device }) => {
+  const settingsQuery = buildSettingsQuery()
+  const { data: settings } = await client.query(
+    settingsQuery.definition,
+    settingsQuery.options
+  )
+  const appSetting = settings?.[0] || {}
+
+  const timeseries = trips.map(trip => {
+    const startDate = trip.properties.start_fmt_time
+    const endDate = trip.properties.end_fmt_time
+    return {
+      _type: GEOJSON_DOCTYPE,
+      series: [trip],
+      startDate,
+      endDate,
+      source: 'cozy.io',
+      captureDevice: device
+    }
+  })
+
+  const makeSections = timeserie => {
+    const serie = timeserie.series[0]
+    return getSectionsFromTrip(serie, appSetting)
+  }
+
+  const normalizedTimeseries = computeAggregatedTimeseries({
+    timeseries,
+    makeSections,
+    t
+  })
+
+  return normalizedTimeseries
+}

--- a/src/lib/openpath/openpath.js
+++ b/src/lib/openpath/openpath.js
@@ -96,7 +96,7 @@ export const fetchTrips = async (client, account) => {
       return
     }
   } catch (err) {
-    logService.error('Error during execution: ', err.message)
+    logService('error', 'Error during execution: ', err.message)
     return
   }
 }

--- a/src/lib/openpath/queries.js
+++ b/src/lib/openpath/queries.js
@@ -16,12 +16,12 @@ export const queryAccountByToken = async (client, token) => {
   return account && account.data?.length > 0 ? account.data[0] : null
 }
 
-export const queryTripsByRange = async (
+export const queryTimeseriesByRange = async (
   client,
-  { trips, accountId, limit = 100 }
+  { timeseries, accountId, limit = 100 }
 ) => {
-  const firstDate = trips[0].properties.start_fmt_time
-  const lastDate = trips[trips.length - 1].properties.start_fmt_time
+  const firstDate = timeseries[0].startDate
+  const lastDate = timeseries[timeseries.length - 1].startDate
   const query = buildTimeseriesByDateRange({
     firstDate,
     lastDate,

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -21,14 +21,51 @@
  * @property {Date} endDate - The timeserie end date
  * @property {string} source - The source of the timeserie 
  * @property {Aggregation} aggregation - The aggregation of the timeserie, describing the trip
- * @property {Array<object>} series - The actual GeoJSON content
+ * @property {Array<RawGeoJSON>} series - The actual GeoJSON content
  *
+ * 
+ * 
 
+/**
+ * The GeoJSON raw content. 
+ * 
+ * @typedef {object} RawGeoJSON
+ * @property {string} type - Always "FeatureCollection"
+ * @property {GeoJSONProperties} properties - Trip properties
+ * @property {Array<GeoJSONFeature>} features - Trip features
+ */
+
+/**
+ * GeoJSON properties
+ *
+ * @typedef {object} GeoJSONProperties
+ * @property {string} start_fmt_time - The trip starting date
+ * @property {string} end_fmt_time - The trip ending date
+ * @property {number} duration - Trip duration
+ * @property {number} distance - Trip distance
+ * @property {object} start_loc - Trip starting location
+ * @property {object} end_loc - Trip ending location
+ * @property {object} start_place - Trip start place id - internal to openpath
+ * @property {object} end_place - Trip end place id - internal to openpath
+ * @property {number} confidence_threshold - Trip confidence
+ * @property {number} manual_purpose - Manual purpose set by the user - not used
+ * @property {number} automatic_purpose - Automatic purpose computed by openpath - not used
+ */
+
+/**
+ * GeoJSON features
+ *
+ * @typedef {object} GeoJSONFeature
+ * @property {string} type - "Feature" or "FeatureCollection"
+ * @property {object} geometry - The feature geometry
+ * @property {string} id - The feature id - internal to openpath
+ * @property {object} properties - Feature properties
+ */
 
 /**
  * The timeseries aggregation. It is used as a summarization that can be queried
  * more easily than the series geoJSON.
- * 
+ *
  * @typedef {object} Aggregation
  * @property {string} purpose - The trip purpose
  * @property {Array<string>} modes - All the transportation modes used for this trip
@@ -38,9 +75,9 @@
  * @property {number} totalCalories - The total calories for this trip
  * @property {number} totalDistance - The total distance for this trip
  * @property {number} totalDuration - The total duration for this trip
- * @property {object} coordinates - The coordinates of the trip 
- * @property {Array<Section>} sections - The section details of the trip 
- *  
+ * @property {object} coordinates - The coordinates of the trip
+ * @property {Array<Section>} sections - The section details of the trip
+ *
  */
 
 /**

--- a/src/targets/services/timeseriesWithoutAggregateMigration.js
+++ b/src/targets/services/timeseriesWithoutAggregateMigration.js
@@ -64,8 +64,10 @@ const migrateTimeSeriesWithoutAggregation = async () => {
     await client.save(timeserie)
   }
 
+  // This service should eventually disappear, so let's add a warning when
+  // it was actually useful
   logService(
-    'info',
+    'warn',
     `${migratedTimeseries.length} timeseries migrated with aggregation`
   )
 }


### PR DESCRIPTION
We used to rely on the `timeseriesWithoutAggregation` service in order to compute the `aggregation` block. This service is run after a geojson creation, with 1min debounce.
This is not ideal because it is an async operation, which mean that some timeseries can exist without the `aggregation`, forcing the app to adapt queries and checks to guarantee its existence.

As the trips are now fetched through a coachco2 service (and not from an external konnector), we can now compute this `aggregation` before saving the trips.
This users will see their trips faster (better UX), and eventually we won't have to check for this block existence anymore (better DX).



```
### ✨ Features

* Normalize trips as soon as they are fetched

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
