### PR TITLE
fix: The query  used by `recurringPurposes` service

### DIFF
--- a/src/queries/queries.js
+++ b/src/queries/queries.js
@@ -461,7 +461,11 @@ export const buildBikeCommuteTimeseriesQueryByAccountLogin = ({
 }
 
 export const queryTimeserieByDocId = async (client, docId) => {
-  const res = await client.query(Q(GEOJSON_DOCTYPE).getById(docId))
+  const res = await client.query(
+    Q(GEOJSON_DOCTYPE)
+      .getById(docId)
+      .include(['startPlaceContact', 'endPlaceContact'])
+  )
   return res?.data
 }
 


### PR DESCRIPTION
...must return referenced contacts.

```
### 🐛 Bug Fixes

* Each time the recurrence service was run on a trip with defined contacts, the related contacts were not found.
  The title of the modal then returned to its default value (the place of arrival)
```
