### PR TITLE
feat: Show a modal when location service is disabled when enabling location tracking on iOS 

### DIFF
--- a/src/components/GeolocationTracking/LocationDisabledDialog.jsx
+++ b/src/components/GeolocationTracking/LocationDisabledDialog.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
+
+export const LocationDisabledDialog = ({ onClose }) => {
+  const { t } = useI18n()
+
+  return (
+    <ConfirmDialog
+      open
+      title={t('geolocationTracking.locationDisabledDialog.title')}
+      content={t('geolocationTracking.locationDisabledDialog.description')}
+      actions={<Button label="OK" onClick={onClose} />}
+      onClose={onClose}
+    />
+  )
+}

--- a/src/components/GeolocationTracking/helpers.js
+++ b/src/components/GeolocationTracking/helpers.js
@@ -7,9 +7,12 @@ import {
 
 import { isFlagshipApp } from 'cozy-device-helper'
 import flag from 'cozy-flags'
+import minilog from 'cozy-minilog'
 import { getRandomUUID } from 'cozy-ui/transpiled/react/helpers/getRandomUUID'
 
 const FEATURE_NAME = 'geolocationTracking'
+
+const log = minilog('GeolocationTracking')
 
 export const createOpenPathAccount = async ({
   client,
@@ -157,25 +160,34 @@ export const checkPermissionsAndEnableTrackingOrShowDialog = async ({
   permissions,
   webviewIntent,
   setShowLocationRequestableDialog,
-  setShowLocationRefusedDialog
+  setShowLocationRefusedDialog,
+  setShowLocationDisabledDialog
 }) => {
-  const checkedPermissions =
-    permissions ||
-    (await webviewIntent?.call('checkPermissions', 'geolocationTracking')) ||
-    {}
+  try {
+    const checkedPermissions =
+      permissions ||
+      (await webviewIntent?.call('checkPermissions', 'geolocationTracking')) ||
+      {}
 
-  if (checkedPermissions.granted) {
-    await enableGeolocationTracking({
-      client,
-      lang,
-      t,
-      webviewIntent,
-      setIsGeolocationTrackingEnabled
-    })
-  } else if (checkedPermissions.canRequest) {
-    setShowLocationRequestableDialog(true)
-  } else {
-    setShowLocationRefusedDialog(true)
+    if (checkedPermissions.granted) {
+      await enableGeolocationTracking({
+        client,
+        lang,
+        t,
+        webviewIntent,
+        setIsGeolocationTrackingEnabled
+      })
+    } else if (checkedPermissions.canRequest) {
+      setShowLocationRequestableDialog(true)
+    } else {
+      setShowLocationRefusedDialog(true)
+    }
+  } catch (e) {
+    if (e.message === 'Native permission unavailable') {
+      setShowLocationDisabledDialog(true)
+    } else {
+      log.error(e)
+    }
   }
 }
 
@@ -207,7 +219,8 @@ export const getNewPermissionAndEnabledTrackingOrShowDialog = async ({
   t,
   setIsGeolocationTrackingEnabled,
   setShowLocationRequestableDialog,
-  setShowLocationRefusedDialog
+  setShowLocationRefusedDialog,
+  setShowLocationDisabledDialog
 }) => {
   const permissions = await webviewIntent?.call(
     'requestPermissions',
@@ -221,6 +234,7 @@ export const getNewPermissionAndEnabledTrackingOrShowDialog = async ({
     permissions,
     webviewIntent,
     setShowLocationRequestableDialog,
-    setShowLocationRefusedDialog
+    setShowLocationRefusedDialog,
+    setShowLocationDisabledDialog
   })
 }

--- a/src/components/Providers/GeolocationTrackingProvider.jsx
+++ b/src/components/Providers/GeolocationTrackingProvider.jsx
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useMemo
 } from 'react'
+import { LocationDisabledDialog } from 'src/components/GeolocationTracking/LocationDisabledDialog'
 import {
   disableGeolocationTracking,
   enableGeolocationTracking,
@@ -50,6 +51,8 @@ export const GeolocationTrackingProvider = ({ children }) => {
     useState(false)
   const [showLocationRefusedDialog, setShowLocationRefusedDialog] =
     useState(false)
+  const [showLocationDisabledDialog, setShowLocationDisabledDialog] =
+    useState(false)
 
   useEffect(() => {
     checkAndSetGeolocationTrackingAvailability(
@@ -94,7 +97,8 @@ export const GeolocationTrackingProvider = ({ children }) => {
           setIsGeolocationTrackingEnabled,
           webviewIntent,
           setShowLocationRequestableDialog,
-          setShowLocationRefusedDialog
+          setShowLocationRefusedDialog,
+          setShowLocationDisabledDialog
         })
     }),
     [
@@ -129,7 +133,8 @@ export const GeolocationTrackingProvider = ({ children }) => {
                 t,
                 setIsGeolocationTrackingEnabled,
                 setShowLocationRequestableDialog,
-                setShowLocationRefusedDialog
+                setShowLocationRefusedDialog,
+                setShowLocationDisabledDialog
               })
             } else {
               await enableGeolocationTracking({
@@ -159,6 +164,13 @@ export const GeolocationTrackingProvider = ({ children }) => {
           description={t(
             'geolocationTracking.locationRefusedDialog.description'
           )}
+        />
+      )}
+      {showLocationDisabledDialog && (
+        <LocationDisabledDialog
+          onClose={() => {
+            setShowLocationDisabledDialog(false)
+          }}
         />
       )}
     </GeolocationTrackingContext.Provider>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -337,6 +337,10 @@
     "locationRefusedDialog": {
       "description": "Your Cozy needs access to additional data in order to help you analyze your movements. This data will NEVER be transmitted to anyone without your explicit request.\n\nYou will be redirected to the app's settings to authorize it to ALWAYS access your phone's position, even when the app is not in use, and PHYSICAL ACTIVITY, movement and shape data.."
     },
+    "locationDisabledDialog": {
+      "title": "Enable location service",
+      "description": "To record your movements, you must first enable location services in Settings > Privacy and security > Location service."
+    },
     "settings": {
       "enable": "Record my movements with my mobile (GPS)",
       "sendLogs": "Send my logs to support",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -339,6 +339,10 @@
     "locationRefusedDialog": {
       "description": "Votre Cozy a besoin d'accéder à des données supplémentaires afin de vous aider à analyser vos déplacements. Elles ne seront JAMAIS transmises à qui que ce soit sans votre demande explicite.\n\nVous allez être redirigé vers les paramètres de l'app afin de l'autoriser à TOUJOURS accéder à la position de votre téléphone, donc aussi lorsque l'app n'est pas utilisée, et au données d'ACTIVITÉ PHYSIQUE, mouvements et formes."
     },
+    "locationDisabledDialog": {
+      "title": "Activez les services de localisation",
+      "description": "Pour enregistrer vos déplacements, vous devez d'abord activer les services de localisation dans Paramètres > Confidentialité et sécurité > Service de localisation."
+    },
     "settings": {
       "enable": "Enregistrer mes déplacements avec mon mobile (GPS)",
       "sendLogs": "Envoyer mes logs au support",


### PR DESCRIPTION
When we ask location permissions and location service is disabled, flagship app throw an "Native permission unavailable" on iOS only. We catch this error and show a simple modal asking to enable location service.

We also log other errors here.

```
### 🐛 Bug Fixes

* Show a modal when location service is disabled when enabling location tracking on iOS 

```
