### PR TITLE
feat(ContactToPlace): Use `type` and `label` to set start/end point tag

### DIFF
--- a/src/components/ContactToPlace/CustomLabelDialog.jsx
+++ b/src/components/ContactToPlace/CustomLabelDialog.jsx
@@ -1,19 +1,26 @@
 import React, { useState } from 'react'
+import { isCustomLabel } from 'src/components/ContactToPlace/actions/helpers'
 import { useContactToPlace } from 'src/components/Providers/ContactToPlaceProvider'
 
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import FormControlLabel from 'cozy-ui/transpiled/react/FormControlLabel'
+import RadioGroup from 'cozy-ui/transpiled/react/RadioGroup'
+import Radio from 'cozy-ui/transpiled/react/Radios'
 import TextField from 'cozy-ui/transpiled/react/TextField'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 const CustomLabelDialog = ({ onClose }) => {
-  const [value, setValue] = useState()
+  const { label, setLabel, category, setCategory } = useContactToPlace()
   const { t } = useI18n()
-  const { setLabel, setCategory } = useContactToPlace()
+  const [state, setState] = useState({
+    label: isCustomLabel(label, t) ? label : '',
+    category: isCustomLabel(label, t) ? category : 'home'
+  })
 
   const handleClick = () => {
-    setLabel(value)
-    setCategory()
+    setLabel(state.label)
+    setCategory(state.category)
     onClose()
   }
 
@@ -22,13 +29,37 @@ const CustomLabelDialog = ({ onClose }) => {
       open
       title={t('contactToPlace.customLabel')}
       content={
-        <TextField
-          className="u-mt-half"
-          variant="outlined"
-          fullWidth
-          autoFocus
-          onChange={ev => setValue(ev.target.value)}
-        />
+        <>
+          <TextField
+            className="u-mt-half"
+            variant="outlined"
+            value={state.label}
+            fullWidth
+            autoFocus
+            onChange={ev => setState(v => ({ ...v, label: ev.target.value }))}
+          />
+          <RadioGroup
+            style={{ flexDirection: 'row' }}
+            className="u-mt-half u-ml-half"
+            aria-label="radio"
+            name="category"
+            value={state.category}
+            onChange={ev =>
+              setState(v => ({ ...v, category: ev.target.value }))
+            }
+          >
+            <FormControlLabel
+              value="home"
+              label={t('contactToPlace.perso')}
+              control={<Radio />}
+            />
+            <FormControlLabel
+              value="work"
+              label={t('contactToPlace.pro')}
+              control={<Radio />}
+            />
+          </RadioGroup>
+        </>
       }
       actions={
         <>
@@ -37,7 +68,11 @@ const CustomLabelDialog = ({ onClose }) => {
             label={t('contactToPlace.cancel')}
             onClick={onClose}
           />
-          <Button label={t('contactToPlace.submit')} onClick={handleClick} />
+          <Button
+            label={t('contactToPlace.submit')}
+            disabled={!state.label}
+            onClick={handleClick}
+          />
         </>
       }
       onClose={onClose}

--- a/src/components/ContactToPlace/LabelItem.jsx
+++ b/src/components/ContactToPlace/LabelItem.jsx
@@ -6,7 +6,12 @@ import {
   work,
   customLabel
 } from 'src/components/ContactToPlace/actions'
+import {
+  isCustomLabel,
+  makeCustomLabel
+} from 'src/components/ContactToPlace/actions/helpers'
 import { useContactToPlace } from 'src/components/Providers/ContactToPlaceProvider'
+import { ADDRESS_CATEGORY_TO_LABEL } from 'src/constants'
 
 import ActionsMenu from 'cozy-ui/transpiled/react/ActionsMenu'
 import { makeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
@@ -24,11 +29,19 @@ const LabelItem = () => {
   const [showLabelMenu, setShowLabelMenu] = useState(false)
   const anchorRef = useRef(null)
   const { t } = useI18n()
-  const { label } = useContactToPlace()
+  const { label, category } = useContactToPlace()
 
   const actions = makeActions([noLabel, home, work, customLabel], {
     showCustomLabelModal: () => setShowCustomLabelModal(true)
   })
+
+  const primaryText = isCustomLabel(label, t)
+    ? makeCustomLabel({ label, category, t })
+    : category
+    ? `${t(`contactToPlace.${category}`)} (${t(
+        `contactToPlace.${ADDRESS_CATEGORY_TO_LABEL[category]}`
+      ).toLowerCase()})`
+    : t('contactToPlace.noLabel')
 
   return (
     <>
@@ -43,7 +56,7 @@ const LabelItem = () => {
         <ListItemIcon>
           <Icon icon={LabelOutlinedIcon} />
         </ListItemIcon>
-        <ListItemText primary={label || t('contactToPlace.noLabel')} />
+        <ListItemText primary={primaryText} />
         <ListItemIcon>
           <Icon icon={BottomIcon} />
         </ListItemIcon>

--- a/src/components/ContactToPlace/actions/customLabel.jsx
+++ b/src/components/ContactToPlace/actions/customLabel.jsx
@@ -1,4 +1,8 @@
 import React, { forwardRef } from 'react'
+import {
+  isCustomLabel,
+  makeCustomLabel
+} from 'src/components/ContactToPlace/actions/helpers'
 import { useContactToPlace } from 'src/components/Providers/ContactToPlaceProvider'
 
 import ActionsMenuItem from 'cozy-ui/transpiled/react/ActionsMenu/ActionsMenuItem'
@@ -10,20 +14,14 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 export const customLabel = ({ showCustomLabelModal }) => {
   const CustomLabelActionComponent = forwardRef((props, ref) => {
     const { t } = useI18n()
-    const { label } = useContactToPlace()
-
-    const isCutomLabel = ![
-      t('contactToPlace.work'),
-      t('contactToPlace.home'),
-      undefined
-    ].includes(label)
+    const { label, category } = useContactToPlace()
 
     return (
       <ActionsMenuItem {...props} ref={ref}>
         <ListItemIcon>
-          <Radio checked={isCutomLabel} />
+          <Radio checked={isCustomLabel(label, t)} />
         </ListItemIcon>
-        <ListItemText primary={t('contactToPlace.custom')} />
+        <ListItemText primary={makeCustomLabel({ label, category, t })} />
       </ActionsMenuItem>
     )
   })

--- a/src/components/ContactToPlace/actions/helpers.js
+++ b/src/components/ContactToPlace/actions/helpers.js
@@ -1,0 +1,19 @@
+import { ADDRESS_CATEGORY_TO_LABEL } from 'src/constants'
+
+export const isCustomLabel = (label, t) =>
+  ![t('contactToPlace.work'), t('contactToPlace.home'), undefined].includes(
+    label
+  )
+
+export const makeCustomLabel = ({ label, category, t }) => {
+  const type = ADDRESS_CATEGORY_TO_LABEL[category]
+
+  const firstString = isCustomLabel(label, t)
+    ? label
+    : t('contactToPlace.custom')
+  const secondString = isCustomLabel(label, t)
+    ? ` (${t(`contactToPlace.${type}`)})`.toLowerCase()
+    : ''
+
+  return firstString + secondString
+}

--- a/src/components/ContactToPlace/actions/helpers.spec.js
+++ b/src/components/ContactToPlace/actions/helpers.spec.js
@@ -1,0 +1,47 @@
+import { makeCustomLabel } from './helpers'
+
+const t = x => x
+
+describe('makeCustomLabel', () => {
+  describe('if custom label', () => {
+    it('should return label with type `perso`', () => {
+      const res = makeCustomLabel({ label: 'custom', category: 'home', t })
+
+      expect(res).toBe('custom (contacttoplace.perso)')
+    })
+
+    it('should return label with type `pro`', () => {
+      const res = makeCustomLabel({ label: 'custom', category: 'work', t })
+
+      expect(res).toBe('custom (contacttoplace.pro)')
+    })
+  })
+
+  describe('if not custom label', () => {
+    it('should return label for `home`', () => {
+      const res = makeCustomLabel({
+        label: 'contactToPlace.home',
+        category: 'home',
+        t
+      })
+
+      expect(res).toBe('contactToPlace.custom')
+    })
+
+    it('should return label for `work`', () => {
+      const res = makeCustomLabel({
+        label: 'contactToPlace.work',
+        category: 'work',
+        t
+      })
+
+      expect(res).toBe('contactToPlace.custom')
+    })
+
+    it('should return label', () => {
+      const res = makeCustomLabel({ t })
+
+      expect(res).toBe('contactToPlace.custom')
+    })
+  })
+})

--- a/src/components/ContactToPlace/actions/home.jsx
+++ b/src/components/ContactToPlace/actions/home.jsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react'
+import { isCustomLabel } from 'src/components/ContactToPlace/actions/helpers'
 import { useContactToPlace } from 'src/components/Providers/ContactToPlaceProvider'
 import { HOME_ADDRESS_CATEGORY } from 'src/constants'
 
@@ -11,20 +12,26 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 export const home = () => {
   const HomeComponent = forwardRef(({ onClick, ...props }, ref) => {
     const { t } = useI18n()
-    const { label, setLabel, setCategory } = useContactToPlace()
-
-    const compLabel = t('contactToPlace.home')
+    const { label, setLabel, category, setCategory } = useContactToPlace()
 
     return (
       <ActionsMenuItem
         {...props}
         ref={ref}
-        onClick={() => onClick({ compLabel, setLabel, setCategory })}
+        onClick={() => onClick({ setLabel, setCategory })}
       >
         <ListItemIcon>
-          <Radio checked={label === compLabel} />
+          <Radio
+            checked={
+              !isCustomLabel(label, t) && category === HOME_ADDRESS_CATEGORY
+            }
+          />
         </ListItemIcon>
-        <ListItemText primary={compLabel} />
+        <ListItemText
+          primary={`${t('contactToPlace.home')} (${t(
+            'contactToPlace.perso'
+          ).toLowerCase()})`}
+        />
       </ActionsMenuItem>
     )
   })
@@ -33,8 +40,8 @@ export const home = () => {
 
   return {
     name: HOME_ADDRESS_CATEGORY,
-    action: (_, { compLabel, setLabel, setCategory }) => {
-      setLabel(compLabel)
+    action: (_, { setLabel, setCategory }) => {
+      setLabel()
       setCategory(HOME_ADDRESS_CATEGORY)
     },
     Component: HomeComponent

--- a/src/components/ContactToPlace/actions/noLabel.jsx
+++ b/src/components/ContactToPlace/actions/noLabel.jsx
@@ -10,7 +10,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 export const noLabel = () => {
   const NoLabelActionComponent = forwardRef(({ onClick, ...props }, ref) => {
     const { t } = useI18n()
-    const { label, setLabel, setCategory } = useContactToPlace()
+    const { setLabel, category, setCategory } = useContactToPlace()
 
     return (
       <ActionsMenuItem
@@ -19,7 +19,7 @@ export const noLabel = () => {
         onClick={() => onClick({ setLabel, setCategory })}
       >
         <ListItemIcon>
-          <Radio checked={label === undefined} />
+          <Radio checked={category === undefined} />
         </ListItemIcon>
         <ListItemText primary={t('contactToPlace.noLabel')} />
       </ActionsMenuItem>

--- a/src/components/ContactToPlace/actions/work.jsx
+++ b/src/components/ContactToPlace/actions/work.jsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react'
+import { isCustomLabel } from 'src/components/ContactToPlace/actions/helpers'
 import { useContactToPlace } from 'src/components/Providers/ContactToPlaceProvider'
 import { WORK_ADDRESS_CATEGORY } from 'src/constants'
 
@@ -11,20 +12,26 @@ import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 export const work = () => {
   const WorkActionComponent = forwardRef(({ onClick, ...props }, ref) => {
     const { t } = useI18n()
-    const { label, setLabel, setCategory } = useContactToPlace()
-
-    const compLabel = t('contactToPlace.work')
+    const { label, setLabel, category, setCategory } = useContactToPlace()
 
     return (
       <ActionsMenuItem
         {...props}
         ref={ref}
-        onClick={() => onClick({ compLabel, setLabel, setCategory })}
+        onClick={() => onClick({ setLabel, setCategory })}
       >
         <ListItemIcon>
-          <Radio checked={label === compLabel} />
+          <Radio
+            checked={
+              !isCustomLabel(label, t) && category === WORK_ADDRESS_CATEGORY
+            }
+          />
         </ListItemIcon>
-        <ListItemText primary={compLabel} />
+        <ListItemText
+          primary={`${t('contactToPlace.work')} (${t(
+            'contactToPlace.pro'
+          ).toLowerCase()})`}
+        />
       </ActionsMenuItem>
     )
   })
@@ -33,8 +40,8 @@ export const work = () => {
 
   return {
     name: WORK_ADDRESS_CATEGORY,
-    action: (_, { compLabel, setLabel, setCategory }) => {
-      setLabel(compLabel)
+    action: (_, { setLabel, setCategory }) => {
+      setLabel()
       setCategory(WORK_ADDRESS_CATEGORY)
     },
     Component: WorkActionComponent

--- a/src/components/ContactToPlace/helpers.spec.js
+++ b/src/components/ContactToPlace/helpers.spec.js
@@ -76,7 +76,8 @@ describe('addAddressToContact', () => {
           id: '123',
           formattedAddress: 'StartPlace',
           geo: { geo: ['02', '48'], cozyCategory: 'work' },
-          type: 'Work'
+          type: undefined,
+          label: 'work'
         }
       ]
     })
@@ -103,7 +104,8 @@ describe('addAddressToContact', () => {
           id: '123',
           formattedAddress: 'StartPlace',
           geo: { geo: ['02', '48'], cozyCategory: 'work' },
-          type: 'Work'
+          type: undefined,
+          label: 'work'
         }
       ]
     })
@@ -118,7 +120,7 @@ describe('getPlaceLabelByContact', () => {
       const contact = {
         displayName: 'John Connor',
         me: true,
-        address: [{ id: '123', type: 'Home', geo: { cozyCategory: 'home' } }]
+        address: [{ id: '123', label: 'home', geo: { cozyCategory: 'home' } }]
       }
 
       const timeserie = {
@@ -137,7 +139,7 @@ describe('getPlaceLabelByContact', () => {
       const contact = {
         displayName: 'John Connor',
         me: true,
-        address: [{ id: '123', type: 'Work', geo: { cozyCategory: 'work' } }]
+        address: [{ id: '123', label: 'work', geo: { cozyCategory: 'work' } }]
       }
 
       const timeserie = {
@@ -152,11 +154,44 @@ describe('getPlaceLabelByContact', () => {
       expect(getPlaceLabelByContact({ timeserie, type, t })).toBe('Work')
     })
 
-    it('should return the label', () => {
+    it('should return the custom type for home', () => {
       const contact = {
         displayName: 'John Connor',
         me: true,
-        address: [{ id: '123', type: 'custom' }]
+        address: [
+          {
+            id: '123',
+            type: 'custom',
+            label: 'home',
+            geo: { cozyCategory: 'home' }
+          }
+        ]
+      }
+
+      const timeserie = {
+        startPlaceContact: { data: contact },
+        relationships: {
+          startPlaceContact: {
+            data: { metadata: { addressId: '123' } }
+          }
+        }
+      }
+
+      expect(getPlaceLabelByContact({ timeserie, type, t })).toBe('custom')
+    })
+
+    it('should return the custom type for work', () => {
+      const contact = {
+        displayName: 'John Connor',
+        me: true,
+        address: [
+          {
+            id: '123',
+            type: 'custom',
+            label: 'work',
+            geo: { cozyCategory: 'work' }
+          }
+        ]
       }
 
       const timeserie = {
@@ -195,7 +230,7 @@ describe('getPlaceLabelByContact', () => {
     it('should return `At contact name`', () => {
       const contact = {
         displayName: 'Sarah Connor',
-        address: [{ id: '123', type: 'Home', geo: { cozyCategory: 'home' } }]
+        address: [{ id: '123', label: 'home', geo: { cozyCategory: 'home' } }]
       }
 
       const timeserie = {
@@ -212,10 +247,10 @@ describe('getPlaceLabelByContact', () => {
       )
     })
 
-    it('should return contact name and work', () => {
+    it('should return contact name and `Work`', () => {
       const contact = {
         displayName: 'Sarah Connor',
-        address: [{ id: '123', type: 'Work', geo: { cozyCategory: 'work' } }]
+        address: [{ id: '123', label: 'work', geo: { cozyCategory: 'work' } }]
       }
 
       const timeserie = {
@@ -232,10 +267,44 @@ describe('getPlaceLabelByContact', () => {
       )
     })
 
-    it('should contact name and label', () => {
+    it('should contact name and type for home', () => {
       const contact = {
         displayName: 'Sarah Connor',
-        address: [{ id: '123', type: 'custom' }]
+        address: [
+          {
+            id: '123',
+            type: 'custom',
+            label: 'home',
+            geo: { cozyCategory: 'home' }
+          }
+        ]
+      }
+
+      const timeserie = {
+        startPlaceContact: { data: contact },
+        relationships: {
+          startPlaceContact: {
+            data: { metadata: { addressId: '123' } }
+          }
+        }
+      }
+
+      expect(getPlaceLabelByContact({ timeserie, type, t })).toBe(
+        'Sarah Connor (custom)'
+      )
+    })
+
+    it('should contact name and type for work', () => {
+      const contact = {
+        displayName: 'Sarah Connor',
+        address: [
+          {
+            id: '123',
+            type: 'custom',
+            label: 'work',
+            geo: { cozyCategory: 'work' }
+          }
+        ]
       }
 
       const timeserie = {

--- a/src/components/Providers/ContactToPlaceProvider.jsx
+++ b/src/components/Providers/ContactToPlaceProvider.jsx
@@ -24,10 +24,10 @@ export const useContactToPlace = () => {
 }
 
 const ContactToPlaceProvider = ({ children }) => {
-  const [type, setType] = useState()
+  const [type, setType] = useState() // 'start'|'end'
   const [contact, setContact] = useState()
   const [label, setLabel] = useState()
-  const [category, setCategory] = useState()
+  const [category, setCategory] = useState() // 'home'|'work'
   const { timeserie } = useTrip()
 
   const contactId =

--- a/src/constants.js
+++ b/src/constants.js
@@ -62,6 +62,10 @@ export const OTHER_PURPOSE = 'OTHER_PURPOSE'
 // list of address categories
 export const HOME_ADDRESS_CATEGORY = 'home'
 export const WORK_ADDRESS_CATEGORY = 'work'
+export const ADDRESS_CATEGORY_TO_LABEL = {
+  home: 'perso',
+  work: 'pro'
+}
 
 /**
  * Transporation CO2 constants, given in kg per km.

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -13,22 +13,22 @@
 
 /**
  * The GeoJSON timeseries doctype.
- * 
+ *
  * See https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.timeseries.md#iocozytimeseriesgeojson
- * 
+ *
  * @typedef {object} TimeseriesGeoJSON
  * @property {Date} startDate - The timeserie start date
  * @property {Date} endDate - The timeserie end date
- * @property {string} source - The source of the timeserie 
+ * @property {string} source - The source of the timeserie
  * @property {Aggregation} aggregation - The aggregation of the timeserie, describing the trip
  * @property {Array<RawGeoJSON>} series - The actual GeoJSON content
  *
- * 
- * 
+ *
+ *
 
 /**
- * The GeoJSON raw content. 
- * 
+ * The GeoJSON raw content.
+ *
  * @typedef {object} RawGeoJSON
  * @property {string} type - Always "FeatureCollection"
  * @property {GeoJSONProperties} properties - Trip properties
@@ -125,7 +125,7 @@
  * @property {Array<number>} geo - The coordinates, [lon, lat]
  * @property {Array<number>} sum - The sum of all the coordinates [lon, lat]
  * @property {number} count - The count of all the coordinates
- * @property {string} cozyCategory - The address category, e.g. Work
+ * @property {'work'|'home'} cozyCategory - The address category
  */
 
 /**

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -89,6 +89,8 @@
     "customLabel": "Custom label",
     "home": "Home",
     "work": "Work",
+    "pro": "Pro",
+    "perso": "Perso",
     "error": "Specify which contact to save the address under",
     "addSuccess": "The addresses have been registered",
     "removeSuccess": "The addresses have been deleted",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -89,6 +89,8 @@
     "customLabel": "Libellé personnalisé",
     "home": "Domicile",
     "work": "Travail",
+    "pro": "Pro",
+    "perso": "Perso",
     "error": "Préciser sous quel contact enregistrer l'adresse",
     "addSuccess": "Les adresses ont bien été enregistrées",
     "removeSuccess": "Les adresses ont bien été supprimées",


### PR DESCRIPTION
![image](https://github.com/cozy/coachCO2/assets/67680939/dc5023f3-834d-48e3-9974-95eaa5128579)
Lorsque l'on lie un contact à un point de départ/arrivée, on peut indiquer un libellé.

Préalablement dans l'app CCO2, on stockait le `type` (qu'on appelait `label` dans le code) sur l'adresse et le label (qu'on appelait `category`) sur la clé `geo` de l'adresse.

Suite aux changements effectués sur l'app Contacts, il s'agit maintenant de stocker un `type` et un `label` (home|work) sur l'adresse.

```
### ✨ Features

* Store `type` and `label` address value when linking a contact to a start/end point.

```