### PR TITLE
Remove node 16 from tests and stages in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,13 @@ env:
     # REGISTRY_TOKEN for yarn cozyPublish script
     # to generate yours : travis encrypt REGISTRY_TOKEN=<your_REGISTRY_TOKEN> -r cozy/coachCO2
     # N.B.: the --org option is needed only for public repositories
-stages:
-  - prebuild
-  - build
 jobs:
   include:
     - name: 'Lint'
-      stage: 'prebuild'
       script: yarn lint
     - name: 'Unit tests'
-      stage: 'prebuild'
       script: yarn test
     - name: 'Build app'
-      stage: 'build'
       script:
         - yarn build
         - yarn bundlemon

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-node_js: 20
 dist: jammy
 cache:
   npm: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,8 @@ jobs:
     - name: 'Lint'
       stage: 'prebuild'
       script: yarn lint
-    - name: 'Unit tests node 16'
+    - name: 'Unit tests'
       stage: 'prebuild'
-      node_js: 16
-      script: yarn test
-    - name: 'Unit tests node 20'
-      stage: 'prebuild'
-      node_js: 20
       script: yarn test
     - name: 'Build app'
       stage: 'build'


### PR DESCRIPTION
Transition to node 20 has been done successfuly on our production servers.

```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

* Remove node 16 from tests in CI
* Remove stages in CI
```
