### PR TITLE
Feat: The disappearance of sources

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -91,7 +91,13 @@
     }
   },
   "services": {
-      "fetchOpenPathTrips": {
+    "computeAggregate": {
+      "type": "node",
+      "file": "services/computeAggregate/coachco2.js",
+      "trigger": "@event io.cozy.timeseries.geojson:CREATED",
+      "debounce": "1m"
+    },
+    "fetchOpenPathTrips": {
       "type": "node",
       "file": "services/fetchOpenPathTrips/coachco2.js",
       "trigger": "@hourly"

--- a/src/components/AccountSelector.jsx
+++ b/src/components/AccountSelector.jsx
@@ -1,27 +1,28 @@
 import React from 'react'
-import {
-  useAccountContext,
-  getAccountLabel
-} from 'src/components/Providers/AccountProvider'
+import { useAccountContext } from 'src/components/Providers/AccountProvider'
 
 import SelectBox from 'cozy-ui/transpiled/react/SelectBox'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 const AccountSelector = () => {
   const { t } = useI18n()
-  const { accounts, account, setAccount, isAllAccountsSelected } =
-    useAccountContext()
+  const {
+    accountsLogins,
+    accountLogin,
+    setAccountLogin,
+    isAllAccountsSelected
+  } = useAccountContext()
 
   const getValue = () => {
     if (isAllAccountsSelected) {
       return { label: t('settings.allAccounts'), value: 'allSources' }
     }
-    return { label: getAccountLabel(account), value: account?._id }
+    return { label: accountLogin, value: accountLogin }
   }
 
-  const options = accounts.map(account => ({
-    label: getAccountLabel(account),
-    value: account._id
+  const options = accountsLogins.map(name => ({
+    label: name,
+    value: name
   }))
   options.push({ label: t('settings.allAccounts'), value: 'allSources' })
 
@@ -29,9 +30,9 @@ const AccountSelector = () => {
 
   const handleChange = ({ value }) => {
     if (value === 'allSources') {
-      setAccount(null)
+      setAccountLogin(null)
     } else {
-      setAccount(accounts.find(acc => acc._id === value))
+      setAccountLogin(accountsLogins.find(name => name === value))
     }
   }
 

--- a/src/components/AppProviders.jsx
+++ b/src/components/AppProviders.jsx
@@ -9,6 +9,7 @@ import {
   ACCOUNTS_DOCTYPE,
   CCO2_SETTINGS_DOCTYPE
 } from 'src/doctypes'
+import { launchComputeAggregateJob } from 'src/lib/computeAggregateService'
 
 import { CozyProvider, RealTimeQueries } from 'cozy-client'
 import { WebviewIntentProvider } from 'cozy-intent'
@@ -33,6 +34,13 @@ const generateClassName = createGenerateClassName({
 })
 
 const AppProviders = ({ client, lang, polyglot, children }) => {
+  React.useEffect(() => {
+    const launch = async () => {
+      launchComputeAggregateJob(client)
+    }
+    launch()
+  }, [client])
+
   return (
     <WebviewIntentProvider>
       <StylesProvider generateClassName={generateClassName}>

--- a/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
+++ b/src/components/CO2EmissionsChart/CO2EmissionsChart.jsx
@@ -7,8 +7,8 @@ import { DACC_MEASURE_NAME_CO2_MONTHLY } from 'src/constants'
 import useFetchDACCAggregates from 'src/hooks/useFetchDACCAggregates'
 import useSettings from 'src/hooks/useSettings'
 import {
-  buildOneYearOldTimeseriesWithAggregationByAccountId,
-  buildOneYearOldTimeseriesWithAggregation
+  buildOneYearOldTimeseriesWithAggregation,
+  buildOneYearOldTimeseriesWithAggregationByAccountLogin
 } from 'src/queries/queries'
 
 import { isQueryLoading, useQueryAll } from 'cozy-client'
@@ -16,12 +16,12 @@ import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 import { useTheme } from 'cozy-ui/transpiled/react/styles'
 
-const getQuery = ({ isAllAccountsSelected, accountId }) => {
+const getQuery = ({ isAllAccountsSelected, accountLogin }) => {
   if (isAllAccountsSelected) {
     return buildOneYearOldTimeseriesWithAggregation()
   }
-  return buildOneYearOldTimeseriesWithAggregationByAccountId({
-    accountId
+  return buildOneYearOldTimeseriesWithAggregationByAccountLogin({
+    accountLogin
   })
 }
 
@@ -29,14 +29,14 @@ const CO2EmissionsChart = () => {
   const { t, f } = useI18n()
   const theme = useTheme()
   const { isMobile } = useBreakpoints()
-  const { account, isAllAccountsSelected } = useAccountContext()
+  const { accountLogin, isAllAccountsSelected } = useAccountContext()
 
   const { isLoading: isSettingsLoading, value: sendToDACC = false } =
     useSettings('CO2Emission.sendToDACC')
 
   const oneYearOldTimeseriesQuery = getQuery({
     isAllAccountsSelected,
-    accountId: account?._id
+    accountLogin
   })
   const { data: oneYearOldTimeseries, ...queryResult } = useQueryAll(
     oneYearOldTimeseriesQuery.definition,

--- a/src/components/EmptyContent/ChangeAccount.jsx
+++ b/src/components/EmptyContent/ChangeAccount.jsx
@@ -2,10 +2,7 @@ import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import EmptySvg from 'src/assets/icons/pins-path.svg'
 import FAQHelp from 'src/components/FAQ/FAQHelp'
-import {
-  useAccountContext,
-  getAccountLabel
-} from 'src/components/Providers/AccountProvider'
+import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import Titlebar from 'src/components/Titlebar'
 
 import Button from 'cozy-ui/transpiled/react/Buttons'
@@ -17,15 +14,15 @@ const ChangeAccount = () => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const navigate = useNavigate()
-  const { account, isAllAccountsSelected } = useAccountContext()
+  const { accountLogin, isAllAccountsSelected } = useAccountContext()
   const accountLabel = isAllAccountsSelected
     ? t('settings.allAccounts')
-    : `${t('trips.from')} ${getAccountLabel(account)}`
+    : `${t('trips.from')} ${accountLogin}`
 
   return (
     <>
       {isMobile && (
-        <Titlebar label={account ? `${accountLabel}` : t('trips.trips')} />
+        <Titlebar label={accountLogin ? `${accountLabel}` : t('trips.trips')} />
       )}
       <Empty
         icon={EmptySvg}

--- a/src/components/EmptyContent/EmptyContentManager.jsx
+++ b/src/components/EmptyContent/EmptyContentManager.jsx
@@ -3,7 +3,7 @@ import ChangeAccount from 'src/components/EmptyContent/ChangeAccount'
 import GPSStandby from 'src/components/EmptyContent/GPSStandby'
 import InstallApp from 'src/components/EmptyContent/InstallApp'
 import Welcome from 'src/components/EmptyContent/Welcome'
-import { makeQueriesByAccountsId } from 'src/components/EmptyContent/helpers'
+import { makeQueriesByCaptureDevices } from 'src/components/EmptyContent/helpers'
 import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import { useGeolocationTracking } from 'src/components/Providers/GeolocationTrackingProvider'
 
@@ -11,7 +11,8 @@ import { useQueries, isQueriesLoading } from 'cozy-client'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 const EmptyContentManager = () => {
-  const { accounts, account, isAllAccountsSelected } = useAccountContext()
+  const { accountsLogins, accountLogin, isAllAccountsSelected } =
+    useAccountContext()
   const { isGeolocationTrackingAvailable, isGeolocationTrackingEnabled } =
     useGeolocationTracking()
 
@@ -19,11 +20,12 @@ const EmptyContentManager = () => {
     isGeolocationTrackingAvailable === null ||
     isGeolocationTrackingEnabled === null
 
-  const otherAccounts = isAllAccountsSelected
+  const otherCaptureDevices = isAllAccountsSelected
     ? []
-    : accounts.filter(allAccount => allAccount._id !== account?._id)
-  const queriesByAccountsId = makeQueriesByAccountsId(otherAccounts)
-  const results = useQueries(queriesByAccountsId)
+    : accountsLogins.filter(login => login !== accountLogin)
+  const queriesByCaptureDevices =
+    makeQueriesByCaptureDevices(otherCaptureDevices)
+  const results = useQueries(queriesByCaptureDevices)
   const isLoading = isQueriesLoading(results)
 
   if (isLoading || isGeolocationTrackingLoading) {
@@ -44,7 +46,10 @@ const EmptyContentManager = () => {
     return <InstallApp />
   }
 
-  if (!isGeolocationTrackingEnabled || (!account && !isAllAccountsSelected)) {
+  if (
+    !isGeolocationTrackingEnabled ||
+    (!accountLogin && !isAllAccountsSelected)
+  ) {
     return <Welcome />
   }
 

--- a/src/components/EmptyContent/EmptyContentManager.spec.jsx
+++ b/src/components/EmptyContent/EmptyContentManager.spec.jsx
@@ -38,14 +38,14 @@ jest.mock('src/components/EmptyContent/Welcome', () => () => (
 ))
 
 const setup = ({
-  accounts,
-  account,
+  accountsLogins,
+  accountLogin,
   isLoading,
   queries,
   isGeolocAvailable,
   isGeolocEnabled
 } = {}) => {
-  useAccountContext.mockReturnValue({ accounts, account })
+  useAccountContext.mockReturnValue({ accountsLogins, accountLogin })
   useGeolocationTracking.mockReturnValue({
     isGeolocationTrackingAvailable: isGeolocAvailable,
     isGeolocationTrackingEnabled: isGeolocEnabled
@@ -66,10 +66,10 @@ describe('EmptyContentManager', () => {
   })
 
   describe('should show a spinner', () => {
-    it('if no account and queries are loading', () => {
+    it('if no accountLogin and queries are loading', () => {
       const { getByRole, queryByTestId } = setup({
-        account: null,
-        accounts: [],
+        accountLogin: null,
+        accountsLogins: [],
         isLoading: true
       })
 
@@ -80,10 +80,10 @@ describe('EmptyContentManager', () => {
       expect(queryByTestId('Welcome')).toBeNull()
     })
 
-    it('if no account selected and queries are loading', () => {
+    it('if no accountLogin selected and queries are loading', () => {
       const { getByRole, queryByTestId } = setup({
-        account: null,
-        accounts: [{ _id: 'accountId' }],
+        accountLogin: null,
+        accountsLogins: ['accountAuthLogin01'],
         isLoading: true
       })
 
@@ -94,10 +94,10 @@ describe('EmptyContentManager', () => {
       expect(queryByTestId('Welcome')).toBeNull()
     })
 
-    it('if account selected but queries are loading', () => {
+    it('if accountLogin selected but queries are loading', () => {
       const { getByRole, queryByTestId } = setup({
-        account: { _id: 'accountId' },
-        accounts: [{ _id: 'accountId' }],
+        accountLogin: 'accountAuthLogin01',
+        accountsLogins: ['accountAuthLogin01'],
         isLoading: true
       })
 
@@ -112,8 +112,8 @@ describe('EmptyContentManager', () => {
   describe('should show...', () => {
     it('install app page', () => {
       const { queryByRole, queryByTestId } = setup({
-        account: { _id: 'accountId' },
-        accounts: [{ _id: 'accountId' }],
+        accountLogin: 'accountAuthLogin01',
+        accountsLogins: ['accountAuthLogin01'],
         isLoading: false,
         queries: {},
         isGeolocAvailable: false,
@@ -129,8 +129,8 @@ describe('EmptyContentManager', () => {
 
     it('welcome page', () => {
       const { queryByRole, queryByTestId } = setup({
-        account: { _id: 'accountId' },
-        accounts: [{ _id: 'accountId' }],
+        accountLogin: 'accountAuthLogin01',
+        accountsLogins: ['accountAuthLogin01'],
         isLoading: false,
         queries: {},
         isGeolocAvailable: true,
@@ -146,8 +146,8 @@ describe('EmptyContentManager', () => {
 
     it('gps standby page', () => {
       const { queryByRole, queryByTestId } = setup({
-        account: { _id: 'accountId' },
-        accounts: [{ _id: 'accountId' }],
+        accountLogin: 'accountAuthLogin01',
+        accountsLogins: ['accountAuthLogin01'],
         isLoading: false,
         queries: {},
         isGeolocAvailable: true,
@@ -161,10 +161,10 @@ describe('EmptyContentManager', () => {
       expect(queryByTestId('Welcome')).toBeNull()
     })
 
-    it('welcome page and no gps standby, because there is no account selected', () => {
+    it('welcome page and no gps standby, because there is no accountLogin selected', () => {
       const { queryByRole, queryByTestId } = setup({
-        account: null,
-        accounts: [{ _id: 'accountId' }],
+        accountLogin: null,
+        accountsLogins: ['accountAuthLogin01'],
         isLoading: false,
         queries: {},
         isGeolocAvailable: true,
@@ -178,10 +178,10 @@ describe('EmptyContentManager', () => {
       expect(queryByTestId('Welcome'))
     })
 
-    it('change account page', () => {
+    it('change accountLogin page', () => {
       const { queryByRole, queryByTestId } = setup({
-        account: { _id: 'accountId' },
-        accounts: [{ _id: 'accountId' }],
+        accountLogin: 'accountAuthLogin01',
+        accountsLogins: ['accountAuthLogin01'],
         isLoading: false,
         queries: { id1: { data: [{}] } },
         isGeolocAvailable: true,

--- a/src/components/EmptyContent/GPSStandby.jsx
+++ b/src/components/EmptyContent/GPSStandby.jsx
@@ -1,10 +1,7 @@
 import React from 'react'
 import EmptySvg from 'src/assets/images/location-detected.svg'
 import FAQHelp from 'src/components/FAQ/FAQHelp'
-import {
-  useAccountContext,
-  getAccountLabel
-} from 'src/components/Providers/AccountProvider'
+import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import Titlebar from 'src/components/Titlebar'
 
 import Empty from 'cozy-ui/transpiled/react/Empty'
@@ -14,11 +11,11 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 const GPSStandby = () => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
-  const { account, isAllAccountsSelected } = useAccountContext()
+  const { accountLogin, isAllAccountsSelected } = useAccountContext()
 
   const accountLabel = isAllAccountsSelected
     ? t('trips.allTrips')
-    : `${t('trips.from')} ${getAccountLabel(account)}`
+    : `${t('trips.from')} ${accountLogin}`
 
   return (
     <>

--- a/src/components/EmptyContent/helpers.js
+++ b/src/components/EmptyContent/helpers.js
@@ -1,18 +1,19 @@
 import { getSource } from 'src/components/Goals/BikeGoal/helpers'
-import { buildHasTimeseriesQueryByAccountId } from 'src/queries/queries'
+import { buildHasTimeseriesQueryByAccountLogin } from 'src/queries/queries'
 
 import flag from 'cozy-flags'
 
-export const makeQueriesByAccountsId = accounts => {
-  const accountsIds = accounts.map(account => account._id)
+export const makeQueriesByCaptureDevices = otherCaptureDevices => {
+  const queriesByCaptureDevices = otherCaptureDevices.reduce(
+    (prev, current) => {
+      const query = buildHasTimeseriesQueryByAccountLogin(current)
+      prev[current] = { ...query.options, query: query.definition }
+      return prev
+    },
+    {}
+  )
 
-  const queriesByAccountsId = accountsIds.reduce((prev, current) => {
-    const query = buildHasTimeseriesQueryByAccountId(current)
-    prev[current] = { ...query.options, query: query.definition }
-    return prev
-  }, {})
-
-  return queriesByAccountsId
+  return queriesByCaptureDevices
 }
 
 export const makeWelcomeText = () => {

--- a/src/components/EmptyContent/helpers.spec.js
+++ b/src/components/EmptyContent/helpers.spec.js
@@ -1,5 +1,5 @@
 import {
-  makeQueriesByAccountsId,
+  makeQueriesByCaptureDevices,
   makeWelcomeText
 } from 'src/components/EmptyContent/helpers.js'
 
@@ -9,17 +9,20 @@ jest.mock('cozy-flags')
 
 const setupFlags = flags => flag.mockImplementation(flagName => flags[flagName])
 
-describe('makeQueriesByAccountsId', () => {
+describe('makeQueriesByCaptureDevices', () => {
   it('should create well formatted object', () => {
-    const res = makeQueriesByAccountsId([{ _id: 'id1' }, { _id: 'id2' }])
+    const res = makeQueriesByCaptureDevices([
+      'captureDevice01',
+      'captureDevice02'
+    ])
 
     expect(res).toMatchObject({
-      id1: {
+      captureDevice01: {
         as: expect.any(String),
         fetchPolicy: expect.any(Function),
         query: expect.any(Object)
       },
-      id2: {
+      captureDevice02: {
         as: expect.any(String),
         fetchPolicy: expect.any(Function),
         query: expect.any(Object)

--- a/src/components/Goals/BikeGoal/BikeGoalManager.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalManager.jsx
@@ -7,9 +7,9 @@ import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import { filterTimeseriesByYear } from 'src/lib/timeseries'
 import {
   buildSettingsQuery,
-  buildBikeCommuteTimeseriesQueryByAccountId,
   buildContextQuery,
-  buildBikeCommuteTimeseriesQuery
+  buildBikeCommuteTimeseriesQuery,
+  buildBikeCommuteTimeseriesQueryByAccountLogin
 } from 'src/queries/queries'
 
 import { isQueryLoading, useQuery, useQueryAll, useClient } from 'cozy-client'
@@ -25,17 +25,17 @@ const style = {
   }
 }
 
-const getQuery = ({ isAllAccountsSelected, accountId }) => {
+const getQuery = ({ isAllAccountsSelected, accountLogin }) => {
   if (isAllAccountsSelected) {
     return buildBikeCommuteTimeseriesQuery()
   }
-  return buildBikeCommuteTimeseriesQueryByAccountId({ accountId })
+  return buildBikeCommuteTimeseriesQueryByAccountLogin({ accountLogin })
 }
 
 const BikeGoalManager = () => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
-  const { account, isAccountLoading, isAllAccountsSelected } =
+  const { accountLogin, isAccountLoading, isAllAccountsSelected } =
     useAccountContext()
   const client = useClient()
   const rootURL = client.getStackClient().uri
@@ -53,14 +53,14 @@ const BikeGoalManager = () => {
   )
 
   const timeseriesQuery = getQuery({
-    accountId: account?._id,
+    accountLogin,
     isAllAccountsSelected
   })
   const { data: timeseries, ...timeseriesQueryLeft } = useQueryAll(
     timeseriesQuery.definition,
     {
       ...timeseriesQuery.options,
-      enabled: Boolean(account) || isAllAccountsSelected
+      enabled: Boolean(accountLogin) || isAllAccountsSelected
     }
   )
   const isLoadingTimeseriesQuery =

--- a/src/components/Goals/BikeGoal/BikeGoalSummary.jsx
+++ b/src/components/Goals/BikeGoal/BikeGoalSummary.jsx
@@ -6,9 +6,9 @@ import BikeGoalSummaryYearlyItem from 'src/components/Goals/BikeGoal/BikeGoalSum
 import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import { filterTimeseriesByYear } from 'src/lib/timeseries'
 import {
-  buildBikeCommuteTimeseriesQueryByAccountId,
   buildBikeCommuteTimeseriesQuery,
-  buildSettingsQuery
+  buildSettingsQuery,
+  buildBikeCommuteTimeseriesQueryByAccountLogin
 } from 'src/queries/queries'
 
 import { isQueryLoading, useQueryAll, useQuery } from 'cozy-client'
@@ -22,17 +22,17 @@ const style = {
   div: { height: 65 }
 }
 
-const getQuery = ({ isAllAccountsSelected, accountId }) => {
+const getQuery = ({ isAllAccountsSelected, accountLogin }) => {
   if (isAllAccountsSelected) {
     return buildBikeCommuteTimeseriesQuery()
   }
-  return buildBikeCommuteTimeseriesQueryByAccountId({ accountId })
+  return buildBikeCommuteTimeseriesQueryByAccountLogin({ accountLogin })
 }
 
 const BikeGoalSummary = () => {
   const { t } = useI18n()
   const navigate = useNavigate()
-  const { account, isAccountLoading, isAllAccountsSelected } =
+  const { accountLogin, isAccountLoading, isAllAccountsSelected } =
     useAccountContext()
 
   const settingsQuery = buildSettingsQuery()
@@ -43,14 +43,14 @@ const BikeGoalSummary = () => {
   const isSettingsLoading = isQueryLoading(settingsQueryLeft)
 
   const timeseriesQuery = getQuery({
-    accountId: account?._id,
+    accountLogin,
     isAllAccountsSelected
   })
   const { data: timeseries, ...timeseriesQueryLeft } = useQueryAll(
     timeseriesQuery.definition,
     {
       ...timeseriesQuery.options,
-      enabled: Boolean(account) || isAllAccountsSelected
+      enabled: Boolean(accountLogin) || isAllAccountsSelected
     }
   )
 

--- a/src/components/ListWrapper.jsx
+++ b/src/components/ListWrapper.jsx
@@ -8,8 +8,8 @@ import { useSelectDatesContext } from 'src/components/Providers/SelectDatesProvi
 import SelectDatesWrapper from 'src/components/SelectDatesWrapper'
 import Titlebar from 'src/components/Titlebar'
 import {
-  buildTimeseriesQueryByDateAndAccountId,
-  buildTimeseriesQueryByDate
+  buildTimeseriesQueryByDate,
+  buildTimeseriesQueryByDateAndAccountLogin
 } from 'src/queries/queries'
 
 import { isQueryLoading, useQueryAll } from 'cozy-client'
@@ -20,7 +20,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 const getQuery = ({
   isAllAccountsSelected,
   selectedDate,
-  accountId,
+  accountLogin,
   isFullYear
 }) => {
   if (isAllAccountsSelected) {
@@ -29,15 +29,15 @@ const getQuery = ({
       date: selectedDate
     })
   }
-  return buildTimeseriesQueryByDateAndAccountId({
+  return buildTimeseriesQueryByDateAndAccountLogin({
     date: selectedDate,
     isFullYear,
-    accountId
+    accountLogin
   })
 }
 
 const AnalysisWrapper = () => {
-  const { account, isAccountLoading, isAllAccountsSelected } =
+  const { accountLogin, isAccountLoading, isAllAccountsSelected } =
     useAccountContext()
   const { selectedDate, isFullYear, isSelectedDateLoading } =
     useSelectDatesContext()
@@ -46,7 +46,7 @@ const AnalysisWrapper = () => {
     isAllAccountsSelected,
     selectedDate,
     isFullYear,
-    accountId: account?._id
+    accountLogin
   })
   const { data: timeseries, ...timeseriesQueryLeft } = useQueryAll(
     timeserieQuery.definition,
@@ -58,7 +58,7 @@ const AnalysisWrapper = () => {
   }
 
   if (
-    (account || isAllAccountsSelected) &&
+    (accountLogin || isAllAccountsSelected) &&
     (isQueryLoading(timeseriesQueryLeft) || timeseriesQueryLeft.hasMore) &&
     selectedDate !== null
   ) {
@@ -66,7 +66,7 @@ const AnalysisWrapper = () => {
   }
 
   if (
-    (!account && !isAllAccountsSelected) ||
+    (!accountLogin && !isAllAccountsSelected) ||
     !timeseries ||
     timeseries?.length === 0
   ) {

--- a/src/components/Providers/AccountProvider.jsx
+++ b/src/components/Providers/AccountProvider.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useCallback } from 'react'
 import { CCO2_SETTINGS_DOCTYPE } from 'src/doctypes'
-import { buildSettingsQuery, buildAccountQuery } from 'src/queries/queries'
+import { buildSettingsQuery } from 'src/queries/queries'
 
 import { isQueryLoading, useMutation, useQuery } from 'cozy-client'
 
@@ -15,8 +15,6 @@ export const useAccountContext = () => {
   return context
 }
 
-export const getAccountLabel = account => account?.auth?.login
-
 let firstLaunch = true // Tips to avoid duplicate settings creation. Updating the app settings refreshes the useQuery which doesn't yet have the latest updated state and therefore a second update is made
 
 const AccountProvider = ({ children }) => {
@@ -28,49 +26,40 @@ const AccountProvider = ({ children }) => {
   )
   const isSettingsQueryLoading = isQueryLoading(settingsQueryLeft)
 
-  const accountQuery = buildAccountQuery()
-  const { data: accounts, ...accountQueryLeft } = useQuery(
-    accountQuery.definition,
-    accountQuery.options
-  )
-  const isAccountQueryLoading = isQueryLoading(accountQueryLeft)
-
-  const isLoading = isSettingsQueryLoading || isAccountQueryLoading
-
-  // When the user launch the app for the first time, or account property doesn't exist, we create the settings
+  // When the user launch the app for the first time, or accountLogin property doesn't exist, we create the settings
   useEffect(() => {
-    if (!isLoading && firstLaunch) {
-      if (settings?.[0]?.account === undefined) {
+    if (!isSettingsQueryLoading && firstLaunch) {
+      if (settings?.[0]?.accountLogin === undefined) {
         const setting = settings?.[0] || {}
         mutate({
           ...setting,
           _type: CCO2_SETTINGS_DOCTYPE,
-          account: null,
+          accountLogin: null,
           isAllAccountsSelected: true
         })
         firstLaunch = false
       }
     }
-  }, [settings, isLoading, mutate])
+  }, [settings, isSettingsQueryLoading, mutate])
 
-  const setAccount = useCallback(
-    account => {
+  const setAccountLogin = useCallback(
+    accountLogin => {
       const setting = settings[0] || {}
       mutate({
         ...setting,
         _type: CCO2_SETTINGS_DOCTYPE,
-        account,
-        isAllAccountsSelected: account === null
+        accountLogin,
+        isAllAccountsSelected: accountLogin === null
       })
     },
     [mutate, settings]
   )
 
   const value = {
-    accounts,
-    account: settings?.[0]?.account ?? null,
-    setAccount,
-    isAccountLoading: isAccountQueryLoading,
+    accountLogin: settings?.[0]?.accountLogin ?? null,
+    accountsLogins: settings?.[0]?.accountsLogins ?? [],
+    setAccountLogin,
+    isAccountLoading: isSettingsQueryLoading,
     isAllAccountsSelected: settings?.[0]?.isAllAccountsSelected ?? false
   }
 

--- a/src/components/SelectDatesWrapper.jsx
+++ b/src/components/SelectDatesWrapper.jsx
@@ -4,8 +4,8 @@ import { useSelectDatesContext } from 'src/components/Providers/SelectDatesProvi
 import SelectDatesWithLoader from 'src/components/SelectDates/SelectDatesWithLoader'
 import { makeLatestDate } from 'src/components/SelectDates/helpers'
 import {
-  buildAggregatedTimeseriesQueryByAccountId,
-  buildAggregatedTimeseriesQuery
+  buildAggregatedTimeseriesQuery,
+  buildAggregatedTimeseriesQueryByAccountLogin
 } from 'src/queries/queries'
 
 import { isQueryLoading, useQueryAll } from 'cozy-client'
@@ -15,12 +15,12 @@ const computeOptions = (isLoading, timeseries) => {
   return timeseries.map(timeserie => new Date(timeserie.startDate))
 }
 
-const getQuery = ({ isAllAccountsSelected, accountId }) => {
+const getQuery = ({ isAllAccountsSelected, accountLogin }) => {
   if (isAllAccountsSelected) {
     return buildAggregatedTimeseriesQuery({ limit: 1000 })
   }
-  return buildAggregatedTimeseriesQueryByAccountId({
-    accountId,
+  return buildAggregatedTimeseriesQueryByAccountLogin({
+    accountLogin,
     limit: 1000
   })
 }
@@ -36,16 +36,16 @@ const SelectDatesWrapper = () => {
     options,
     setOptions
   } = useSelectDatesContext()
-  const { account, isAllAccountsSelected } = useAccountContext()
+  const { accountLogin, isAllAccountsSelected } = useAccountContext()
   const timeseriesQuery = getQuery({
     isAllAccountsSelected,
-    accountId: account?._id
+    accountLogin
   })
   const { data: timeseries, ...timeseriesQueryResult } = useQueryAll(
     timeseriesQuery.definition,
     {
       ...timeseriesQuery.options,
-      enabled: Boolean(account) || isAllAccountsSelected
+      enabled: Boolean(accountLogin) || isAllAccountsSelected
     }
   )
 
@@ -54,7 +54,7 @@ const SelectDatesWrapper = () => {
 
   useEffect(() => {
     if (
-      (account || isAllAccountsSelected) &&
+      (accountLogin || isAllAccountsSelected) &&
       !isLoading &&
       isSelectedDateLoading
     ) {
@@ -67,19 +67,19 @@ const SelectDatesWrapper = () => {
       }
     }
 
-    if (!account && !isAllAccountsSelected) {
+    if (!accountLogin && !isAllAccountsSelected) {
       setIsSelectedDateLoading(false)
     }
 
     if (
-      (account || isAllAccountsSelected) &&
+      (accountLogin || isAllAccountsSelected) &&
       isLoading &&
       !isSelectedDateLoading
     ) {
       setIsSelectedDateLoading(true)
     }
   }, [
-    account,
+    accountLogin,
     isAllAccountsSelected,
     isLoading,
     isSelectedDateLoading,

--- a/src/components/Views/BikeGoal.jsx
+++ b/src/components/Views/BikeGoal.jsx
@@ -3,24 +3,24 @@ import BikeGoalDialogMobile from 'src/components/Goals/BikeGoal/BikeGoalDialogMo
 import BikeGoalViewDesktop from 'src/components/Goals/BikeGoal/BikeGoalViewDesktop'
 import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import {
-  buildBikeCommuteTimeseriesQueryByAccountId,
   buildBikeCommuteTimeseriesQuery,
-  buildSettingsQuery
+  buildSettingsQuery,
+  buildBikeCommuteTimeseriesQueryByAccountLogin
 } from 'src/queries/queries'
 
 import { isQueryLoading, useQueryAll, useQuery } from 'cozy-client'
 import ListSkeleton from 'cozy-ui/transpiled/react/Skeletons/ListSkeleton'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
-const getQuery = ({ isAllAccountsSelected, accountId }) => {
+const getQuery = ({ isAllAccountsSelected, accountLogin }) => {
   if (isAllAccountsSelected) {
     return buildBikeCommuteTimeseriesQuery()
   }
-  return buildBikeCommuteTimeseriesQueryByAccountId({ accountId })
+  return buildBikeCommuteTimeseriesQueryByAccountLogin({ accountLogin })
 }
 
 const Bikegoal = () => {
-  const { account, isAccountLoading, isAllAccountsSelected } =
+  const { accountLogin, isAccountLoading, isAllAccountsSelected } =
     useAccountContext()
   const { isMobile } = useBreakpoints()
 
@@ -32,14 +32,14 @@ const Bikegoal = () => {
   const isSettingsLoading = isQueryLoading(settingsQueryLeft)
 
   const timeseriesQuery = getQuery({
-    accountId: account?._id,
+    accountLogin,
     isAllAccountsSelected
   })
   const { data: timeseries, ...timeseriesQueryLeft } = useQueryAll(
     timeseriesQuery.definition,
     {
       ...timeseriesQuery.options,
-      enabled: Boolean(account) || isAllAccountsSelected
+      enabled: Boolean(accountLogin) || isAllAccountsSelected
     }
   )
 

--- a/src/components/Views/Settings.jsx
+++ b/src/components/Views/Settings.jsx
@@ -17,10 +17,7 @@ import BikeGoalDaccSwitcher from 'src/components/Goals/BikeGoal/BikeGoalDaccSwit
 import BikeGoalOnboardedSwitcher from 'src/components/Goals/BikeGoal/BikeGoalOnboardedSwitcher'
 import BikeGoalSwitcher from 'src/components/Goals/BikeGoal/BikeGoalSwitcher'
 import { getSource } from 'src/components/Goals/BikeGoal/helpers'
-import {
-  useAccountContext,
-  getAccountLabel
-} from 'src/components/Providers/AccountProvider'
+import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import { useGeolocationTracking } from 'src/components/Providers/GeolocationTrackingProvider'
 import Titlebar from 'src/components/Titlebar'
 import { CONTEXT } from 'src/constants'
@@ -41,8 +38,12 @@ export const Settings = () => {
   const { isMobile } = useBreakpoints()
   const { isGeolocationTrackingAvailable, isGeolocationTrackingEnabled } =
     useGeolocationTracking()
-  const { isAccountLoading, accounts, account, isAllAccountsSelected } =
-    useAccountContext()
+  const {
+    isAccountLoading,
+    accountsLogins,
+    accountLogin,
+    isAllAccountsSelected
+  } = useAccountContext()
   const { sourceName } = getSource()
 
   if (isAccountLoading) {
@@ -51,7 +52,7 @@ export const Settings = () => {
     )
   }
 
-  if (accounts.length === 0) {
+  if (accountsLogins.length === 0) {
     if (!isGeolocationTrackingAvailable) {
       return <InstallApp />
     }
@@ -63,7 +64,7 @@ export const Settings = () => {
 
   const accountName = isAllAccountsSelected
     ? t('settings.allAccounts')
-    : getAccountLabel(account)
+    : accountLogin
 
   return (
     <>
@@ -95,7 +96,7 @@ export const Settings = () => {
           <CsvExporter accountName={accountName} />
         </List>
 
-        {(account || isAllAccountsSelected) && (
+        {(accountLogin || isAllAccountsSelected) && (
           <List subheader={<ListSubheader>{t('support.label')}</ListSubheader>}>
             <FAQ />
             {isGeolocationTrackingAvailable ? (

--- a/src/components/Views/Trips.jsx
+++ b/src/components/Views/Trips.jsx
@@ -3,15 +3,12 @@ import CO2EmissionsChart from 'src/components/CO2EmissionsChart/CO2EmissionsChar
 import CO2EmissionDaccManager from 'src/components/DaccManager/CO2EmissionDaccManager'
 import EmptyContentManager from 'src/components/EmptyContent/EmptyContentManager'
 import BikeGoalManager from 'src/components/Goals/BikeGoal/BikeGoalManager'
-import {
-  useAccountContext,
-  getAccountLabel
-} from 'src/components/Providers/AccountProvider'
+import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import Titlebar from 'src/components/Titlebar'
 import TripsList from 'src/components/TripsList'
 import {
-  buildAggregatedTimeseriesQueryByAccountId,
-  buildAggregatedTimeseriesQuery
+  buildAggregatedTimeseriesQuery,
+  buildAggregatedTimeseriesQueryByAccountLogin
 } from 'src/queries/queries'
 
 import { hasQueryBeenLoaded, isQueryLoading, useQuery } from 'cozy-client'
@@ -29,31 +26,31 @@ const style = {
   }
 }
 
-const getQuery = ({ isAllAccountsSelected, accountId }) => {
+const getQuery = ({ isAllAccountsSelected, accountLogin }) => {
   if (isAllAccountsSelected) {
     return buildAggregatedTimeseriesQuery({ limit: 50 })
   }
-  return buildAggregatedTimeseriesQueryByAccountId({
-    accountId,
+  return buildAggregatedTimeseriesQueryByAccountLogin({
+    accountLogin,
     limit: 50
   })
 }
 
 export const Trips = () => {
-  const { account, isAccountLoading, isAllAccountsSelected } =
+  const { accountLogin, isAccountLoading, isAllAccountsSelected } =
     useAccountContext()
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
 
   const timeseriesQuery = getQuery({
     isAllAccountsSelected,
-    accountId: account?._id
+    accountLogin
   })
   const { data: timeseries, ...timeseriesQueryLeft } = useQuery(
     timeseriesQuery.definition,
     {
       ...timeseriesQuery.options,
-      enabled: Boolean(account) || isAllAccountsSelected
+      enabled: Boolean(accountLogin) || isAllAccountsSelected
     }
   )
   if (isAccountLoading) {
@@ -61,7 +58,7 @@ export const Trips = () => {
   }
 
   if (
-    (account || isAllAccountsSelected) &&
+    (accountLogin || isAllAccountsSelected) &&
     isQueryLoading(timeseriesQueryLeft) &&
     !hasQueryBeenLoaded(timeseriesQueryLeft)
   ) {
@@ -69,7 +66,7 @@ export const Trips = () => {
   }
 
   if (
-    (!isAllAccountsSelected && !account) ||
+    (!isAllAccountsSelected && !accountLogin) ||
     !timeseries ||
     timeseries?.length === 0
   ) {
@@ -78,7 +75,7 @@ export const Trips = () => {
 
   const accountLabel = isAllAccountsSelected
     ? t('trips.allTrips')
-    : `${t('trips.from')} ${getAccountLabel(account)}`
+    : `${t('trips.from')} ${accountLogin}`
 
   return (
     <>

--- a/src/hooks/useExportTripsToCSV.jsx
+++ b/src/hooks/useExportTripsToCSV.jsx
@@ -1,30 +1,27 @@
 import { useEffect, useState } from 'react'
-import {
-  getAccountLabel,
-  useAccountContext
-} from 'src/components/Providers/AccountProvider'
+import { useAccountContext } from 'src/components/Providers/AccountProvider'
 import { uploadFile } from 'src/lib/exportTripsToCSV'
 import {
-  buildTimeseriesQueryByAccountId,
+  buildTimeseriesQueryByAccountLogin,
   buildTimeseriesQuery
 } from 'src/queries/queries'
 
 import { isQueryLoading, useQueryAll, useClient } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
-const getQuery = ({ isAllAccountsSelected, accountId }) => {
+const getQuery = ({ isAllAccountsSelected, accountLogin }) => {
   if (isAllAccountsSelected) {
     return buildTimeseriesQuery()
   }
-  return buildTimeseriesQueryByAccountId({
-    accountId
+  return buildTimeseriesQueryByAccountLogin({
+    accountLogin
   })
 }
 
 const useExportTripsToCSV = () => {
   const { t } = useI18n()
   const client = useClient()
-  const { account, isAllAccountsSelected } = useAccountContext()
+  const { accountLogin, isAllAccountsSelected } = useAccountContext()
   const [importCSVProcess, setImportCSVProcess] = useState(false)
 
   const [{ appDir, fileCreated, isLoading }, setResult] = useState({
@@ -35,7 +32,7 @@ const useExportTripsToCSV = () => {
 
   const timeseriesQuery = getQuery({
     isAllAccountsSelected,
-    accountId: account?._id
+    accountLogin
   })
   const { data: timeseries, ...queryResult } = useQueryAll(
     timeseriesQuery.definition,
@@ -46,7 +43,7 @@ const useExportTripsToCSV = () => {
 
   const accountName = isAllAccountsSelected
     ? t('settings.allAccounts')
-    : getAccountLabel(account)
+    : accountLogin
 
   useEffect(() => {
     const init = async () => {

--- a/src/hooks/useExportTripsToCSV.spec.jsx
+++ b/src/hooks/useExportTripsToCSV.spec.jsx
@@ -19,7 +19,7 @@ jest.mock('src/components/Providers/AccountProvider', () => ({
   ...jest.requireActual('src/components/Providers/AccountProvider'),
   __esModule: true,
   useAccountContext: jest.fn().mockReturnValue({
-    account: { auth: { login: 'accountName' } }
+    accountLogin: 'accountLogin'
   })
 }))
 

--- a/src/lib/computeAggregateService.js
+++ b/src/lib/computeAggregateService.js
@@ -1,0 +1,77 @@
+import difference from 'lodash/difference'
+import { CCO2_SETTINGS_DOCTYPE, JOBS_DOCTYPE } from 'src/doctypes'
+import { buildAggregateCaptureDeviceTimeseriesQuery } from 'src/queries/nodeQueries'
+import { buildSettingsQuery } from 'src/queries/queries'
+
+import logger from 'cozy-logger'
+
+const logService = logger.namespace('services/computeAggregateService')
+
+/**
+ * @param {import('cozy-client/types/CozyClient').default} client - The cozy client
+ */
+export const runComputeAggregateService = async client => {
+  const { data: settings } = await client.query(buildSettingsQuery().definition)
+  if (!settings || settings?.length < 1) {
+    logService('error', 'App settings not found')
+    return false
+  }
+  const settingsCaptureDevices = settings[0].captureDevices || []
+
+  const timeseries = await client.queryAll(
+    buildAggregateCaptureDeviceTimeseriesQuery().definition
+  )
+  const timeseriesCaptureDevices = [
+    ...new Set(timeseries.map(ts => ts.captureDevice))
+  ]
+
+  const isAlreadyUpToDate =
+    settingsCaptureDevices.length === timeseriesCaptureDevices.length &&
+    difference(settingsCaptureDevices, timeseriesCaptureDevices).length === 0
+
+  if (isAlreadyUpToDate) {
+    logService('info', 'captureDevices in app settings are already up to date')
+    return false
+  }
+
+  await client.save({
+    ...settings[0],
+    _type: CCO2_SETTINGS_DOCTYPE,
+    captureDevices: timeseriesCaptureDevices
+  })
+
+  logService('info', 'captureDevices in app settings updated successfully')
+}
+
+/**
+ * @param {import('cozy-client/types/CozyClient').default} client
+ */
+export const launchComputeAggregateJob = async client => {
+  try {
+    logService('info', 'Start launchComputeAggregateJob')
+    const settings = await client.queryAll(buildSettingsQuery().definition)
+    const setting = settings?.[0] || {}
+
+    if (setting?.captureDevices) {
+      logService(
+        'info',
+        'Stop launchComputeAggregateJob because captureDevices is already exists in app settings'
+      )
+      return
+    }
+
+    logService(
+      'info',
+      "Create job service with slug: 'coachco2' & name: 'computeAggregate'"
+    )
+    const jobColl = client.collection(JOBS_DOCTYPE)
+    await jobColl.create(
+      'service',
+      { slug: 'coachco2', name: 'computeAggregate' },
+      {},
+      true
+    )
+  } catch (error) {
+    logService('error', `launchComputeAggregateJob error: ${error}`)
+  }
+}

--- a/src/lib/computeAggregateService.js
+++ b/src/lib/computeAggregateService.js
@@ -16,7 +16,7 @@ export const runComputeAggregateService = async client => {
     logService('error', 'App settings not found')
     return false
   }
-  const settingsCaptureDevices = settings[0].captureDevices || []
+  const settingsCaptureDevices = settings[0].accountsLogins || []
 
   const timeseries = await client.queryAll(
     buildAggregateCaptureDeviceTimeseriesQuery().definition
@@ -30,17 +30,17 @@ export const runComputeAggregateService = async client => {
     difference(settingsCaptureDevices, timeseriesCaptureDevices).length === 0
 
   if (isAlreadyUpToDate) {
-    logService('info', 'captureDevices in app settings are already up to date')
+    logService('info', 'accountsLogins in app settings already up to date')
     return false
   }
 
   await client.save({
     ...settings[0],
     _type: CCO2_SETTINGS_DOCTYPE,
-    captureDevices: timeseriesCaptureDevices
+    accountsLogins: timeseriesCaptureDevices
   })
 
-  logService('info', 'captureDevices in app settings updated successfully')
+  logService('info', 'accountsLogins in app settings updated successfully')
 }
 
 /**
@@ -52,10 +52,10 @@ export const launchComputeAggregateJob = async client => {
     const settings = await client.queryAll(buildSettingsQuery().definition)
     const setting = settings?.[0] || {}
 
-    if (setting?.captureDevices) {
+    if (setting?.accountsLogins) {
       logService(
         'info',
-        'Stop launchComputeAggregateJob because captureDevices is already exists in app settings'
+        'Stop launchComputeAggregateJob because accountsLogins already exists in app settings'
       )
       return
     }

--- a/src/queries/nodeQueries.js
+++ b/src/queries/nodeQueries.js
@@ -216,3 +216,14 @@ export const buildContactsWithGeoCoordinates = ({ limit = 1000 } = {}) => {
     }
   }
 }
+
+export const buildAggregateCaptureDeviceTimeseriesQuery = () => ({
+  definition: Q(GEOJSON_DOCTYPE)
+    .where({})
+    .partialIndex({
+      aggregation: {
+        $exists: true
+      }
+    })
+    .select(['aggregation', 'captureDevice'])
+})

--- a/src/queries/queries.spec.js
+++ b/src/queries/queries.spec.js
@@ -1,8 +1,5 @@
-import MockDate from 'mockdate'
-
 import {
   buildTimeseriesQueryByDateAndAccountId,
-  buildOneYearOldTimeseriesWithAggregationByAccountId,
   buildBikeCommuteTimeseriesQueryByAccountId
 } from './queries'
 
@@ -106,35 +103,6 @@ describe('buildTimeseriesQueryByDateAndAccountId', () => {
   })
 })
 
-describe('buildOneYearOldTimeseriesWithAggregationByAccountId', () => {
-  beforeEach(() => {
-    MockDate.set('2020-01-01')
-  })
-
-  afterEach(() => {
-    MockDate.reset()
-  })
-
-  it('should return a well formated query', () => {
-    const query = buildOneYearOldTimeseriesWithAggregationByAccountId({
-      accountId: 'accountId'
-    })
-
-    expect(query).toMatchObject({
-      definition: {
-        selector: {
-          startDate: {
-            $gte: '2019-01-01T00:00:00.000Z'
-          }
-        }
-      },
-      options: {
-        as: 'io.cozy.timeseries.geojson/sourceAccount/accountId/withAggregation/fromDate/2019-0'
-      }
-    })
-  })
-})
-
 describe('buildBikeCommuteTimeseriesQueryByAccountId', () => {
   it('should use a well formated selector without date', () => {
     const query = buildBikeCommuteTimeseriesQueryByAccountId(
@@ -154,7 +122,8 @@ describe('buildBikeCommuteTimeseriesQueryByAccountId', () => {
           'aggregation',
           'aggregation.modes',
           'aggregation.purpose',
-          'cozyMetadata.sourceAccount'
+          'cozyMetadata.sourceAccount',
+          'captureDevice'
         ],
         id: undefined,
         ids: undefined,
@@ -208,7 +177,8 @@ describe('buildBikeCommuteTimeseriesQueryByAccountId', () => {
           'aggregation',
           'aggregation.modes',
           'aggregation.purpose',
-          'cozyMetadata.sourceAccount'
+          'cozyMetadata.sourceAccount',
+          'captureDevice'
         ],
         id: undefined,
         ids: undefined,

--- a/src/targets/browser/setupApp.jsx
+++ b/src/targets/browser/setupApp.jsx
@@ -14,17 +14,17 @@ import manifest from '../../../manifest.webapp'
 
 // TODO: To be removed once we have handled the problem of having multiple data sources
 /**
- * Force allSelected accounts if a specific account is defined
+ * Force allSelected sources if a specific accountLogin is defined
  * @param  {import('cozy-client/types/CozyClient').default} client CozyClient
  */
 const forceAllSelectedAccountToAppSettings = async client => {
   const { data: settings } = await client.query(buildSettingsQuery().definition)
   const setting = settings[0] || {}
-  if (setting.account) {
+  if (setting.accountLogin) {
     await client.save({
       ...setting,
       _type: CCO2_SETTINGS_DOCTYPE,
-      account: null,
+      accountLogin: null,
       isAllAccountsSelected: true
     })
   }

--- a/src/targets/services/computeAggregate.js
+++ b/src/targets/services/computeAggregate.js
@@ -1,0 +1,21 @@
+import fetch from 'node-fetch'
+import schema from 'src/doctypes'
+import { runComputeAggregateService } from 'src/lib/computeAggregateService'
+
+import CozyClient from 'cozy-client'
+import logger from 'cozy-logger'
+
+const logService = logger.namespace('services/computeAggregate')
+
+global.fetch = fetch
+
+const computeAggregate = async () => {
+  logService('info', 'Start computeAggregate service')
+  const client = CozyClient.fromEnv(process.env, { schema })
+  await runComputeAggregateService(client)
+}
+
+computeAggregate().catch(e => {
+  logService('error', e)
+  process.exit(1)
+})


### PR DESCRIPTION
Cette PR corrige la disparition des sources dans le sélecteur sur la page des paramètres de l'application.
En effet, dans le cas où un connecteur est déconnecté ou désinstallé, la source qui n'est autre que le compte(`io.cozy.accounts`) est supprimé.

En sachant cela, et comme nous souhaitons pouvoir continuer à sélectionner les noms des comptes avec leur trajets, nous devons plutôt nous servir de la propriété `captureDevice` présente sur tous les `timeseries` qui ont pour valeur le nom du compte d'où elles proviennent.

Ainsi, nous pouvons continuer à sélectionner le nom des comptes et afficher leurs trajets.


Le service ne réagissant qu'à la création d'un `timeseries`, nous avons besoin de créer un Job et de le déclencher une fois "manuellement" lorsque l'utilisateur arrive sur l'app.
Ainsi il n'aura pas à attendre la création d'un nouveau trajet pour voir ses anciennes sources dans ses paramètres.
(ce Job est conditionné à la non présence du nouveau paramètre `accountsLists` dans les settings de l'app créé par le service)

```
### 🐛 Bug Fixes

* Display all sources in AccountSelector

```