### PR TITLE
[DAT-57] [DAT-36] [DAT-48] Improve recurring service perfs

### DIFF
--- a/src/components/ContactToPlace/helpers.js
+++ b/src/components/ContactToPlace/helpers.js
@@ -97,7 +97,6 @@ export const hasRelationshipByType = (timeserie, type) => {
 
 export const getPlaceLabelByContact = ({ timeserie, type, t }) => {
   const contact = getRelationshipByType(timeserie, type)?.data
-
   if (!contact) {
     return null
   }

--- a/src/lib/contacts.js
+++ b/src/lib/contacts.js
@@ -48,7 +48,6 @@ export const findClosestStartAndEndContactsAddress = (timeserie, contacts) => {
         endCoordinates,
         addressCoordinates
       )
-
       if (startPlaceDistance < minStartDistance) {
         closestStart = {
           distance: startPlaceDistance,

--- a/src/queries/nodeQueries.js
+++ b/src/queries/nodeQueries.js
@@ -46,7 +46,7 @@ export const buildNewestRecurringTimeseriesQuery = () => ({
       'aggregation.recurring': true
     })
     .indexFields(['startDate'])
-    .sortBy([{ 'cozyMetadata.sourceAccount': 'desc' }, { startDate: 'desc' }])
+    .sortBy([{ startDate: 'desc' }])
     .limitBy(1)
 })
 


### PR DESCRIPTION
In the recurring service, we try to match an existing contact address for each trip start/end place.
When there are a lot of trips to process, this can result in many database IO and tend to make many conflicts since the few same contacts tend to be updated (e.g. myself).
So instead of updating each contact for each trip, we postpone the actual db save after all the trips are processed, and deduplicate the contacts update. For example, if the myself contact has an address with 100 match, we save it once instead of 100 times. 

```
### ✨ Features

*

### 🐛 Bug Fixes

* Minimize conflicts on recurring service 
* Minimize risks of recurring service timeout

### 🔧 Tech

*
```
