### PR TITLE
feat: Decrease fetchOpenPathTrips frequency

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -94,7 +94,7 @@
       "fetchOpenPathTrips": {
       "type": "node",
       "file": "services/fetchOpenPathTrips/coachco2.js",
-      "trigger": "@hourly"
+      "trigger": "@daily"
     },
     "fetchOpenPathTripsWebhook": {
       "type": "node",


### PR DESCRIPTION
We used to run this service every hour to ensure to retrieve trips as soon as possible.
Now it can e triggered through a webhook  so it appears less necessary: the periodic execution might be useful just in case we missed the webhook execution for some reason.
Furthermore, having this very high frequency (hourly) is problematic in the objective to deploy this app on a large scale, as it results in producing a lot of jobs.



```
### ✨ Features

* Decrease periodic openpath fetching from hourly to daily

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
