### PR TITLE
fix: The export must also have the modes chosen manually

### DIFF
--- a/src/lib/trips.js
+++ b/src/lib/trips.js
@@ -22,14 +22,16 @@ export const getEndPlaceDisplayName = trip => {
 
 /**
  * Returns the mode of a feature
+ * manual mode is created when the user edit the feature mode manualy
  * sensed mode is created by the prediction algorithm
  * default mode is created by the user in the settings of mode, if defined it takes priority over sensed mode
  * @param {object} feature - The feature from a section
  * @param {object} appSetting - The app settings
- * @returns The feature's mode depending on whether it has been changed manually
+ * @returns The mode used in the following priority: manual / default / sensed / unknown
  */
 export const getFeatureMode = (feature, appSetting) => {
   const { defaultTransportModeByGroup } = appSetting || {}
+  const manualMode = get(feature, 'properties.manual_mode', '').toUpperCase()
   const sensedOriginalMode = get(
     feature,
     'properties.sensed_mode',
@@ -40,12 +42,14 @@ export const getFeatureMode = (feature, appSetting) => {
     sensedOriginalMode.split('PREDICTEDMODETYPES.')[1] ||
     sensedOriginalMode.split('MOTIONTYPES.')[1]
   const isSupportedSensedMode = modes.includes(sensedMode)
+  const isSupportedManualMode = modes.includes(manualMode)
 
   const defaultMode = modes.find(
     mode => defaultTransportModeByGroup?.[modeToCategory(sensedMode)] === mode
   )
 
   return (
+    (isSupportedManualMode && manualMode) ||
     (!!defaultMode && defaultMode) ||
     (isSupportedSensedMode && sensedMode) ||
     UNKNOWN_MODE

--- a/src/lib/trips.spec.js
+++ b/src/lib/trips.spec.js
@@ -65,6 +65,50 @@ describe('getSectionsFromTrip', () => {
 })
 
 describe('getFeatureMode', () => {
+  it('should return the manual mode if present', () => {
+    const result = getFeatureMode(
+      {
+        properties: {
+          manual_mode: 'BICYCLING',
+          sensed_mode: 'PredictedModeTypes.CAR'
+        }
+      },
+      {
+        defaultTransportModeByGroup: { BICYCLING_CATEGORY: 'SCOOTER_ELECTRIC' }
+      }
+    )
+
+    expect(result).toBe('BICYCLING')
+  })
+
+  it('should return the sensed mode if no manual mode', () => {
+    const result = getFeatureMode(
+      {
+        properties: {
+          manual_mode: undefined,
+          sensed_mode: 'PredictedModeTypes.CAR'
+        }
+      },
+      {
+        defaultTransportModeByGroup: undefined
+      }
+    )
+    expect(result).toBe('CAR')
+  })
+
+  it('should return the default mode for undefined manual, sensed and default mode', () => {
+    const result = getFeatureMode(
+      {
+        properties: { manual_mode: undefined, sensed_mode: undefined }
+      },
+      {
+        defaultTransportModeByGroup: undefined
+      }
+    )
+
+    expect(result).toBe('UNKNOWN')
+  })
+
   it('should return the default mode if sensed mode is same category', () => {
     const result = getFeatureMode(
       {


### PR DESCRIPTION
In a past commit we removed the condition on manual mode in the `getFeatureMode` function. (see c2c2ad0)

Today we need this condition because `getFeatureMode` is also used by the Export function.

Without this condition, the latter exports the trips without looking at the changes made by the user in the meantime.

```
### 🐛 Bug Fixes

* The export must also have the modes chosen manually
```
