### PR TITLE
fix: Sentry issue

### DIFF
--- a/src/targets/browser/setupApp.jsx
+++ b/src/targets/browser/setupApp.jsx
@@ -30,8 +30,7 @@ const setupApp = memoize(() => {
       new Sentry.BrowserTracing()
     ],
     tracesSampleRate: 1,
-    // React log these warnings(bad Proptypes), in a console.error, it is not relevant to report this type of information to Sentry
-    ignoreErrors: [/^Warning: /]
+    defaultIntegrations: false
   })
 
   initBar({ client, container, lang, appName })


### PR DESCRIPTION
By default `InboundFilters` is enabled and ignore
errors that start with Script error or
Javascript error: Script error.

https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/inboundfilters/

So there were no errors in Sentry. I disable all
the `defaultIntegrations` in order to not have any filter.

I saw this, by adding `debug:true` to the Sentry
config object, so I had message like
"Event droped due to being matched by ignoreErrors options"



```

### 🔧 Tech

* Errors are now sent to sentry
```

I know that I removed the ignore stuff that we had before, but we need to get errors on sentry ASAP. I didn't have the time to fine tune it yet. 