### PR TITLE
[VER-224] fix: Handle multiple service accounts

### DIFF
--- a/src/components/GeolocationTracking/helpers.js
+++ b/src/components/GeolocationTracking/helpers.js
@@ -2,7 +2,7 @@ import { OPENPATH_ACCOUNT_TYPE } from 'src/constants'
 import { ACCOUNTS_DOCTYPE } from 'src/doctypes'
 import {
   buildAccountQueryByLogin,
-  buildLastCreatedServiceAccountQuery
+  buildServiceAccountsQueryByCreatedAt
 } from 'src/queries/queries'
 
 import { isFlagshipApp } from 'cozy-device-helper'
@@ -113,7 +113,8 @@ export const enableGeolocationTracking = async ({
 
     if (deviceName) {
       let password
-      const accountQuery = buildLastCreatedServiceAccountQuery()
+      // Get latest service account, by creation date
+      const accountQuery = buildServiceAccountsQueryByCreatedAt({ limit: 1 })
       const { data: resp } = await client.query(
         accountQuery.definition,
         accountQuery.options

--- a/src/lib/openpath/openpath.js
+++ b/src/lib/openpath/openpath.js
@@ -75,7 +75,11 @@ export const fetchTrips = async (client, account, startDate) => {
   const tripsMetadata = await fetchTripsMetadata(token, startDate, {
     excludeFirst: !firstRun
   })
-  logService('info', `Trips metadata ${JSON.stringify(tripsMetadata)}`)
+  if (!tripsMetadata || tripsMetadata.length < 1) {
+    logService('No trips metadata found')
+    return
+  }
+  logService('info', `Found ${tripsMetadata.length} trips metadata`)
 
   /* Create chunks of trips to serialize execution */
   const tripChunks = createChunks(tripsMetadata, TRIPS_CHUNK_SIZE)

--- a/src/lib/openpath/queries.js
+++ b/src/lib/openpath/queries.js
@@ -2,12 +2,14 @@ import {
   buildTimeseriesByDateRange,
   buildAccountByToken
 } from 'src/queries/nodeQueries'
-import { buildLastCreatedServiceAccountQuery } from 'src/queries/queries'
+import { buildServiceAccountsQueryByCreatedAt } from 'src/queries/queries'
 
-export const queryLastServiceAccount = async client => {
-  const accountsQuery = buildLastCreatedServiceAccountQuery().definition
-  const account = await client.query(accountsQuery)
-  return account && account.data?.length > 0 ? account.data[0] : null
+export const queryServiceAccounts = async client => {
+  const accountsQuery = buildServiceAccountsQueryByCreatedAt({
+    limit: 100
+  }).definition
+  const accounts = await client.queryAll(accountsQuery)
+  return accounts?.length > 0 ? accounts : null
 }
 
 export const queryAccountByToken = async (client, token) => {

--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -415,7 +415,7 @@ export const buildAccountQuery = ({
   }
 }
 
-export const buildLastCreatedServiceAccountQuery = () => {
+export const buildServiceAccountsQueryByCreatedAt = ({ limit = 100 } = {}) => {
   const queryDef = Q(ACCOUNTS_DOCTYPE)
     .where({
       'cozyMetadata.createdAt': {
@@ -430,7 +430,7 @@ export const buildLastCreatedServiceAccountQuery = () => {
     })
     .indexFields(['cozyMetadata.createdAt'])
     .sortBy([{ 'cozyMetadata.createdAt': 'desc' }])
-    .limitBy(1)
+    .limitBy(limit)
   return {
     definition: queryDef,
     options: {


### PR DESCRIPTION
It can happen that a user has several openpath service accounts, typically because of https://github.com/cozy/coachCO2/pull/405, or if he changed the device.
To be sure we are not missing any trip, we now query all the openpath accounts.



```
### ✨ Features

*

### 🐛 Bug Fixes

* Handle multiple service accounts, to ensure all trips retrieval

### 🔧 Tech

*
```
