### PR TITLE
[DAT-10] feat: Request openpath purge after fetch 

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -274,6 +274,7 @@ export const DACC_MONTHLY_CO2_SERVICE_NAME = 'daccMonthlyCO2'
 export const DACC_BIKE_GOAL_SERVICE_NAME = 'daccBikeGoal'
 export const MAX_DACC_MEASURES_SENT = 12
 
+export const FETCH_TRIPS_SERVICE_NAME = 'fetchOpenPathTrips'
 export const RECURRING_PURPOSES_SERVICE_NAME = 'recurringPurposes'
 // Maximum distance ratio gap between trips to be considered as similar
 export const TRIPS_DISTANCE_SIMILARITY_RATIO = 0.1

--- a/src/lib/openpath/lib.js
+++ b/src/lib/openpath/lib.js
@@ -52,11 +52,14 @@ export const fetchTripsMetadata = async (
 /**
  * Fetch and save trips from a trace server
  *
+ * @typedef FetchResult
+ * @property {number} savedCount - The number of saved trips
+ * @property {string} lastSavedTripDate - The last saved trip date
+ *
  * @param {string} token - The user token
  * @param {Array<OpenPathTrip>} tripsMetadata - The trips metadata to fetch
  * @param {object} option - The options
-
- * @returns {Promise<string| null>} The date of the last saved trip
+ * @returns {Promise<FetchResult>} The fetching results
  */
 export const fetchAndSaveTrips = async (
   client,
@@ -96,7 +99,7 @@ export const fetchAndSaveTrips = async (
     }
   }
   if (fetchedTrips.length < 1) {
-    return null
+    return { savedCount: 0, lastSavedTripDate: null }
   }
 
   log.info(`${fetchedTrips.length} trips fetched`)
@@ -104,6 +107,11 @@ export const fetchAndSaveTrips = async (
   const tripsToSave = await normalizeTrips(client, fetchedTrips, {
     device
   })
-  await saveTrips(client, tripsToSave, { accountId })
-  return tripsMetadata[tripsMetadata.length - 1].metadata.write_fmt_time
+  const savedCount = await saveTrips(client, tripsToSave, { accountId })
+  const lastSavedTripDate =
+    savedCount > 0
+      ? tripsMetadata[tripsMetadata.length - 1].metadata.write_fmt_time
+      : null
+
+  return { savedCount, lastSavedTripDate }
 }

--- a/src/lib/openpath/lib.spec.js
+++ b/src/lib/openpath/lib.spec.js
@@ -1,6 +1,7 @@
 import { createMockClient } from 'cozy-client'
 
 import { fetchAndSaveTrips } from './lib'
+import { saveTrips } from './save'
 import { getTripsForDay } from './traceRequests.js'
 
 jest.mock('./save', () => ({
@@ -18,6 +19,7 @@ const token = 'fake-token'
 describe('konnector', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.spyOn(mockClient, 'query').mockResolvedValue({ data: [{}] })
   })
 
   it('should correctly fetch trips', async () => {
@@ -77,7 +79,8 @@ describe('konnector', () => {
     getTripsForDay.mockResolvedValueOnce(fullTripsDay1)
     getTripsForDay.mockResolvedValueOnce(fullTripsDay2)
 
-    const lastTripDate = await fetchAndSaveTrips(
+    saveTrips.mockResolvedValueOnce(3)
+    const { savedCount, lastSavedTripDate } = await fetchAndSaveTrips(
       mockClient,
       token,
       mockedTrips,
@@ -90,6 +93,7 @@ describe('konnector', () => {
     expect(getTripsForDay).toHaveBeenNthCalledWith(1, token, '2021-02-01')
     expect(getTripsForDay).toHaveBeenNthCalledWith(2, token, '2021-02-02')
 
-    expect(lastTripDate).toBe('2021-03-01T12:00:02')
+    expect(savedCount).toEqual(3)
+    expect(lastSavedTripDate).toEqual('2021-03-01T12:00:02')
   })
 })

--- a/src/lib/openpath/normalizeData.js
+++ b/src/lib/openpath/normalizeData.js
@@ -19,7 +19,7 @@ const { t } = initPolyglot()
  * @property {string} device - The capturing device
  *
  * @param {Cozyclient} client - The cozy client instance
- * @param {RawGeoJSON>} trips - The trip to normalize
+ * @param {RawGeoJSON} trips - The trip to normalize
  * @param {Params} params - Additional params
  * @returns {Array<TimeseriesGeoJSON>} the normalized timeseries
  */

--- a/src/lib/openpath/openpath.js
+++ b/src/lib/openpath/openpath.js
@@ -1,7 +1,11 @@
+import subDays from 'date-fns/subDays'
 import { TRIPS_CHUNK_SIZE } from 'src/constants'
 import { fetchAndSaveTrips, fetchTripsMetadata } from 'src/lib/openpath/lib'
 import { saveAccountData } from 'src/lib/openpath/save'
-import { getFirstAndLastTripTimestamp } from 'src/lib/openpath/traceRequests'
+import {
+  getFirstAndLastTripTimestamp,
+  requestOpenPathPurge
+} from 'src/lib/openpath/traceRequests'
 import {
   canSaveNextTripsChunk,
   restartService,
@@ -11,6 +15,12 @@ import {
 import logger from 'cozy-logger'
 
 const logService = logger.namespace('services/openpath')
+
+/**
+ * @typedef {import("cozy-client/dist/index").CozyClient} CozyClient
+ * @typedef {import("cozy-client/types/types").IoCozyAccount} IoCozyAccount
+ * @typedef {import('./types').TimeseriesGeoJSON} TimeseriesGeoJSON
+ */
 
 const getTimeout = () => {
   const maxExecutionTimeSeconds = parseInt(
@@ -22,81 +32,99 @@ const getTimeout = () => {
 
 const startExecTime = new Date()
 
-export const fetchTrips = async (client, account) => {
+const isFirstRun = account => {
+  return !account.data?.lastSavedTripDate
+}
+
+/**
+ * Get the fetching starting date
+ * @param {IoCozyAccount} account - The account to fetch
+ * @returns {Date} - The starting date
+ */
+export const getStartingDate = async account => {
+  const lastSavedTripDate = account.data?.lastSavedTripDate
+  if (lastSavedTripDate) {
+    return new Date(lastSavedTripDate)
+  }
+  const timestamps = await getFirstAndLastTripTimestamp(account.token)
+  if (!timestamps.start_ts || !timestamps.end_ts) {
+    return null
+  }
+  return new Date(timestamps.start_ts * 1000)
+}
+
+/**
+ * Fetch trips from an openpath server
+ *
+ * @param {CozyClient} client - The cozy client instance
+ * @param {IoCozyAccount} account  - The account to fetch
+ * @param {Date} startDate - The date to start the fetching
+ * @returns {number} The number of trips actually saved
+ */
+export const fetchTrips = async (client, account, startDate) => {
   logService('info', `Timeout is set to ${getTimeout()}s`)
 
   const device = account.auth.login
   const token = account.token
   const accountId = account._id
-  /* Get the trips starting date */
-  let startDate
-  let startManualDate
-  let firstRun = false
-  try {
-    const lastSavedTripDate = account.data?.lastSavedTripDate
-    if (lastSavedTripDate) {
-      startDate = new Date(lastSavedTripDate)
-    }
-    if (!startDate) {
-      const timestamps = await getFirstAndLastTripTimestamp(token)
-      if (!timestamps.start_ts || !timestamps.end_ts) {
-        logService('info', 'No trip saved yet. Abort.')
-        return
-      }
-      startDate = new Date(timestamps.start_ts * 1000)
-      firstRun = true
-    }
-    if (!startManualDate) {
-      startManualDate = startDate
-    }
+  let totalSavedTrips = 0
+  const firstRun = isFirstRun(account)
 
-    /* Extract the days having saved trips */
-    logService('info', `Fetch trips metadata from ${startDate.toISOString()}`)
-    const tripsMetadata = await fetchTripsMetadata(token, startDate, {
-      excludeFirst: !firstRun
-    })
-    logService('info', `Trips metadata ${JSON.stringify(tripsMetadata)}`)
+  /* Extract the days having saved trips */
+  logService('info', `Fetch trips metadata from ${startDate.toISOString()}`)
+  const tripsMetadata = await fetchTripsMetadata(token, startDate, {
+    excludeFirst: !firstRun
+  })
+  logService('info', `Trips metadata ${JSON.stringify(tripsMetadata)}`)
 
-    /* Create chunks of trips to serialize execution */
-    const tripChunks = createChunks(tripsMetadata, TRIPS_CHUNK_SIZE)
-    logService('info', `${tripChunks.length} chunks of trips to save`)
+  /* Create chunks of trips to serialize execution */
+  const tripChunks = createChunks(tripsMetadata, TRIPS_CHUNK_SIZE)
+  logService('info', `${tripChunks.length} chunks of trips to save`)
 
-    for (const chunk of tripChunks) {
-      /* Fetch new trips from the start date and save them in geojson doctype */
-      const lastSavedTripDate = await fetchAndSaveTrips(client, token, chunk, {
+  for (const chunk of tripChunks) {
+    /* Fetch new trips from the start date and save them in geojson doctype */
+    const { savedCount, lastSavedTripDate } = await fetchAndSaveTrips(
+      client,
+      token,
+      chunk,
+      {
         accountId,
         device
+      }
+    )
+    totalSavedTrips += savedCount
+    if (lastSavedTripDate) {
+      logService('info', `Save last trip date : ${lastSavedTripDate}`)
+      const accountData = account.data
+      await saveAccountData(client, accountId, {
+        ...accountData,
+        lastSavedTripDate
       })
-      if (lastSavedTripDate) {
-        logService('info', `Save last trip date : ${lastSavedTripDate}`)
-        const accountData = account.data
-        await saveAccountData(client, accountId, {
-          ...accountData,
-          lastSavedTripDate
-        })
-      }
-      if (!canSaveNextTripsChunk(startExecTime, getTimeout())) {
-        logService(
-          'info',
-          `No time left to save the remaining trips, restart job.`
-        )
-      // Abort the execution to avoid timeout and restart the job
-      await restartService(client)
-        return
-      }
     }
-
     if (!canSaveNextTripsChunk(startExecTime, getTimeout())) {
       logService(
-        'info',
-        `No time left to save the manual entries, restart job.`
+        'warn',
+        `No time left to save the remaining trips, restart job.`
       )
       // Abort the execution to avoid timeout and restart the job
-      await restartKonnector(client, accountId)
-      return
+      await restartService(client)
+      return totalSavedTrips
     }
-  } catch (err) {
-    logService('error', 'Error during execution: ', err.message)
-    return
   }
+
+  return totalSavedTrips
+}
+
+/**
+ * Request openpath server to purge data
+ *
+ * @param {IoCozyAccount} account -  The related account
+ * @param {Date} date - The date before which data can be purged
+ * @returns {Promise<OpenPathResponse>} The openpath server response
+ */
+export const purgeOpenPath = async (account, date) => {
+  const beforeDate = subDays(date, 7).toISOString() // Remove 7 days for safety
+  logService('info', `Request purge before date ${beforeDate}`)
+
+  return requestOpenPathPurge(account.token, beforeDate)
 }

--- a/src/lib/openpath/openpath.js
+++ b/src/lib/openpath/openpath.js
@@ -4,7 +4,7 @@ import { saveAccountData } from 'src/lib/openpath/save'
 import { getFirstAndLastTripTimestamp } from 'src/lib/openpath/traceRequests'
 import {
   canSaveNextTripsChunk,
-  restartKonnector,
+  restartService,
   createChunks
 } from 'src/lib/openpath/utils'
 
@@ -80,8 +80,8 @@ export const fetchTrips = async (client, account) => {
           'info',
           `No time left to save the remaining trips, restart job.`
         )
-        // Abort the execution to avoid timeout and restart the job
-        await restartKonnector(client, accountId)
+      // Abort the execution to avoid timeout and restart the job
+      await restartService(client)
         return
       }
     }

--- a/src/lib/openpath/openpath.spec.js
+++ b/src/lib/openpath/openpath.spec.js
@@ -10,13 +10,13 @@ jest.mock('src/lib/openpath/lib', () => ({
 }))
 jest.mock('src/lib/openpath/utils', () => ({
   ...jest.requireActual('./utils'),
-  restartKonnector: jest.fn()
+  restartService: jest.fn()
 }))
 jest.mock('src/lib/openpath/save', () => ({
   saveAccountData: jest.fn()
 }))
 jest.mock('./queries.js')
-import { restartKonnector } from 'src/lib/openpath/utils'
+import { restartService } from 'src/lib/openpath/utils'
 
 import { createMockClient } from 'cozy-client'
 
@@ -37,13 +37,13 @@ describe('timeout', () => {
   it('should not restart execution when timeout is not reached', async () => {
     process.env.COZY_TIME_LIMIT = 3600 // in seconds
     await fetchTrips(mockClient, mockAccount)
-    expect(restartKonnector).toHaveBeenCalledTimes(0)
+    expect(restartService).toHaveBeenCalledTimes(0)
   })
 
   it('should restart execution when timeout is detected', async () => {
     process.env.COZY_TIME_LIMIT = 1
     await fetchTrips(mockClient, mockAccount)
-    expect(restartKonnector).toHaveBeenCalledTimes(1)
+    expect(restartService).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/lib/openpath/save.js
+++ b/src/lib/openpath/save.js
@@ -1,8 +1,27 @@
 import { keepOnlyNewTrips } from 'src/lib/openpath/utils'
 import { queryAccountByDocId } from 'src/queries/nodeQueries'
 
+import logger from 'cozy-logger'
+
 import { queryTimeseriesByRange } from './queries'
 
+const logService = logger.namespace('services/openpath')
+
+/**
+ * @typedef {import("cozy-client/dist/index").CozyClient} CozyClient
+ * @typedef {import('./types').TimeseriesGeoJSON} TimeseriesGeoJSON
+ */
+
+/**
+ *
+ * @typedef Params
+ * @property {string} accountId - The account id
+ *
+ * @param {CozyClient} client - The cozy-client instance
+ * @param {Array<TimeseriesGeoJSON>} trips - The trips to save
+ * @param {Params} {accountId} - Additional params
+ * @returns {number} The number of trips actually saved
+ */
 export const saveTrips = async (client, trips, { accountId }) => {
   // Deduplication
   const existingTrips = await queryTimeseriesByRange(client, {
@@ -13,9 +32,18 @@ export const saveTrips = async (client, trips, { accountId }) => {
     incomingTrips: trips,
     existingTrips
   })
+  if (tripsToSave.length != trips.length) {
+    logService(
+      'info',
+      `${trips.length - tripsToSave.length} duplicates found and excluded`
+    )
+  }
   if (tripsToSave.length > 0) {
     await client.saveAll(tripsToSave)
+  } else {
+    logService('info', `No trips to save`)
   }
+  return tripsToSave.length
 }
 
 export const saveAccountData = async (client, accountId, accountData) => {

--- a/src/lib/openpath/traceRequests.js
+++ b/src/lib/openpath/traceRequests.js
@@ -81,6 +81,22 @@ export const getTripsForDay = async (token, day) => {
 }
 
 /**
+ * Request openpath purge
+ *
+ * @param {string} token - The account token
+ * @param {string} beforeDate - The date before which data can be purged
+ * @returns {Promise<OpenPathResponse>} The openpath server response
+ */
+export const requestOpenPathPurge = async (token, beforeDate) => {
+  const url = `${OPENPATH_URL}/cozy/run/purge`
+  const body = {
+    user: token,
+    before_date: beforeDate
+  }
+  return requestOpenPath(url, body)
+}
+
+/**
  * Request the OpenPath server
  *
  * @param {string} url - The openpath url to request

--- a/src/lib/openpath/utils.js
+++ b/src/lib/openpath/utils.js
@@ -26,10 +26,11 @@ export const keepOnlyNewTrips = async ({ incomingTrips, existingTrips }) => {
 
   const tripsToSave = differenceWith(incomingTrips, existingTrips, trip => {
     const duplicate = existingTrips.find(existingTrip => {
+      const newTrip = trip.series[0]
       return (
-        new Date(trip.properties.start_fmt_time).getTime() ===
+        new Date(newTrip.properties.start_fmt_time).getTime() ===
           new Date(existingTrip.startDate).getTime() &&
-        new Date(trip.properties.end_fmt_time).getTime() ===
+        new Date(newTrip.properties.end_fmt_time).getTime() ===
           new Date(existingTrip.endDate).getTime()
       )
     })

--- a/src/lib/openpath/utils.js
+++ b/src/lib/openpath/utils.js
@@ -1,18 +1,19 @@
 import { chunk, differenceWith } from 'lodash'
+import { FETCH_TRIPS_SERVICE_NAME } from 'src/constants'
 
 export const canSaveNextTripsChunk = (startExecTime, timeout) => {
   const executionTimeSeconds = (new Date() - startExecTime) / 1000
   return executionTimeSeconds < timeout
 }
 
-export const restartKonnector = async (client, accountId) => {
+export const restartService = async client => {
   const args = {
-    konnector: 'openpath',
-    account: accountId
+    name: FETCH_TRIPS_SERVICE_NAME,
+    slug: 'coachco2'
   }
 
   const jobCollection = client.collection('io.cozy.jobs')
-  return jobCollection.create('konnector', args)
+  return jobCollection.create('service', args)
 }
 
 export const createChunks = (tripsMetadata, chunkSize) => {

--- a/src/lib/openpath/utils.spec.js
+++ b/src/lib/openpath/utils.spec.js
@@ -3,16 +3,24 @@ import { keepOnlyNewTrips } from './utils'
 describe('remove duplicates', () => {
   const incomingTrips = [
     {
-      properties: {
-        start_fmt_time: '2021-01-01T12:00:00',
-        end_fmt_time: '2021-01-01T13:00:00'
-      }
+      series: [
+        {
+          properties: {
+            start_fmt_time: '2021-01-01T12:00:00',
+            end_fmt_time: '2021-01-01T13:00:00'
+          }
+        }
+      ]
     },
     {
-      properties: {
-        start_fmt_time: '2021-01-02T12:00:00',
-        end_fmt_time: '2021-01-02T13:00:00'
-      }
+      series: [
+        {
+          properties: {
+            start_fmt_time: '2021-01-02T12:00:00',
+            end_fmt_time: '2021-01-02T13:00:00'
+          }
+        }
+      ]
     }
   ]
 


### PR DESCRIPTION
When the fetch service has saved new trips, request the openpath server
to purge itself from old data.

This is useful to prevent out-of-control database growing, and improve
pipeline performances, as we measured a performance drop when the
`Stage_analysis_timeseries` grows.

Note this purge is called only when new trips are saved, and is desgined
to keep a 7-days security before purging.
```
### ✨ Features

* Request openpath purge after new saved trips

### 🐛 Bug Fixes

* Trip deduplication
* Fetch service auto-restart when timeout is coming 

### 🔧 Tech

*
```
