### PR TITLE
[DAT-59] fix: Address matching

### DIFF
--- a/src/lib/recurringPurposes.spec.js
+++ b/src/lib/recurringPurposes.spec.js
@@ -206,11 +206,6 @@ describe('runRecurringPurposesForNewTrips', () => {
     jest.resetAllMocks()
     jest.spyOn(mockClient, 'save').mockImplementation(trips => trips)
   })
-  it('should do nothing if no account is found', async () => {
-    jest.spyOn(mockClient, 'query').mockResolvedValueOnce({ data: null })
-    const res = await runRecurringPurposesForNewTrips(mockClient)
-    expect(res.length).toEqual(0)
-  })
 
   it('should set purpose when similar timeseries have one', async () => {
     jest

--- a/src/lib/recurringPurposes.spec.js
+++ b/src/lib/recurringPurposes.spec.js
@@ -129,7 +129,7 @@ describe('setRecurringPurposes', () => {
 describe('runRecurringPurposesForManualTrip', () => {
   beforeEach(() => {
     jest.resetAllMocks()
-    jest.spyOn(mockClient, 'saveAll').mockImplementation(trips => trips)
+    jest.spyOn(mockClient, 'save').mockImplementation(trips => trips)
   })
   it('should do nothing if the timeserie is not found or miss fields', async () => {
     jest.spyOn(mockClient, 'query').mockResolvedValueOnce({ data: null })
@@ -204,7 +204,7 @@ describe('runRecurringPurposesForManualTrip', () => {
 describe('runRecurringPurposesForNewTrips', () => {
   beforeEach(() => {
     jest.resetAllMocks()
-    jest.spyOn(mockClient, 'saveAll').mockImplementation(trips => trips)
+    jest.spyOn(mockClient, 'save').mockImplementation(trips => trips)
   })
   it('should do nothing if no account is found', async () => {
     jest.spyOn(mockClient, 'query').mockResolvedValueOnce({ data: null })

--- a/src/queries/nodeQueries.js
+++ b/src/queries/nodeQueries.js
@@ -19,31 +19,21 @@ export const buildOldestTimeseriesQueryByAccountId = accountId => ({
     .limitBy(1)
 })
 
-export const buildTimeseriesQueryByAccountIdAndDate = ({
-  accountId,
-  date = null
-}) => {
+export const buildTimeseriesQueryByDate = ({ date = null }) => {
   return {
     definition: Q(GEOJSON_DOCTYPE)
       .where({
-        'cozyMetadata.sourceAccount': accountId,
         ...(date && {
           startDate: {
             $gt: date
           }
         })
       })
-      .indexFields([
-        'cozyMetadata.sourceAccount',
-        ...(date ? ['startDate'] : [])
-      ])
-      .sortBy([
-        { 'cozyMetadata.sourceAccount': 'desc' },
-        ...(date ? [{ startDate: 'desc' }] : [])
-      ])
+      .indexFields([...(date ? ['startDate'] : [])])
+      .sortBy([...(date ? [{ startDate: 'desc' }] : [])])
       .limitBy(1000),
     options: {
-      as: `${GEOJSON_DOCTYPE}/sourceAccount/${accountId}`,
+      as: `${GEOJSON_DOCTYPE}/date/${date}`,
       fetchPolicy: CozyClient.fetchPolicies.olderThan(older30s)
     }
   }
@@ -60,26 +50,8 @@ export const buildNewestRecurringTimeseriesQuery = () => ({
     .limitBy(1)
 })
 
-export const buildNewestRecurringTimeseriesQueryByAccountId = ({
-  accountId
-}) => {
-  return {
-    definition: Q(GEOJSON_DOCTYPE)
-      .where({
-        'cozyMetadata.sourceAccount': accountId
-      })
-      .partialIndex({
-        'aggregation.recurring': true
-      })
-      .indexFields(['cozyMetadata.sourceAccount', 'startDate'])
-      .sortBy([{ 'cozyMetadata.sourceAccount': 'desc' }, { startDate: 'desc' }])
-      .limitBy(1)
-  }
-}
-
 // accounId from timeseries (timeseries.cozyMetadata.sourceAccount)
 export const buildRecurringTimeseriesByStartAndEndPointRange = ({
-  accountId,
   minLatStart,
   maxLatStart,
   minLonStart,
@@ -93,7 +65,6 @@ export const buildRecurringTimeseriesByStartAndEndPointRange = ({
   return {
     definition: Q(GEOJSON_DOCTYPE)
       .where({
-        'cozyMetadata.sourceAccount': accountId,
         'aggregation.coordinates.startPoint.lon': {
           $gte: minLonStart,
           $lte: maxLonStart
@@ -115,7 +86,6 @@ export const buildRecurringTimeseriesByStartAndEndPointRange = ({
         'aggregation.recurring': true
       })
       .indexFields([
-        'cozyMetadata.sourceAccount',
         'aggregation.coordinates.startPoint.lon',
         'aggregation.coordinates.startPoint.lat',
         'aggregation.coordinates.endPoint.lon',


### PR DESCRIPTION
We noticed issues in the address matching made in the recurring service, notably:
1. Errors on timeseries bulk saving
2. Address matching is restricted on account

For 1. we noticed errors in the logs, but with no way to know more about it, since the bulk save does not provide info.
Thus, we come back to the gool ol' document save.

For 2. we suspect that the multi-account feature was causing some side-effect. So we simply remove the account restriction and perform the matching on all timeseries.


```
### ✨ Features

* Recurring service now applies on all past trips, without account restriction

### 🐛 Bug Fixes

* Address matching 

### 🔧 Tech

*
```
