### PR TITLE
"Copy OpenPath identifier" debug button return correctly OpenPath identifier

### DIFF
--- a/src/components/GeolocationTracking/helpers.js
+++ b/src/components/GeolocationTracking/helpers.js
@@ -81,6 +81,10 @@ export const syncTrackingStatusWithFlagship = async (
   setIsGeolocationQuotaExceeded(quotaExceeded)
 }
 
+export const getGeolocationTrackingId = async webviewIntent => {
+  return webviewIntent?.call('getGeolocationTrackingId')
+}
+
 export const disableGeolocationTracking = async (
   webviewIntent,
   setIsGeolocationTrackingEnabled,
@@ -102,9 +106,7 @@ export const enableGeolocationTracking = async ({
   setIsGeolocationTrackingEnabled
 }) => {
   // create account if necessary
-  const geolocationTrackingId = await webviewIntent?.call(
-    'getGeolocationTrackingId'
-  )
+  const geolocationTrackingId = await getGeolocationTrackingId(webviewIntent)
 
   if (geolocationTrackingId === null) {
     const { deviceName } = (await webviewIntent?.call('getDeviceInfo')) || {

--- a/src/components/Providers/GeolocationTrackingProvider.jsx
+++ b/src/components/Providers/GeolocationTrackingProvider.jsx
@@ -9,6 +9,7 @@ import { LocationDisabledDialog } from 'src/components/GeolocationTracking/Locat
 import {
   disableGeolocationTracking,
   enableGeolocationTracking,
+  getGeolocationTrackingId,
   checkPermissionsAndEnableTrackingOrShowDialog,
   syncTrackingStatusWithFlagship,
   getNewPermissionAndEnabledTrackingOrShowDialog,
@@ -84,6 +85,7 @@ export const GeolocationTrackingProvider = ({ children }) => {
       isGeolocationTrackingAvailable,
       isGeolocationTrackingEnabled,
       isGeolocationQuotaExceeded,
+      getGeolocationTrackingId: () => getGeolocationTrackingId(webviewIntent),
       disableGeolocationTracking: () =>
         disableGeolocationTracking(
           webviewIntent,


### PR DESCRIPTION
getGeolocationTrackingId method was used to copy openpath identifier (a button hidden behind a flag). But it was not implemented so it was failing silently.


```
### 🐛 Bug Fixes

* "Copy OpenPath identifier" debug button return correctly OpenPath identifier
```
