### PR TITLE
feat: Behavior of POI modal

### DIFF
--- a/src/components/ContactToPlace/ContactToPlaceDialogActions.jsx
+++ b/src/components/ContactToPlace/ContactToPlaceDialogActions.jsx
@@ -6,8 +6,9 @@ import {
 } from 'src/components/ContactToPlace/helpers'
 import { useContactToPlace } from 'src/components/Providers/ContactToPlaceProvider'
 import { useTrip } from 'src/components/Providers/TripProvider'
+import { buildSettingsQuery } from 'src/queries/queries'
 
-import { useClient } from 'cozy-client'
+import { useClient, useQuery } from 'cozy-client'
 import Alert from 'cozy-ui/transpiled/react/Alert'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import Snackbar from 'cozy-ui/transpiled/react/Snackbar'
@@ -22,6 +23,12 @@ const ContactToPlaceDialogActions = () => {
   const { timeserie } = useTrip()
   const client = useClient()
   const { showAlert } = useAlert()
+
+  const settingsQuery = buildSettingsQuery()
+  const { data: settings } = useQuery(
+    settingsQuery.definition,
+    settingsQuery.options
+  )
 
   const onClose = () => setType()
 
@@ -39,6 +46,7 @@ const ContactToPlaceDialogActions = () => {
     }
     await saveRelationship({
       client,
+      setting: settings[0],
       type,
       timeserie,
       contact,

--- a/src/components/ContactToPlace/helpers.js
+++ b/src/components/ContactToPlace/helpers.js
@@ -2,6 +2,7 @@ import remove from 'lodash/remove'
 import set from 'lodash/set'
 import unset from 'lodash/unset'
 import { HOME_ADDRESS_CATEGORY } from 'src/constants'
+import { CCO2_SETTINGS_DOCTYPE } from 'src/doctypes'
 import {
   getPlaceCoordinates,
   getPlaceDisplayName,
@@ -236,8 +237,21 @@ const updateRelationship = async ({
   await client.save(timeserie)
 }
 
+/**
+ * @param {Object} params
+ * @param {import('cozy-client/types/CozyClient').default} params.client - The cozy client
+ * @param {Object} params.setting - The io.cozy.coachco2.settings document
+ * @param {string} params.type - The type of the relationship
+ * @param {Object} params.timeserie - The timeserie document
+ * @param {Object} params.contact - The contact document
+ * @param {string} params.label - The label of the relationship
+ * @param {boolean} params.isSameContact - Whether the contact is the same as the previous one
+ * @param {string} params.category - The category of the relationship
+ * @param {Function} params.t - The translation function
+ */
 export const saveRelationship = async ({
   client,
+  setting,
   type,
   timeserie,
   contact,
@@ -252,24 +266,31 @@ export const saveRelationship = async ({
     type
   })
 
-  return isSameContact && !!address
-    ? updateRelationship({
-        client,
-        contact,
-        timeserie,
-        type,
-        label,
-        isSameContact,
-        category,
-        t
-      })
-    : createRelationship({
-        client,
-        contact,
-        timeserie,
-        type,
-        label,
-        category,
-        t
-      })
+  if (isSameContact && !!address) {
+    updateRelationship({
+      client,
+      contact,
+      timeserie,
+      type,
+      label,
+      isSameContact,
+      category,
+      t
+    })
+  } else {
+    createRelationship({
+      client,
+      contact,
+      timeserie,
+      type,
+      label,
+      category,
+      t
+    })
+  }
+  client.save({
+    ...setting,
+    _type: CCO2_SETTINGS_DOCTYPE,
+    hidePoiModal: true
+  })
 }

--- a/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
+++ b/src/components/EditDialogs/PurposeEditDialog/PurposeEditDialog.jsx
@@ -11,8 +11,9 @@ import { useTrip } from 'src/components/Providers/TripProvider'
 import { purposes } from 'src/components/helpers'
 import { OTHER_PURPOSE } from 'src/constants'
 import { getTimeseriePurpose } from 'src/lib/timeseries'
+import { buildSettingsQuery } from 'src/queries/queries'
 
-import { useClient } from 'cozy-client'
+import { useClient, useQuery } from 'cozy-client'
 import NestedSelectModal from 'cozy-ui/transpiled/react/NestedSelect/Modal'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
@@ -30,6 +31,11 @@ const PurposeEditDialog = ({ onClose }) => {
   const client = useClient()
   const { timeserie } = useTrip()
   const { type, setType } = useContactToPlace()
+  const settingsQuery = buildSettingsQuery()
+  const { data: settings } = useQuery(
+    settingsQuery.definition,
+    settingsQuery.options
+  )
 
   const handleSelect = async item => {
     const oldPurpose = getTimeseriePurpose(timeserie)
@@ -44,6 +50,7 @@ const PurposeEditDialog = ({ onClose }) => {
       })
     }
     openContactToPlaceModalOrClose({
+      setting: settings[0],
       timeserie,
       selectedPurpose: item.id,
       setContactToPlaceType: setType,

--- a/src/components/EditDialogs/PurposeEditDialog/helpers.js
+++ b/src/components/EditDialogs/PurposeEditDialog/helpers.js
@@ -28,19 +28,26 @@ export const createGeojsonWithModifiedPurpose = ({
   return timeserie
 }
 
+/**
+ * @param {Object} params
+ * @param {Object} params.setting - The io.cozy.coachco2.settings document
+ * @param {Object} params.timeserie - The timeserie document
+ * @param {string} params.selectedPurpose - The selected purpose
+ * @param {Function} params.setContactToPlaceType - The function to set the contact to place type
+ * @param {Function} params.onClose - The function to close the dialog
+ */
 export const openContactToPlaceModalOrClose = ({
+  setting,
   timeserie,
   selectedPurpose,
   setContactToPlaceType,
   onClose
 }) => {
+  const hidePoiModal = setting?.hidePoiModal
   const isCommute = selectedPurpose === COMMUTE_PURPOSE
   const isOtherPurpose = selectedPurpose === OTHER_PURPOSE
-  const hasConstactToPlace =
-    hasRelationshipByType(timeserie, 'start') ||
-    hasRelationshipByType(timeserie, 'end')
 
-  if ((!isOtherPurpose && !hasConstactToPlace) || isCommute) {
+  if ((!isOtherPurpose && !hidePoiModal) || isCommute) {
     if (!hasRelationshipByType(timeserie, 'start')) {
       setContactToPlaceType('start')
     } else if (!hasRelationshipByType(timeserie, 'end')) {


### PR DESCRIPTION
For all changes of purpose, except "Going to or from work", it should only appear if no POI has ever been saved.

As soon as a POI is created, the POI modal should never be displayed again. (except for "Going to or from work" purpose)


Cette PR corrige une mauvaise interprétation du besoin fait ici : https://github.com/cozy/coachCO2/pull/408