### PR TITLE
fix: initPolyglot should load the "en" as a fallback

### DIFF
--- a/src/lib/services.js
+++ b/src/lib/services.js
@@ -3,13 +3,24 @@ import { JOBS_DOCTYPE } from 'src/doctypes'
 
 import { initTranslation } from 'cozy-ui/transpiled/react/providers/I18n'
 
+const DEFAULT_LANG = 'en'
+
+const dictRequire = lang => {
+  let res
+  try {
+    res = require(`locales/${lang}`)
+  } catch (error) {
+    res = require(`locales/${DEFAULT_LANG}`)
+  }
+  return res
+}
+
 /**
  * Init polyglot and returns t
  * @returns {object}
  */
 export const initPolyglot = () => {
-  const lang = process.env.COZY_LOCALE || 'en'
-  const dictRequire = lang => require(`locales/${lang}`)
+  const lang = process.env.COZY_LOCALE || DEFAULT_LANG
   const polyglot = initTranslation(lang, dictRequire)
   const t = polyglot.t.bind(polyglot)
 


### PR DESCRIPTION
Services could crash if user has a locale that is not supported by services. Currently, only "en" and "fr" are supported.

```
### 🐛 Bug Fixes

* Services will not crash anymore when trying to translate in an unsupported locale
```
