### PR TITLE
[DAT-42] Fix 500 openpath

### DIFF
--- a/src/lib/openpath/traceRequests.js
+++ b/src/lib/openpath/traceRequests.js
@@ -17,6 +17,7 @@ class HTTPResponseError extends Error {
   constructor(response) {
     super(`HTTP Error Response: ${response.status} ${response.statusText}`)
     this.response = response
+    this.status = response.status
   }
 }
 
@@ -104,18 +105,14 @@ export const requestOpenPathPurge = async (token, beforeDate) => {
  * @returns {Promise<OpenPathResponse>} The openpath server response
  */
 const requestOpenPath = async (url, body) => {
-  try {
-    const response = await fetch(url, {
-      method: 'post',
-      body: JSON.stringify(body),
-      headers: { 'Content-Type': 'application/json' }
-    })
-    if (!response.ok) {
-      throw new HTTPResponseError(response)
-    }
-    const data = await response.json()
-    return data
-  } catch (err) {
-    throw new Error(`HTTP Error during openpath request: ${err}`)
+  const response = await fetch(url, {
+    method: 'post',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' }
+  })
+  if (!response.ok) {
+    throw new HTTPResponseError(response)
   }
+  const data = await response.json()
+  return data
 }


### PR DESCRIPTION
Sometimes, the openpath server returns a 500 error on retrieval trip API, when there is a particular trip that is malformed.
To avoid being blocked by this, we catch the 500 error and continue the execution: https://github.com/cozy/coachCO2/blob/master/src/lib/openpath/lib.js#L92
However, this was not properly working because of a wrong error catching

```
### ✨ Features

*

### 🐛 Bug Fixes

* Correctly handle 500 errors when fetching trips

### 🔧 Tech

*
```
