### PR TITLE
[DAT-35] fix: Rely on device name rather than login

### DIFF
--- a/src/components/GeolocationTracking/helpers.js
+++ b/src/components/GeolocationTracking/helpers.js
@@ -32,7 +32,10 @@ export const createOpenPathAccount = async ({
     auth: {
       login: newLogin
     },
-    token: newToken
+    token: newToken,
+    data: {
+      deviceName
+    }
   }
   await client.create(ACCOUNTS_DOCTYPE, attributes)
   return {
@@ -119,7 +122,10 @@ export const enableGeolocationTracking = async ({
         accountQuery.options
       )
       const account = resp?.[0]
-      if (!account?.token || account?.auth?.login !== deviceName) {
+      // The account.auth.login is kept for backward compatibility. The auth.login can include additional formatting, e.g.
+      // "iPhone - Created at ...", while the deviceName is directly given by the OS.
+      const storedDeviceName = account?.data?.deviceName || account?.auth?.login
+      if (!account?.token || storedDeviceName !== deviceName) {
         // Note that both konnector (without token) and service account (with token)
         // could have the same device name. A migration might be needed at some point.
         const account = await createOpenPathAccount({


### PR DESCRIPTION
By default, the openpath login account is the device name, as provided by the OS, e.g. "iPhone"
However, this login can include additional formatting, such as "iPhone - Created on 01/01/24".
Thus, to determine if a new openpath account should be created, we should rely on the deterministic OS device name rather than the login.



```
### ✨ Features

*

### 🐛 Bug Fixes

* Rely on device name rather than login for account creation

### 🔧 Tech

*
```
