### PR TITLE
chore: Fix duplication of `createRoot` when reloading

### DIFF
--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -5,15 +5,13 @@ import 'cozy-bar/dist/stylesheet.css'
 
 import 'src/styles/index.styl'
 import React from 'react'
-import { createRoot } from 'react-dom/client'
 import AppProviders from 'src/components/AppProviders'
 import AppRouter from 'src/components/AppRouter'
 import { register as registerServiceWorker } from 'src/targets/browser/serviceWorkerRegistration'
 import setupApp from 'src/targets/browser/setupApp'
 
 const init = function () {
-  const { container, client, lang, polyglot } = setupApp()
-  const root = createRoot(container)
+  const { root, client, lang, polyglot } = setupApp()
 
   root.render(
     <AppProviders client={client} lang={lang} polyglot={polyglot}>

--- a/src/targets/browser/setupApp.jsx
+++ b/src/targets/browser/setupApp.jsx
@@ -1,6 +1,7 @@
 import { CaptureConsole } from '@sentry/integrations'
 import * as Sentry from '@sentry/react'
 import memoize from 'lodash/memoize'
+import { createRoot } from 'react-dom/client'
 import { CCO2_SETTINGS_DOCTYPE } from 'src/doctypes'
 import { buildSettingsQuery } from 'src/queries/queries'
 import { getValues } from 'src/utils/bar'
@@ -35,6 +36,7 @@ const forceAllSelectedAccountToAppSettings = async client => {
  */
 const setupApp = memoize(() => {
   const container = document.querySelector('[role=application]')
+  const root = createRoot(container)
   const { lang } = getValues(JSON.parse(container.dataset.cozy))
   const polyglot = initTranslation(lang, lang => require(`locales/${lang}`))
   const client = getClient()
@@ -57,7 +59,7 @@ const setupApp = memoize(() => {
     defaultIntegrations: false
   })
 
-  return { container, client, lang, polyglot }
+  return { root, client, lang, polyglot }
 })
 
 export default setupApp


### PR DESCRIPTION
For a long time we have had problems with the app's routes opening modals.
Indeed, in dev we could not refresh the app with an open modal without it being duplicated.

It is the fact of having the `createRoot` function in the `init` function of the app that causes these problems, because the latter executes twice when the app is launched via the `yarn start/watch` commands.

Other Cozy apps (in the same versions of React) execute this function in `setupApp` which is memoized, and thus avoids the double execution of `createRoot`.

```
### 🔧 Tech

* Fix duplication of `createRoot` when reloading
```
