### PR TITLE
fix: Querying all trips from all accounts

### DIFF
--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -33,19 +33,10 @@ export const buildAggregatedTimeseriesQuery = ({ limit } = {}) => ({
         $exists: true
       }
     })
-    .select([
-      'cozyMetadata.sourceAccount',
-      'startDate',
-      'endDate',
-      'title',
-      'aggregation'
-    ])
-    .indexFields(['cozyMetadata.sourceAccount', 'startDate', 'endDate'])
-    .sortBy([
-      { 'cozyMetadata.sourceAccount': 'desc' },
-      { startDate: 'desc' },
-      { endDate: 'desc' }
-    ])
+    .select(['startDate', 'endDate', 'title', 'aggregation'])
+    // FIXME "endDate" should be removed when https://github.com/cozy/cozy-client/issues/1216 fixed
+    .indexFields(['startDate', 'endDate'])
+    .sortBy([{ startDate: 'desc' }])
     .limitBy(limit),
   options: {
     as: `${GEOJSON_DOCTYPE}/limitedBy/${limit}`,


### PR DESCRIPTION
This query should not sort the accounts, because since there is a limitBy, we can run into a case where we don't see all the latest trips.
The presence in the .select is not necessary either.