### PR TITLE
fix: Use startDate sorted by asc for geolocation quota notification

### DIFF
--- a/src/lib/geolocationQuota/lib.js
+++ b/src/lib/geolocationQuota/lib.js
@@ -11,7 +11,8 @@ const REMAINING_DAYS_FOR_ALMOST_EXPIRED_NOTIFICATION = 3
 
 const getFirstTimeserie = async client => {
   const firstTimeserieQuery = buildAggregatedTimeseriesQuery({
-    limit: 1
+    limit: 1,
+    sortOrder: 'asc'
   }).definition
   const firstTimeserieResult = await client.query(firstTimeserieQuery)
   return firstTimeserieResult.data?.[0]

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -25,7 +25,10 @@ const neverReload = 100000 * 1000
 
 // Timeseries doctype -------------
 
-export const buildAggregatedTimeseriesQuery = ({ limit } = {}) => ({
+export const buildAggregatedTimeseriesQuery = ({
+  limit,
+  sortOrder = 'desc'
+} = {}) => ({
   definition: Q(GEOJSON_DOCTYPE)
     .where({})
     .partialIndex({
@@ -36,10 +39,10 @@ export const buildAggregatedTimeseriesQuery = ({ limit } = {}) => ({
     .select(['startDate', 'endDate', 'title', 'aggregation'])
     // FIXME "endDate" should be removed when https://github.com/cozy/cozy-client/issues/1216 fixed
     .indexFields(['startDate', 'endDate'])
-    .sortBy([{ startDate: 'desc' }])
+    .sortBy([{ startDate: sortOrder }])
     .limitBy(limit),
   options: {
-    as: `${GEOJSON_DOCTYPE}/limitedBy/${limit}`,
+    as: `${GEOJSON_DOCTYPE}/limitedBy/${limit}/sortedBy/${sortOrder}`,
     fetchPolicy: CozyClient.fetchPolicies.olderThan(older30s)
   }
 })


### PR DESCRIPTION
Fix of https://github.com/cozy/coachCO2/pull/388